### PR TITLE
Few bugfixes

### DIFF
--- a/middle_end/flambda2.0/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2.0/from_lambda/lambda_to_flambda_primitives.ml
@@ -528,7 +528,7 @@ let convert_lprim ~backend (prim : L.primitive) (args : Simple.t list)
     Checked {
       primitive =
         box_bint Pnativeint
-          (Binary (Int_arith (I.Naked_nativeint, Mod),
+          (Binary (Int_arith (I.Naked_nativeint, Div),
             unbox_bint Pnativeint arg1, unbox_bint Pnativeint arg2));
       validity_conditions = [
         Binary (Phys_equal (K.naked_nativeint, Neq), unbox_bint Pnativeint arg2,

--- a/middle_end/flambda2.0/to_cmm/un_cps.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps.ml
@@ -331,16 +331,19 @@ let binary_int_arith_primitive _env dbg kind op x y =
       C.sub_int x y dbg
   | (Naked_int32 | Naked_int64 | Naked_nativeint | Naked_immediate), Mul ->
       C.mul_int x y dbg
-  | (Naked_int32 | Naked_int64 | Naked_nativeint | Naked_immediate), Div ->
-      C.div_int x y Lambda.Unsafe dbg
-  | (Naked_int32 | Naked_int64 | Naked_nativeint | Naked_immediate), Mod ->
-      C.mod_int x y Lambda.Unsafe dbg
   | (Naked_int32 | Naked_int64 | Naked_nativeint | Naked_immediate), And ->
       C.and_ ~dbg x y
   | (Naked_int32 | Naked_int64 | Naked_nativeint | Naked_immediate), Or ->
       C.or_ ~dbg x y
   | (Naked_int32 | Naked_int64 | Naked_nativeint | Naked_immediate), Xor ->
       C.xor_ ~dbg x y
+  (* Division and modulo need some extra care *)
+  | (Naked_int32 | Naked_int64 | Naked_nativeint | Naked_immediate), Div ->
+      let bi = C.primitive_boxed_int_of_standard_int kind in
+      C.safe_div_bi Lambda.Unsafe x y bi dbg
+  | (Naked_int32 | Naked_int64 | Naked_nativeint | Naked_immediate), Mod ->
+      let bi = C.primitive_boxed_int_of_standard_int kind in
+      C.safe_mod_bi Lambda.Unsafe x y bi dbg
 
 let binary_int_shift_primitive _env dbg kind op x y =
   match (kind : Flambda_kind.Standard_int.t),

--- a/middle_end/flambda2.0/to_cmm/un_cps_helper.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps_helper.ml
@@ -198,18 +198,13 @@ let unreachable =
 
 (* Block creation *)
 
-let float_tag = function
-  | [] -> assert false
-  | [_] -> Tag.double_tag
-  | _ -> Tag.double_array_tag
-
 let make_block ?(dbg=Debuginfo.none) kind args =
   match (kind : Flambda_primitive.make_block_kind) with
   | Full_of_values (tag, _) ->
       make_alloc dbg (Tag.Scannable.to_int tag) args
   | Full_of_naked_floats
   | Generic_array Full_of_naked_floats ->
-      make_float_alloc dbg (Tag.to_int (float_tag args)) args
+      make_float_alloc dbg (Tag.to_int Tag.double_array_tag) args
   | Generic_array No_specialisation ->
       extcall ~dbg ~alloc:true
         "caml_make_array" Cmm.typ_val

--- a/middle_end/flambda2.0/to_cmm/un_cps_helper.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps_helper.ml
@@ -98,6 +98,14 @@ let sequence x y =
 
 (* Boxing/unboxing *)
 
+let primitive_boxed_int_of_standard_int b =
+  match (b : Flambda_kind.Standard_int.t) with
+  | Naked_int32 -> Primitive.Pint32
+  | Naked_int64 -> Primitive.Pint64
+  | Naked_nativeint -> Primitive.Pnativeint
+  | Naked_immediate
+  | Tagged_immediate -> assert false
+
 let primitive_boxed_int_of_boxable_number b =
   match (b : Flambda_kind.Boxable_number.t) with
   | Naked_float | Untagged_immediate -> assert false

--- a/middle_end/flambda2.0/to_cmm/un_cps_helper.mli
+++ b/middle_end/flambda2.0/to_cmm/un_cps_helper.mli
@@ -253,6 +253,13 @@ val ccatch :
 (** Enclose a body with some static handlers. *)
 
 
+(** {2 Arithmetic/Logic helpers} *)
+
+val primitive_boxed_int_of_standard_int :
+  Flambda_kind.Standard_int.t -> Primitive.boxed_integer
+(** Conversion function. *)
+
+
 (** {2 Arithmetic/Logic operations} *)
 
 val and_ : ?dbg:Debuginfo.t -> Cmm.expression -> Cmm.expression -> Cmm.expression


### PR DESCRIPTION
Three bugfixes:
- there was a typo in `lambda_to_flambda_primtiive.ml` which translated a div into a mod
- `un_cps` now generate the correct checks against `-1` for div and mod operations
- `un_cps` used the wrong tag for arrays/blocks full of floats, this is now fixed.
