### PR TITLE
Fix shifts

### DIFF
--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -2201,16 +2201,16 @@ let xor_int_caml arg1 arg2 dbg =
             Cconst_int (1, dbg)], dbg)
 
 let lsl_int_caml arg1 arg2 dbg =
-  incr_int(lsl_int (decr_int arg1 dbg)
-             (untag_int arg2 dbg) dbg) dbg
+  let k = ignore_high_bit_int (untag_int arg2 dbg) in
+  incr_int(lsl_int (decr_int arg1 dbg) k dbg) dbg
 
 let lsr_int_caml arg1 arg2 dbg =
-  Cop(Cor, [lsr_int arg1 (untag_int arg2 dbg) dbg;
-            Cconst_int (1, dbg)], dbg)
+  let k = ignore_high_bit_int (untag_int arg2 dbg) in
+  Cop(Cor, [lsr_int arg1 k dbg; Cconst_int (1, dbg)], dbg)
 
 let asr_int_caml arg1 arg2 dbg =
-  Cop(Cor, [asr_int arg1 (untag_int arg2 dbg) dbg;
-            Cconst_int (1, dbg)], dbg)
+  let k = ignore_high_bit_int (untag_int arg2 dbg) in
+  Cop(Cor, [asr_int arg1 k dbg; Cconst_int (1, dbg)], dbg)
 
 let int_comp_caml cmp arg1 arg2 dbg =
   tag_int(Cop(Ccmpi cmp,

--- a/middle_end/flambda2.0/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2.0/from_lambda/lambda_to_flambda_primitives.ml
@@ -50,7 +50,7 @@ let bint_binary_prim bi prim arg1 arg2 =
 let bint_shift bi prim arg1 arg2 =
   box_bint bi
     (Binary (Int_shift (C.standard_int_of_boxed_integer bi, prim),
-             unbox_bint bi arg1, arg2))
+             unbox_bint bi arg1, untag_int arg2))
 
 let string_or_bytes_access_validity_condition str kind index : H.expr_primitive =
   Binary (Int_comp (I.Naked_immediate, Unsigned, Lt),
@@ -141,11 +141,11 @@ let convert_lprim ~backend (prim : L.primitive) (args : Simple.t list)
   | Pxorint, [arg1; arg2] ->
     Binary (Int_arith (I.Tagged_immediate, Xor), arg1, arg2)
   | Plslint, [arg1; arg2] ->
-    Binary (Int_shift (I.Tagged_immediate, Lsl), arg1, arg2)
+    Binary (Int_shift (I.Tagged_immediate, Lsl), arg1, untag_int arg2)
   | Plsrint, [arg1; arg2] ->
-    Binary (Int_shift (I.Tagged_immediate, Lsr), arg1, arg2)
+    Binary (Int_shift (I.Tagged_immediate, Lsr), arg1, untag_int arg2)
   | Pasrint, [arg1; arg2] ->
-    Binary (Int_shift (I.Tagged_immediate, Asr), arg1, arg2)
+    Binary (Int_shift (I.Tagged_immediate, Asr), arg1, untag_int arg2)
   | Pnot, [arg] ->
     Unary (Boolean_not, arg)
   | Pintcomp comp, [arg1; arg2] ->

--- a/middle_end/flambda2.0/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2.0/from_lambda/lambda_to_flambda_primitives.ml
@@ -141,11 +141,11 @@ let convert_lprim ~backend (prim : L.primitive) (args : Simple.t list)
   | Pxorint, [arg1; arg2] ->
     Binary (Int_arith (I.Tagged_immediate, Xor), arg1, arg2)
   | Plslint, [arg1; arg2] ->
-    Binary (Int_shift (I.Tagged_immediate, Lsl), arg1, untag_int arg2)
+    Binary (Int_shift (I.Tagged_immediate, Lsl), arg1, arg2)
   | Plsrint, [arg1; arg2] ->
-    Binary (Int_shift (I.Tagged_immediate, Lsr), arg1, untag_int arg2)
+    Binary (Int_shift (I.Tagged_immediate, Lsr), arg1, arg2)
   | Pasrint, [arg1; arg2] ->
-    Binary (Int_shift (I.Tagged_immediate, Asr), arg1, untag_int arg2)
+    Binary (Int_shift (I.Tagged_immediate, Asr), arg1, arg2)
   | Pnot, [arg] ->
     Unary (Boolean_not, arg)
   | Pintcomp comp, [arg1; arg2] ->

--- a/middle_end/flambda2.0/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2.0/from_lambda/lambda_to_flambda_primitives.ml
@@ -141,11 +141,11 @@ let convert_lprim ~backend (prim : L.primitive) (args : Simple.t list)
   | Pxorint, [arg1; arg2] ->
     Binary (Int_arith (I.Tagged_immediate, Xor), arg1, arg2)
   | Plslint, [arg1; arg2] ->
-    Binary (Int_shift (I.Tagged_immediate, Lsl), arg1, arg2)
+    Binary (Int_shift (I.Tagged_immediate, Lsl), arg1, untag_int arg2)
   | Plsrint, [arg1; arg2] ->
-    Binary (Int_shift (I.Tagged_immediate, Lsr), arg1, arg2)
+    Binary (Int_shift (I.Tagged_immediate, Lsr), arg1, untag_int arg2)
   | Pasrint, [arg1; arg2] ->
-    Binary (Int_shift (I.Tagged_immediate, Asr), arg1, arg2)
+    Binary (Int_shift (I.Tagged_immediate, Asr), arg1, untag_int arg2)
   | Pnot, [arg] ->
     Unary (Boolean_not, arg)
   | Pintcomp comp, [arg1; arg2] ->

--- a/middle_end/flambda2.0/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2.0/simplify/simplify_binary_primitive.ml
@@ -394,7 +394,7 @@ end = struct
   let ok_to_evaluate _env = true
 
   let prover_lhs = I.unboxed_prover
-  let prover_rhs = T.prove_equals_tagged_immediates
+  let prover_rhs = T.prove_naked_immediates
 
   let unknown =
     match kind with

--- a/middle_end/flambda2.0/terms/flambda_primitive.ml
+++ b/middle_end/flambda2.0/terms/flambda_primitive.ml
@@ -851,7 +851,7 @@ let args_kind_of_binary_primitive p =
     let kind = K.Standard_int.to_kind kind in
     kind, kind
   | Int_shift (kind, _) ->
-    K.Standard_int.to_kind kind, K.value
+    K.Standard_int.to_kind kind, K.naked_immediate
   | Int_comp (kind, _, _) ->
     let kind = K.Standard_int.to_kind kind in
     kind, kind

--- a/middle_end/flambda2.0/to_cmm/un_cps.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps.ml
@@ -735,6 +735,9 @@ and let_cont_inline env k h body =
      raise/trywith cmm mechanism
    - regular continuations use static jumps, through the
      exit/catch cmm mechanism *)
