### PR TITLE
Remove return wrapper

### DIFF
--- a/asmcomp/CSEgen.ml
+++ b/asmcomp/CSEgen.ml
@@ -255,7 +255,7 @@ method private kill_loads n =
 
 method private cse n i =
   match i.desc with
-  | Iend | Ireturn | Iop(Itailcall_ind _) | Iop(Itailcall_imm _)
+  | Iend | Ireturn _ | Iop(Itailcall_ind _) | Iop(Itailcall_imm _)
   | Iexit _ | Iraise _ ->
       i
   | Iop (Imove | Ispill | Ireload) ->

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -115,6 +115,10 @@ let negate_float_comparison = Lambda.negate_float_comparison
 let swap_float_comparison = Lambda.swap_float_comparison
 type label = int
 
+type exit_label =
+  | Return_lbl
+  | Lbl of label
+
 let label_counter = ref 99
 
 let new_label() = incr label_counter; !label_counter
@@ -195,10 +199,10 @@ type expression =
       * Debuginfo.t
   | Ccatch of
       rec_flag
-        * (int * (Backend_var.With_provenance.t * machtype) list
+        * (label * (Backend_var.With_provenance.t * machtype) list
           * expression * Debuginfo.t) list
         * expression
-  | Cexit of int * expression list * trap_action list
+  | Cexit of exit_label * expression list * trap_action list
   | Ctrywith of expression * trywith_kind * Backend_var.With_provenance.t
       * expression * Debuginfo.t
 

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -97,6 +97,10 @@ val swap_float_comparison: float_comparison -> float_comparison
 type label = int
 val new_label: unit -> label
 
+type exit_label =
+  | Return_lbl
+  | Lbl of label
+
 type rec_flag = Nonrecursive | Recursive
 
 type phantom_defining_expr =
@@ -203,10 +207,10 @@ and expression =
       * Debuginfo.t
   | Ccatch of
       rec_flag
-        * (int * (Backend_var.With_provenance.t * machtype) list
+        * (label * (Backend_var.With_provenance.t * machtype) list
           * expression * Debuginfo.t) list
         * expression
-  | Cexit of int * expression list * trap_action list
+  | Cexit of exit_label * expression list * trap_action list
   | Ctrywith of expression * trywith_kind * Backend_var.With_provenance.t
       * expression * Debuginfo.t
 
@@ -241,7 +245,7 @@ type phrase =
   | Cdata of data_item list
 
 val ccatch :
-     int * (Backend_var.With_provenance.t * machtype) list
+     label * (Backend_var.With_provenance.t * machtype) list
        * expression * expression * Debuginfo.t
   -> expression
 

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -276,7 +276,7 @@ let mk_not dbg cmm =
 
 let create_loop body dbg =
   let cont = Lambda.next_raise_count () in
-  let call_cont = Cexit (cont, [], []) in
+  let call_cont = Cexit (Lbl cont, [], []) in
   let body = Csequence (body, call_cont) in
   Ccatch (Recursive, [cont, [], body, dbg], call_cont)
 
@@ -1476,7 +1476,7 @@ struct
   let bind arg body = bind "switcher" arg body
 
   let make_catch handler = match handler with
-  | Cexit (i,[],[]) -> i,fun e -> e
+  | Cexit (Lbl i,[],[]) -> i,fun e -> e
   | _ ->
       let dbg = Debuginfo.none in
       let i = Lambda.next_raise_count () in
@@ -1488,11 +1488,11 @@ struct
       i,
       (fun body -> match body with
       | Cexit (j,_,_) ->
-          if i=j then handler
+          if Lbl i = j then handler
           else body
       | _ ->  ccatch (i,[],body,handler, dbg))
 
-  let make_exit i = Cexit (i,[],[])
+  let make_exit i = Cexit (Lbl i,[],[])
 
 end
 
@@ -1511,7 +1511,7 @@ module StoreExpForSwitch =
       let make_key index expr =
         let continuation =
           match expr with
-          | Cexit (i,[],[]) -> Some i
+          | Cexit (Lbl i,[],[]) -> Some i
           | _ -> None
         in
         Some (continuation, index)
@@ -1528,7 +1528,7 @@ module StoreExp =
       type t = expression
       type key = int
       let make_key = function
-        | Cexit (i,[],[]) -> Some i
+        | Cexit (Lbl i,[],[]) -> Some i
         | _ -> None
       let compare_key = Stdlib.compare
     end)
@@ -1713,7 +1713,7 @@ let cache_public_method meths tag cache dbg =
            dbg),
         Cifthenelse
           (Cop(Ccmpi Cge, [Cvar li; Cvar hi], dbg),
-           dbg, Cexit (raise_num, [], []),
+           dbg, Cexit (Lbl raise_num, [], []),
            dbg, Ctuple [],
            dbg))))
        dbg,

