### PR TITLE
Flambda2.0 stable clean uncps

### DIFF
--- a/middle_end/flambda2.0/to_cmm/un_cps.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps.ml
@@ -797,9 +797,7 @@ and apply_expr env e =
   let wrap, env = Env.flush_delayed_lets env in
   wrap (wrap_cont env effs call e)
 
-(* CR mshinwell: I've seen (e.g. in List.map) calls to [caml_apply1], which
-   I don't think should exist.  You can just directly call through the
-   first word of the closure. *)
+(* Bare function calls *)
 and apply_call env e =
   let f = Apply_expr.callee e in
   let dbg = Apply_expr.dbg e in

--- a/middle_end/flambda2.0/to_cmm/un_cps_closure.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps_closure.ml
@@ -389,7 +389,7 @@ module Greedy = struct
         let () = add_unallocated_slot_to_set s set in
         create_env_var_slots set state r
 
-  let create_slots_for_set state ~used_closure_vars set_id =
+  let create_slots_for_set state used_closure_vars set_id =
     let set = make_set set_id in
     let state = add_set_to_state state set in
     (* Fill closure slots *)
@@ -674,7 +674,7 @@ let compute_offsets program =
     Name_occurrences.closure_vars (Flambda_static.Program.free_names program)
   in
   let aux _ s =
-    state := Greedy.create_slots_for_set !state ~used_closure_vars s
+    state := Greedy.create_slots_for_set !state used_closure_vars s
   in
   Iter_on_sets_of_closures.program aux program;
   Greedy.finalize !state
@@ -695,12 +695,14 @@ let closure_name id =
 let closure_id_name o id =
   match o with
   | None -> closure_name id
-  | Some map ->
+  | Some _map -> closure_name id
+  (*
       (* CR Gbury: is this part really necessary ? why not always
                    return closure_name id ? *)
       let s = Closure_id.Map.find id map in
       let name = Symbol.linkage_name s in
       Format.asprintf "%a" Linkage_name.print name
+  *)
 
 let closure_code s = Format.asprintf "%s_code" s
 

--- a/middle_end/flambda2.0/to_cmm/un_cps_env.mli
+++ b/middle_end/flambda2.0/to_cmm/un_cps_env.mli
@@ -21,12 +21,15 @@ open Flambda2
 type t
 (** Environment for flambda2 to cmm translation *)
 
-val mk : Un_cps_closure.env -> Continuation.t -> Continuation.t -> t
-(** [mk offsets k k_exn] creates a local environment for translating
-    a flambda2 expression, with return continuation [k] and exception
-    continuation [k_exn]. *)
+val mk :
+  Un_cps_closure.env ->
+  Continuation.t -> Continuation.t ->
+  Var_within_closure.Set.t -> t
+(** [mk offsets k k_exn used_closure_vars] creates a local environment for
+    translating a flambda2 expression, with return continuation [k], exception
+    continuation [k_exn], and which uses the given closures variables. *)
 
-val dummy : Un_cps_closure.env -> t
+val dummy : Un_cps_closure.env -> Var_within_closure.Set.t -> t
 (** Create an environment with dummy return adn exception continuations. *)
 
 
@@ -126,7 +129,3 @@ val layout :
 val used_closure_vars : t -> Var_within_closure.Set.t
 (** All closure variables used in the whole program. *)
 
-val with_used_closure_vars
-   : t
-  -> used_closure_vars:Var_within_closure.Set.t
-  -> t

--- a/middle_end/flambda2.0/to_cmm/un_cps_helper.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps_helper.ml
@@ -201,6 +201,10 @@ let make_block ?(dbg=Debuginfo.none) kind args =
   | Full_of_naked_floats
   | Generic_array Full_of_naked_floats ->
       make_float_alloc dbg (Tag.to_int (float_tag args)) args
+  | Generic_array No_specialisation ->
+      extcall ~dbg ~alloc:true
+        "caml_make_array" Cmm.typ_val
+        [make_alloc dbg 0 args]
   | _ ->
       make_alloc dbg 0 args
 

--- a/middle_end/flambda2.0/to_cmm/un_cps_helper.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps_helper.ml
@@ -419,13 +419,8 @@ let direct_call ?(dbg=Debuginfo.none) ty f args =
   Cmm.Cop (Cmm.Capply ty, f :: args, dbg)
 
 let indirect_call ?(dbg=Debuginfo.none) ty f = function
-  (* CR Gbury: does this optimization (found in cmm_helpers),
-               actually matters ? Also, does always using Mutable here
-               (instead of sometimes using Immutable as done in cmm_helpers'
-               mut_from_env) affect perfs ?
   | [arg] ->
-      Cmm.Cop (Cmm.Capply ty, [load Cmm.Word_val Asttypes.Mutable f; arg; f], dbg)
-  *)
+      Cmm.Cop (Cmm.Capply ty, [load Cmm.Word_int Asttypes.Mutable f; arg; f], dbg)
   | args ->
       let arity = List.length args in
       let l = symbol (apply_function_sym arity) :: args @ [f] in


### PR DESCRIPTION
This PR first contains a lot of cleanup of the code in `un_cps.ml` which had become a bit like spaghetti code after recent changes and bugfixs.

Secondly, this PR contains an unsound, temporary bugfix for the generation of closure id names. This bugfix should work as long as there is a unique mapping between closure ids and code ids in the code being compiled (which in general is not true due to inlining). If that condition is not verified, then the same symbol will be defined twice in the generated cmm, which should hopefully result in a linking error rather than silent failure at compilation.