### PR TITLE
Better check for Apply_cont_rewrite.does_nothing

### DIFF
--- a/middle_end/flambda2.0/simplify/basic/apply_cont_rewrite.ml
+++ b/middle_end/flambda2.0/simplify/basic/apply_cont_rewrite.ml
@@ -75,6 +75,11 @@ let create ~original_params ~used_params ~extra_params ~extra_args
           extra_params_and_args)
       extra_args
   in
+  let extra_args =
+    if Id.Map.for_all (fun _ l -> l = []) extra_args
+    then Id.Map.empty
+    else extra_args
+  in
   let used_extra_params =
     List.filter (fun extra_param -> KP.Set.mem extra_param used_extra_params)
       extra_params


### PR DESCRIPTION
The original check considered that a rewrite which had empty lists for all uses id of a continuation actually did something, which seems wrong.
This patch fixes some problem with switch simplification, but I'm not sure if it's the best way to fix the `does_nothing` function:
- if I'm not wrong, the `Map.is_empty` is actually subsumed by the `Map.for_all` (a for_all is true for any predicate on an empty map), which could simplify the test.
- or if we can assume that all lists in the `Id.Map` have the same size, we could replace the `for_all` by an `exists` (which could be a bit faster).