--- a/asmcomp/comballoc.ml
+++ b/asmcomp/comballoc.ml
@@ -29,7 +29,7 @@ let allocated_size = function
 
 let rec combine i allocstate =
   match i.desc with
-    Iend | Ireturn | Iexit _ | Iraise _ ->
+    Iend | Ireturn _ | Iexit _ | Iraise _ ->
       (i, allocated_size allocstate)
   | Iop(Ialloc { bytes = sz; _ }) ->
       begin match allocstate with

--- a/asmcomp/deadcode.ml
+++ b/asmcomp/deadcode.ml
@@ -44,7 +44,7 @@ let rec deadcode i =
     else i.arg
   in
   match i.desc with
-  | Iend | Ireturn | Iop(Itailcall_ind _) | Iop(Itailcall_imm _) | Iraise _ ->
+  | Iend | Ireturn _ | Iop(Itailcall_ind _) | Iop(Itailcall_imm _) | Iraise _ ->
       let regs = Reg.add_set_array i.live arg in
       { i; regs; exits = Int.Set.empty; }
   | Iop op ->

--- a/asmcomp/debug/available_regs.ml
+++ b/asmcomp/debug/available_regs.ml
@@ -94,7 +94,7 @@ let rec available_regs (instr : M.instruction)
     | Ok avail_before ->
       match instr.desc with
       | Iend -> None, ok avail_before