+(* CR Gbury: "split" the environment according to which variables the
+             handler and the body uses, to allow for inlining to proceed
+             within each expression. *)
 and let_cont_jump env k h body =
   let wrap, env = Env.flush_delayed_lets env in
   let vars, handle = continuation_handler env h in

--- a/middle_end/flambda2.0/to_cmm/un_cps.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps.ml
@@ -356,9 +356,9 @@ let binary_int_shift_primitive _env dbg kind op x y =
   | Naked_int32, Lsr when C.arch64 ->
       C.asr_int (C.zero_extend_32 dbg x) y dbg
   (* Tagged integers *)
-  | Tagged_immediate, Lsl -> C.lsl_int_caml x y dbg
-  | Tagged_immediate, Lsr -> C.lsr_int_caml x y dbg
-  | Tagged_immediate, Asr -> C.asr_int_caml x y dbg
+  | Tagged_immediate, Lsl -> C.lsl_int_caml x (C.tag_int y dbg) dbg
+  | Tagged_immediate, Lsr -> C.lsr_int_caml x (C.tag_int y dbg) dbg
+  | Tagged_immediate, Asr -> C.asr_int_caml x (C.tag_int y dbg) dbg
   (* Naked ints *)
   | (Naked_int32 | Naked_int64 | Naked_nativeint | Naked_immediate), Lsl ->
       C.lsl_int x y dbg

--- a/middle_end/flambda2.0/to_cmm/un_cps.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps.ml
@@ -352,6 +352,9 @@ let binary_int_shift_primitive _env dbg kind op x y =
       todo() (* caml primitives for these have no native/unboxed version *)
   | Naked_int64, Asr when C.arch32 ->
       todo() (* caml primitives for these have no native/unboxed version *)
+  (* Int32 special case *)
+  | Naked_int32, Lsr when C.arch64 ->
+      C.asr_int (C.zero_extend_32 dbg x) y dbg
   (* Tagged integers *)
   | Tagged_immediate, Lsl -> C.lsl_int_caml x y dbg
   | Tagged_immediate, Lsr -> C.lsr_int_caml x y dbg

--- a/middle_end/flambda2.0/to_cmm/un_cps_helper.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps_helper.ml
@@ -19,6 +19,7 @@ open Cmm_helpers
 
 (* Are we compiling on/for a 32-bit architecture ? *)
 let arch32 = Arch.size_int = 4
+let arch64 = Arch.size_int = 8
 
 (* Useful shortcut *)
 let typ_int64 =

--- a/middle_end/flambda2.0/to_cmm/un_cps_helper.mli
+++ b/middle_end/flambda2.0/to_cmm/un_cps_helper.mli
@@ -21,6 +21,9 @@ open Flambda2
 val arch32 : bool
 (** [arch32] is [true] iff we are compiling for a 32-bit target. *)
 
+val arch64 : bool
+(** [arch64] is [true] iff we are compiling for a 64-bit target. *)
+
 val typ_int64 : Cmm.machtype
 (** An adequate Cmm machtype for an int64 (including on a 32-bit target). *)
 


### PR DESCRIPTION
Shifts in flambda2 now take as second argument an untagged integer + fix in un_cps for lsr 32 bits on 64-bits archs.