-      | Ireturn -> None, unreachable
+      | Ireturn _ -> None, unreachable
       | Iop (Itailcall_ind _) | Iop (Itailcall_imm _) ->
         Some (ok Reg_with_debug_info.Set.empty), unreachable
       | Iop (Iname_for_debugger { ident; which_parameter; provenance;

--- a/asmcomp/interf.ml
+++ b/asmcomp/interf.ml
@@ -86,7 +86,7 @@ let build_graph fundecl =
     if Array.length destroyed > 0 then add_interf_set destroyed i.live;
     match i.desc with
       Iend -> ()
-    | Ireturn -> ()
+    | Ireturn _ -> ()
     | Iop(Imove | Ispill | Ireload) ->
         add_interf_move i.arg.(0) i.res.(0) i.live;
         interf i.next
@@ -152,7 +152,7 @@ let build_graph fundecl =
     add_spill_cost weight i.res;
     match i.desc with
       Iend -> ()
-    | Ireturn -> ()
+    | Ireturn _ -> ()
     | Iop(Imove) ->
         add_mutual_pref weight i.arg.(0) i.res.(0);
         prefer weight i.next

--- a/asmcomp/interval.ml
+++ b/asmcomp/interval.ml
@@ -136,7 +136,7 @@ let build_intervals fd =
     | Iop _ ->
         insert_destroyed_at_oper intervals i !pos;
         walk_instruction i.next
-    | Ireturn ->
+    | Ireturn _ ->
         insert_destroyed_at_oper intervals i !pos;
         walk_instruction i.next
     | Iifthenelse(_, ifso, ifnot) ->

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -163,6 +163,15 @@ let linear i n contains_calls =
     | Iop op ->
         copy_instr (Lop op) i (linear env i.Mach.next n)
     | Ireturn traps ->
+        let delta_traps =
+          List.fold_left
+            (fun delta trap ->
+               match trap with
+               | Cmm.Pop -> delta - 1
+               | Cmm.Push _ -> delta + 1)
+            0 traps
+        in
+        let n = adjust_trap_depth (-delta_traps) n in
         let n1 = copy_instr Lreturn i (discard_dead_code n) in
         let n2 =
           if contains_calls

--- a/asmcomp/liveness.ml
+++ b/asmcomp/liveness.ml
@@ -62,7 +62,7 @@ let rec live env i finally =
     Iend ->
       i.live <- finally;
       finally
-  | Ireturn | Iop(Itailcall_ind _) | Iop(Itailcall_imm _) ->
+  | Ireturn _ | Iop(Itailcall_ind _) | Iop(Itailcall_imm _) ->
       i.live <- Reg.Set.empty; (* no regs are live across *)
       Reg.set_of_array arg
   | Iop op ->

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -83,7 +83,7 @@ type instruction =
 and instruction_desc =
     Iend
   | Iop of operation
-  | Ireturn
+  | Ireturn of Cmm.trap_action list
   | Iifthenelse of test * instruction * instruction
   | Iswitch of int array * instruction array
   | Icatch of Cmm.rec_flag * (int * trap_stack * instruction) list * instruction
@@ -151,7 +151,7 @@ let rec instr_iter f i =
       f i;
       match i.desc with
         Iend -> ()
-      | Ireturn | Iop(Itailcall_ind _) | Iop(Itailcall_imm _) -> ()
+      | Ireturn _ | Iop(Itailcall_ind _) | Iop(Itailcall_imm _) -> ()
       | Iifthenelse(_tst, ifso, ifnot) ->
           instr_iter f ifso; instr_iter f ifnot; instr_iter f i.next
       | Iswitch(_index, cases) ->
@@ -201,7 +201,7 @@ let spacetime_node_hole_pointer_is_live_before insn =
     | Ifloatofint | Iintoffloat
     | Iname_for_debugger _ -> false
     end
-  | Iend | Ireturn | Iifthenelse _ | Iswitch _ | Icatch _
+  | Iend | Ireturn _ | Iifthenelse _ | Iswitch _ | Icatch _
   | Iexit _ | Itrywith _ | Iraise _ -> false
 
 let operation_can_raise op =

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -102,7 +102,7 @@ type instruction =
 and instruction_desc =
     Iend
   | Iop of operation
-  | Ireturn
+  | Ireturn of Cmm.trap_action list
   | Iifthenelse of test * instruction * instruction
   | Iswitch of int array * instruction array
   | Icatch of Cmm.rec_flag * (int * trap_stack * instruction) list * instruction

--- a/asmcomp/printcmm.ml
+++ b/asmcomp/printcmm.ml
@@ -95,6 +95,10 @@ let phantom_defining_expr_opt ppf defining_expr =
   | None -> Format.pp_print_string ppf "()"
   | Some defining_expr -> phantom_defining_expr ppf defining_expr
 
+let exit_label ppf = function
+  | Return_lbl -> fprintf ppf "*return*"
+  | Lbl lbl -> fprintf ppf "%d" lbl
+
 let trap_action ppf ta =
   match ta with
   | Push i -> fprintf ppf "push(%d)" i
@@ -258,7 +262,7 @@ let rec expr ppf = function
         sequence e1
         print_handlers handlers
   | Cexit (i, el, traps) ->
-      fprintf ppf "@[<2>(exit%a %d" trap_action_list traps i;
+      fprintf ppf "@[<2>(exit%a %a" trap_action_list traps exit_label i;
       List.iter (fun e -> fprintf ppf "@ %a" expr e) el;
       fprintf ppf ")@]"
   | Ctrywith(e1, kind, id, e2, _dbg) ->

--- a/asmcomp/printmach.ml
+++ b/asmcomp/printmach.ml
@@ -186,8 +186,8 @@ let rec instr ppf i =
   | Iend -> ()
   | Iop op ->
       operation op i.arg ppf i.res
-  | Ireturn ->
-      fprintf ppf "return %a" regs i.arg
+  | Ireturn traps ->
+      fprintf ppf "return%a %a" Printcmm.trap_action_list traps regs i.arg
   | Iifthenelse(tst, ifso, ifnot) ->
       fprintf ppf "@[<v 2>if %a then@,%a" (test tst) i.arg instr ifso;
       begin match ifnot.desc with

--- a/asmcomp/regtype.ml
+++ b/asmcomp/regtype.ml
@@ -215,7 +215,7 @@ let test env i arg _res = function
 let rec instruction_desc env i args res = function
   | Iend -> assert false
   | Iop op -> infer_op env i args res op
-  | Ireturn -> env
+  | Ireturn _ -> env
   | Iifthenelse (t, then_branch, else_branch) ->
       let env = test env i args res t in
       let env = instruction env then_branch in

--- a/asmcomp/reloadgen.ml
+++ b/asmcomp/reloadgen.ml
@@ -82,7 +82,7 @@ method private reload i =
        already at the correct position (e.g. on stack for some arguments).
        However, something needs to be done for the function pointer in
        indirect calls. *)
-    Iend | Ireturn | Iop(Itailcall_imm _) | Iraise _ -> i
+    Iend | Ireturn _ | Iop(Itailcall_imm _) | Iraise _ -> i
   | Iop(Itailcall_ind _) ->
       let newarg = self#makereg1 i.arg in
       insert_moves i.arg newarg

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -912,27 +912,40 @@ method emit_expr (env:environment) exp =
       self#insert env (Icatch (rec_flag, List.map aux l, s_body#extract))
         [||] [||];
       r
-  | Cexit (nfail,args,traps) ->
+  | Cexit (lbl,args,traps) ->
       begin match self#emit_parts_list env args with
         None -> None
       | Some (simple_list, ext_env) ->
-          let src = self#emit_tuple ext_env simple_list in
-          let dest_args, trap_stack =
-            try env_find_static_exception nfail env
-            with Not_found ->
-              Misc.fatal_error ("Selection.emit_expr: unbound label "^
-                                Stdlib.Int.to_string nfail)
-          in
-          (* Intermediate registers to handle cases where some
-             registers from src are present in dest *)
-          let tmp_regs = Reg.createv_like src in
-          (* Ccatch registers must not contain out of heap pointers *)
-          Array.iter (fun reg -> assert(reg.typ <> Addr)) src;
-          self#insert_moves env src tmp_regs ;
-          self#insert_moves env tmp_regs (Array.concat dest_args) ;
-          self#insert env (Iexit (nfail, traps)) [||] [||];
-          set_traps nfail trap_stack env.trap_stack traps;
-          None
+          begin match lbl with
+          | Lbl nfail ->
+              let src = self#emit_tuple ext_env simple_list in
+              let dest_args, trap_stack =
+                try env_find_static_exception nfail env
+                with Not_found ->
+                  Misc.fatal_error ("Selection.emit_expr: unbound label "^
+                                    Stdlib.Int.to_string nfail)
+              in
+              (* Intermediate registers to handle cases where some
+                 registers from src are present in dest *)
+              let tmp_regs = Reg.createv_like src in
+              (* Ccatch registers must not contain out of heap pointers *)
+              Array.iter (fun reg -> assert(reg.typ <> Addr)) src;
+              self#insert_moves env src tmp_regs ;
+              self#insert_moves env tmp_regs (Array.concat dest_args) ;
+              self#insert env (Iexit (nfail, traps)) [||] [||];
+              set_traps nfail trap_stack env.trap_stack traps;
+              None
+          | Return_lbl ->
+              begin match simple_list with
+              | [expr] -> self#emit_return env expr traps; None
+              | [] ->
+                  Misc.fatal_error
+                    "Selection.emit_expr: Return without arguments"
+              | _ :: _ :: _ ->
+                   Misc.fatal_error
+                     "Selection.emit_expr: Return with too many arguments"
+              end
+          end
       end
   | Ctrywith(e1, kind, v, e2, _dbg) ->
       let env_body = env_enter_trywith env kind in
@@ -1107,13 +1120,13 @@ method emit_stores env data regs_addr =
 
 (* Same, but in tail position *)
 
-method private emit_return (env:environment) exp =
+method private emit_return (env:environment) exp (traps:trap_action list) =
   match self#emit_expr env exp with
     None -> ()
   | Some r ->
       let loc = Proc.loc_results r in
       self#insert_moves env r loc;
-      self#insert env Ireturn loc [||]
+      self#insert env (Ireturn traps) loc [||]
 
 method emit_tail (env:environment) exp =
   match exp with
@@ -1154,7 +1167,7 @@ method emit_tail (env:environment) exp =
                 self#insert_debug env (Iop new_op) dbg
                             (Array.append [|r1.(0)|] loc_arg) loc_res;
                 self#insert env (Iop(Istackoffset(-stack_ofs))) [||] [||];
-                self#insert env Ireturn loc_res [||]
+                self#insert env (Ireturn []) loc_res [||]
               end
           | Icall_imm { func; label_after; } ->
               let r1 = self#emit_tuple env new_args in
@@ -1186,7 +1199,7 @@ method emit_tail (env:environment) exp =
                 self#maybe_emit_spacetime_move env ~spacetime_reg;
                 self#insert_debug env (Iop new_op) dbg loc_arg loc_res;
                 self#insert env (Iop(Istackoffset(-stack_ofs))) [||] [||];
-                self#insert env Ireturn loc_res [||]
+                self#insert env (Ireturn []) loc_res [||]
               end
           | _ -> Misc.fatal_error "Selection.emit_tail"
       end
@@ -1282,10 +1295,10 @@ method emit_tail (env:environment) exp =
       | Some r1 ->
           let loc = Proc.loc_results r1 in
           self#insert_moves env r1 loc;
-          self#insert env Ireturn loc [||]
+          self#insert env (Ireturn []) loc [||]
       end
   | _ ->
-      self#emit_return env exp
+      self#emit_return env exp []
 
 method private emit_tail_sequence env exp =
   let s = {< instr_seq = dummy_instr >} in

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -78,6 +78,19 @@ let set_traps nfail traps_ref base_traps exit_traps =
         Misc.fatal_errorf "Mismatching trap stacks for continuation %d" nfail
       else ()
 
+let trap_stack_is_empty env =
+  match env.trap_stack with
+  | Uncaught -> true
+  | Generic_trap _ | Specific_trap _ -> false
+
+let pop_all_traps env =
+  let rec pop_all acc = function
+    | Uncaught -> acc
+    | Generic_trap t
+    | Specific_trap (_, t) -> pop_all (Cmm.Pop :: acc) t
+  in
+  pop_all [] env.trap_stack
+
 let env_empty = {
   vars = V.Map.empty;
   static_exceptions = Int.Map.empty;
@@ -937,7 +950,7 @@ method emit_expr (env:environment) exp =
               None
           | Return_lbl ->
               begin match simple_list with
-              | [expr] -> self#emit_return env expr traps; None
+              | [expr] -> self#emit_return ext_env expr traps; None
               | [] ->
                   Misc.fatal_error
                     "Selection.emit_expr: Return without arguments"
@@ -1147,7 +1160,7 @@ method emit_tail (env:environment) exp =
               let r1 = self#emit_tuple env new_args in
               let rarg = Array.sub r1 1 (Array.length r1 - 1) in
               let (loc_arg, stack_ofs) = Proc.loc_arguments rarg in
-              if stack_ofs = 0 then begin
+              if stack_ofs = 0 && trap_stack_is_empty env then begin
                 let call = Iop (Itailcall_ind { label_after; }) in
                 let spacetime_reg =
                   self#about_to_emit_call env call [| r1.(0) |] dbg
@@ -1167,12 +1180,12 @@ method emit_tail (env:environment) exp =
                 self#insert_debug env (Iop new_op) dbg
                             (Array.append [|r1.(0)|] loc_arg) loc_res;
                 self#insert env (Iop(Istackoffset(-stack_ofs))) [||] [||];
-                self#insert env (Ireturn []) loc_res [||]
+                self#insert env (Ireturn (pop_all_traps env)) loc_res [||]
               end
           | Icall_imm { func; label_after; } ->
               let r1 = self#emit_tuple env new_args in
               let (loc_arg, stack_ofs) = Proc.loc_arguments r1 in
-              if stack_ofs = 0 then begin
+              if stack_ofs = 0 && trap_stack_is_empty env then begin
                 let call = Iop (Itailcall_imm { func; label_after; }) in
                 let spacetime_reg =
                   self#about_to_emit_call env call [| |] dbg
@@ -1199,7 +1212,7 @@ method emit_tail (env:environment) exp =
                 self#maybe_emit_spacetime_move env ~spacetime_reg;
                 self#insert_debug env (Iop new_op) dbg loc_arg loc_res;
                 self#insert env (Iop(Istackoffset(-stack_ofs))) [||] [||];
-                self#insert env (Ireturn []) loc_res [||]
+                self#insert env (Ireturn (pop_all_traps env)) loc_res [||]
               end
           | _ -> Misc.fatal_error "Selection.emit_tail"
       end
@@ -1283,22 +1296,15 @@ method emit_tail (env:environment) exp =
         [||] [||]
   | Ctrywith(e1, kind, v, e2, _dbg) ->
       let env_body = env_enter_trywith env kind in
-      let (opt_r1, s1) = self#emit_sequence env_body e1 in
+      let s1 = self#emit_tail_sequence env_body e1 in
       let rv = self#regs_for typ_val in
       let s2 = self#emit_tail_sequence (env_add v rv env) e2 in
       self#insert env
-        (Itrywith(s1#extract, kind,
+        (Itrywith(s1, kind,
                   instr_cons (Iop Imove) [|Proc.loc_exn_bucket|] rv s2))
-        [||] [||];
-      begin match opt_r1 with
-        None -> ()
-      | Some r1 ->
-          let loc = Proc.loc_results r1 in
-          self#insert_moves env r1 loc;
-          self#insert env (Ireturn []) loc [||]
-      end
+        [||] [||]
   | _ ->
-      self#emit_return env exp []
+      self#emit_return env exp (pop_all_traps env)
 
 method private emit_tail_sequence env exp =
   let s = {< instr_seq = dummy_instr >} in

--- a/asmcomp/spill.ml
+++ b/asmcomp/spill.ml
@@ -139,7 +139,7 @@ let rec reload i before =
   match i.desc with
     Iend ->
       (i, before)
-  | Ireturn | Iop(Itailcall_ind _) | Iop(Itailcall_imm _) ->
+  | Ireturn _ | Iop(Itailcall_ind _) | Iop(Itailcall_imm _) ->
       (add_reloads (Reg.inter_set_array before i.arg) i,
        Reg.Set.empty)
   | Iop(Icall_ind _ | Icall_imm _ | Iextcall { alloc = true; }) ->
@@ -312,7 +312,7 @@ let rec spill env i finally =
   match i.desc with
     Iend ->
       (i, finally)
-  | Ireturn | Iop(Itailcall_ind _) | Iop(Itailcall_imm _) ->
+  | Ireturn _ | Iop(Itailcall_ind _) | Iop(Itailcall_imm _) ->
       (i, Reg.Set.empty)
   | Iop Ireload ->
       let (new_next, after) = spill env i.next finally in

--- a/asmcomp/split.ml
+++ b/asmcomp/split.ml
@@ -125,7 +125,7 @@ let rec rename i sub =
   match i.desc with
     Iend ->
       (i, sub)
-  | Ireturn | Iop(Itailcall_ind _) | Iop(Itailcall_imm _) ->
+  | Ireturn _ | Iop(Itailcall_ind _) | Iop(Itailcall_imm _) ->
       (instr_cons_debug i.desc (subst_regs i.arg sub) [||] i.dbg i.next,
        None)
   | Iop Ireload when i.res.(0).loc = Unknown ->

--- a/asmcomp/strmatch.ml
+++ b/asmcomp/strmatch.ml
@@ -380,8 +380,8 @@ module Make(I:I) = struct
     let catch dbg arg k = match arg with
     | Cexit (_e,[],_traps) ->  k arg
     | _ ->
-        let e =  next_raise_count () in
-        ccatch (e,[],k (Cexit (e,[],[])),arg,dbg)
+        let e = next_raise_count () in
+        ccatch (e,[],k (Cexit (Lbl e,[],[])),arg,dbg)
 
     let compile dbg str default cases =
 (* We do not attempt to really optimise default=None *)

--- a/middle_end/flambda2.0/to_cmm/un_cps.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps.ml
@@ -964,15 +964,24 @@ and apply_cont_exn env e k = function
 (* A call to the return continuation of the current block simply is the return value
    for the current block being translated. *)
 and apply_cont_ret env e k = function
-  | [] ->
-      assert (Apply_cont_expr.trap_action e = None);
-      let wrap, _ = Env.flush_delayed_lets env in
-      wrap C.void
+  (* CR vlaviron: Cmm functions should not return nothing *)
+  (* | [] ->
+   *     assert (Apply_cont_expr.trap_action e = None);
+   *     let wrap, _ = Env.flush_delayed_lets env in
+   *     wrap C.void *)
   | [res] ->
-      assert (Apply_cont_expr.trap_action e = None);
       let res, env, _ = simple env res in
       let wrap, _ = Env.flush_delayed_lets env in
-      wrap res
+      begin match Apply_cont_expr.trap_action e with
+      | None ->
+          wrap res
+      | Some (Pop _) ->
+          wrap (C.trap_return res [Cmm.Pop])
+      | Some (Push _) ->
+          Misc.fatal_errorf
+            "Continuation %a (return cont) should not be applied with a push trap action"
+            Continuation.print k
+      end
   | _ ->
       (* TODO: add support using unboxed tuples *)
       Misc.fatal_errorf

--- a/middle_end/flambda2.0/to_cmm/un_cps.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps.ml
@@ -932,8 +932,7 @@ and apply_cont env e =
   let args = Apply_cont_expr.args e in
   if Continuation.is_exn k then
     apply_cont_exn env e k args
-  else if Continuation.equal (Env.return_cont env) k
-       && Apply_cont_expr.trap_action e = None then
+  else if Continuation.equal (Env.return_cont env) k then
     apply_cont_ret env e k args
   else
     apply_cont_regular env e k args
@@ -1435,8 +1434,6 @@ let function_flags () =
 let function_decl offsets used_closure_vars fun_name _ d =
   Profile.record_call ~accumulate:true fun_name (fun () ->
     let fun_dbg = Function_declaration.dbg d in
-    let result_arity = Function_declaration.result_arity d in
-    let ret_machtype = machtype_of_return_arity result_arity in
     let p = Function_declaration.params_and_body d in
     Function_params_and_body.pattern_match p
       ~f:(fun ~return_continuation:k k_exn vars ~body ~my_closure ->
@@ -1446,22 +1443,9 @@ let function_decl offsets used_closure_vars fun_name _ d =
             (* Init the env and create a jump id for the ret closure
                in case a trap action is attached to one of tis call *)
             let env = Env.mk offsets k k_exn used_closure_vars in
-            let id, env = Env.add_jump_cont env [ret_machtype] k in
-            let fun_handle_var = Backend_var.create_local "*fun_res*" in
-            let fun_handler = C.var fun_handle_var in
-            let fun_handle_vars = [
-              Backend_var.With_provenance.create fun_handle_var,
-              ret_machtype
-            ] in
-            (* translate the arg list and body, inserting a catch for the
-               return continuation. *)
+            (* translate the arg list and body *)
             let env, fun_args = var_list env args in
-            let fun_body =
-              C.ccatch
-                ~rec_flag:false
-                ~body:(expr env body)
-                ~handlers:[C.handler id fun_handle_vars fun_handler]
-            in
+            let fun_body = expr env body in
             let fun_flags = function_flags () in
             C.fundecl fun_name fun_args fun_body fun_flags fun_dbg
           with Misc.Fatal_error ->

--- a/middle_end/flambda2.0/to_cmm/un_cps_env.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps_env.ml
@@ -74,7 +74,7 @@ type stage =
 (* Translation environment *)
 
 type t = {
-  k     : Continuation.t;
+  k_return : Continuation.t;
   (* The continuation of the current context
        (used to determine which calls are tail-calls) *)
   k_exn : Continuation.t;
@@ -101,8 +101,8 @@ type t = {
   (* archived stages, in reverse chronological order. *)
 }
 
-let mk offsets k k_exn used_closure_vars = {
-  k; k_exn; used_closure_vars; offsets;
+let mk offsets k_return k_exn used_closure_vars = {
+  k_return; k_exn; used_closure_vars; offsets;
   stages = [];
   pures = Variable.Map.empty;
   vars = Variable.Map.empty;
@@ -117,7 +117,7 @@ let dummy offsets used_closure_vars =
     (Continuation.create ())
     used_closure_vars
 
-let return_cont env = env.k
+let return_cont env = env.k_return
 let exn_cont env = env.k_exn
 
 (* Variables *)

--- a/middle_end/flambda2.0/to_cmm/un_cps_helper.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps_helper.ml
@@ -434,7 +434,10 @@ let handler ?(dbg=Debuginfo.none) id vars body =
   (id, vars, body, dbg)
 
 let cexit id args trap_actions =
-  Cmm.Cexit (id, args, trap_actions)
+  Cmm.Cexit (Cmm.Lbl id, args, trap_actions)
+
+let trap_return arg trap_actions =
+  Cmm.Cexit (Cmm.Return_lbl, [arg], trap_actions)
 
 let ccatch ~rec_flag ~handlers ~body =
   let rec_flag = if rec_flag then Cmm.Recursive else Cmm.Nonrecursive in

--- a/middle_end/flambda2.0/to_cmm/un_cps_helper.mli
+++ b/middle_end/flambda2.0/to_cmm/un_cps_helper.mli
@@ -245,6 +245,10 @@ val cexit : int -> Cmm.expression list -> Cmm.trap_action list -> Cmm.expression
 (** [cexit id args] creates the cmm expression for static to a static handler with
     exit number [id], with arguments [args]. *)
 
+val trap_return : Cmm.expression -> Cmm.trap_action list -> Cmm.expression
+(** [trap_return res traps] creates the cmm expression for returning [res] after
+    applying the trap actions in [traps]. *)
+
 val ccatch :
   rec_flag:bool ->
   handlers:static_handler list ->

--- a/testsuite/tools/parsecmm.mly
+++ b/testsuite/tools/parsecmm.mly
@@ -30,7 +30,7 @@ let make_switch n selector caselist =
   let index = Array.make n 0 in
   let casev = Array.of_list caselist in
   let dbg = Debuginfo.none in
-  let actv = Array.make (Array.length casev) (Cexit(0,[],[]), dbg) in
+  let actv = Array.make (Array.length casev) (Cexit(Lbl 0,[],[]), dbg) in
   for i = 0 to Array.length casev - 1 do
     let (posl, e) = casev.(i) in
     List.iter (fun pos -> index.(pos) <- i) posl;
@@ -232,20 +232,20 @@ expr:
           match $3 with
             Cconst_int (x, _) when x <> 0 -> $4
           | _ -> Cifthenelse($3, debuginfo (), $4, debuginfo (),
-                             (Cexit(lbl0,[],[])),
+                             (Cexit(Lbl lbl0,[],[])),
                              debuginfo ()) in
         Ccatch(Nonrecursive, [lbl0, [], Ctuple [], debuginfo ()],
           Ccatch(Recursive,
-            [lbl1, [], Csequence(body, Cexit(lbl1, [], [])), debuginfo ()],
-            Cexit(lbl1, [], []))) }
+            [lbl1, [], Csequence(body, Cexit(Lbl lbl1, [], [])), debuginfo ()],
+            Cexit(Lbl lbl1, [], []))) }
   | LPAREN EXIT traps IDENT exprlist RPAREN
-    { Cexit(find_label $4, List.rev $5, $3) }
+    { Cexit(Lbl (find_label $4), List.rev $5, $3) }
   | LPAREN CATCH sequence WITH catch_handlers RPAREN
     { let handlers = $5 in
       List.iter (fun (_, l, _, _) ->
         List.iter (fun (x, _) -> unbind_ident x) l) handlers;
       Ccatch(Recursive, handlers, $3) }
-  | EXIT        { Cexit(0,[],[]) }
+  | EXIT        { Cexit(Lbl 0,[],[]) }
   | LPAREN TRY sequence WITH bind_ident sequence RPAREN
                 { unbind_ident $5; Ctrywith($3, Regular, $5, $6, debuginfo ()) }
   | LPAREN VAL expr expr RPAREN


### PR DESCRIPTION
This PR removes the extra wrapper for the return value of functions.
It needs some extra Cmm support, so the first commit adds this support (it is also present in my branch lthls/ocaml:cmm_traps).
