### PR TITLE
De-nesting and trivial inlinable joins

### DIFF
--- a/.depend
+++ b/.depend
@@ -6328,6 +6328,7 @@ middle_end/flambda2.0/lifting/reification.cmi : \
     middle_end/flambda2.0/simplify/env/downwards_acc.cmi
 middle_end/flambda2.0/lifting/reify_continuation_param_types.cmo : \
     middle_end/flambda2.0/compilenv_deps/variable.cmi \
+    middle_end/flambda2.0/basic/var_within_closure.cmi \
     middle_end/flambda2.0/compilenv_deps/symbol.cmi \
     middle_end/flambda2.0/lifting/sort_lifted_constants.cmi \
     middle_end/flambda2.0/simplify/simplify_import.cmi \
@@ -6346,6 +6347,7 @@ middle_end/flambda2.0/lifting/reify_continuation_param_types.cmo : \
     middle_end/flambda2.0/lifting/reify_continuation_param_types.cmi
 middle_end/flambda2.0/lifting/reify_continuation_param_types.cmx : \
     middle_end/flambda2.0/compilenv_deps/variable.cmx \
+    middle_end/flambda2.0/basic/var_within_closure.cmx \
     middle_end/flambda2.0/compilenv_deps/symbol.cmx \
     middle_end/flambda2.0/lifting/sort_lifted_constants.cmx \
     middle_end/flambda2.0/simplify/simplify_import.cmx \
@@ -6600,11 +6602,9 @@ middle_end/flambda2.0/naming/name_permutation.cmi : \
     middle_end/flambda2.0/basic/name.cmi \
     middle_end/flambda2.0/basic/continuation.cmi
 middle_end/flambda2.0/naming/permutation.cmo : \
-    utils/misc.cmi \
     utils/identifiable.cmi \
     middle_end/flambda2.0/naming/permutation.cmi
 middle_end/flambda2.0/naming/permutation.cmx : \
-    utils/misc.cmx \
     utils/identifiable.cmx \
     middle_end/flambda2.0/naming/permutation.cmi
 middle_end/flambda2.0/naming/permutation.cmi : \
@@ -6890,7 +6890,6 @@ middle_end/flambda2.0/simplify/simplify_common.cmo : \
     middle_end/flambda2.0/simplify/simplify_import.cmi \
     middle_end/flambda2.0/basic/simple.cmi \
     middle_end/flambda2.0/simplify/basic/reachable.cmi \
-    middle_end/flambda2.0/naming/name_occurrences.cmi \
     middle_end/flambda2.0/naming/name_mode.cmi \
     middle_end/flambda2.0/basic/name.cmi \
     utils/misc.cmi \
@@ -6899,9 +6898,6 @@ middle_end/flambda2.0/simplify/simplify_common.cmo : \
     middle_end/flambda2.0/basic/exn_continuation.cmi \
     lambda/debuginfo.cmi \
     middle_end/flambda2.0/basic/continuation.cmi \
-    middle_end/flambda2.0/basic/code_id_or_symbol.cmi \
-    middle_end/flambda2.0/basic/code_id.cmi \
-    middle_end/flambda2.0/types/structures/code_age_relation.cmi \
     middle_end/flambda2.0/naming/bindable_let_bound.cmi \
     middle_end/flambda2.0/simplify/basic/apply_cont_rewrite.cmi \
     middle_end/flambda2.0/simplify/simplify_common.cmi
@@ -6910,7 +6906,6 @@ middle_end/flambda2.0/simplify/simplify_common.cmx : \
     middle_end/flambda2.0/simplify/simplify_import.cmx \
     middle_end/flambda2.0/basic/simple.cmx \
     middle_end/flambda2.0/simplify/basic/reachable.cmx \
-    middle_end/flambda2.0/naming/name_occurrences.cmx \
     middle_end/flambda2.0/naming/name_mode.cmx \
     middle_end/flambda2.0/basic/name.cmx \
     utils/misc.cmx \
@@ -6919,9 +6914,6 @@ middle_end/flambda2.0/simplify/simplify_common.cmx : \
     middle_end/flambda2.0/basic/exn_continuation.cmx \
     lambda/debuginfo.cmx \
     middle_end/flambda2.0/basic/continuation.cmx \
-    middle_end/flambda2.0/basic/code_id_or_symbol.cmx \
-    middle_end/flambda2.0/basic/code_id.cmx \
-    middle_end/flambda2.0/types/structures/code_age_relation.cmx \
     middle_end/flambda2.0/naming/bindable_let_bound.cmx \
     middle_end/flambda2.0/simplify/basic/apply_cont_rewrite.cmx \
     middle_end/flambda2.0/simplify/simplify_common.cmi
@@ -7453,6 +7445,7 @@ middle_end/flambda2.0/simplify/env/continuation_uses_env.cmx : \
 middle_end/flambda2.0/simplify/env/continuation_uses_env.cmi : \
     middle_end/flambda2.0/simplify/env/continuation_uses_env_intf.cmo
 middle_end/flambda2.0/simplify/env/continuation_uses_env_intf.cmo : \
+    middle_end/flambda2.0/simplify/env/simplify_env_and_result.cmi \
     middle_end/flambda2.0/basic/kinded_parameter.cmi \
     middle_end/flambda2.0/types/flambda_type.cmi \
     middle_end/flambda2.0/simplify/env/continuation_use_kind.cmi \
@@ -7460,6 +7453,7 @@ middle_end/flambda2.0/simplify/env/continuation_uses_env_intf.cmo : \
     middle_end/flambda2.0/basic/continuation.cmi \
     middle_end/flambda2.0/basic/apply_cont_rewrite_id.cmi
 middle_end/flambda2.0/simplify/env/continuation_uses_env_intf.cmx : \
+    middle_end/flambda2.0/simplify/env/simplify_env_and_result.cmx \
     middle_end/flambda2.0/basic/kinded_parameter.cmx \
     middle_end/flambda2.0/types/flambda_type.cmx \
     middle_end/flambda2.0/simplify/env/continuation_use_kind.cmx \
@@ -7608,30 +7602,39 @@ middle_end/flambda2.0/simplify/env/upwards_acc.cmi : \
     middle_end/flambda2.0/terms/flambda.cmx \
     middle_end/flambda2.0/basic/continuation.cmx
 middle_end/flambda2.0/simplify/typing_helpers/continuation_uses.cmo : \
+    middle_end/flambda2.0/compilenv_deps/symbol.cmi \
+    middle_end/flambda2.0/simplify/env/simplify_env_and_result.cmi \
     middle_end/flambda2.0/basic/scope.cmi \
     middle_end/flambda2.0/simplify/typing_helpers/one_continuation_use.cmi \
+    middle_end/flambda2.0/basic/name.cmi \
     utils/misc.cmi \
     middle_end/flambda2.0/types/flambda_type.cmi \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda2.0/types/kinds/flambda_arity.cmi \
+    middle_end/flambda2.0/basic/continuation_extra_params_and_args.cmi \
     middle_end/flambda2.0/simplify/env/continuation_env_and_param_types.cmi \
     middle_end/flambda2.0/basic/continuation.cmi \
     utils/clflags.cmi \
     middle_end/flambda2.0/basic/apply_cont_rewrite_id.cmi \
     middle_end/flambda2.0/simplify/typing_helpers/continuation_uses.cmi
 middle_end/flambda2.0/simplify/typing_helpers/continuation_uses.cmx : \
+    middle_end/flambda2.0/compilenv_deps/symbol.cmx \
+    middle_end/flambda2.0/simplify/env/simplify_env_and_result.cmx \
     middle_end/flambda2.0/basic/scope.cmx \
     middle_end/flambda2.0/simplify/typing_helpers/one_continuation_use.cmx \
+    middle_end/flambda2.0/basic/name.cmx \
     utils/misc.cmx \
     middle_end/flambda2.0/types/flambda_type.cmx \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda2.0/types/kinds/flambda_arity.cmx \
+    middle_end/flambda2.0/basic/continuation_extra_params_and_args.cmx \
     middle_end/flambda2.0/simplify/env/continuation_env_and_param_types.cmx \
     middle_end/flambda2.0/basic/continuation.cmx \
     utils/clflags.cmx \
     middle_end/flambda2.0/basic/apply_cont_rewrite_id.cmx \
     middle_end/flambda2.0/simplify/typing_helpers/continuation_uses.cmi
 middle_end/flambda2.0/simplify/typing_helpers/continuation_uses.cmi : \
+    middle_end/flambda2.0/simplify/env/simplify_env_and_result.cmi \
     middle_end/flambda2.0/basic/kinded_parameter.cmi \
     middle_end/flambda2.0/types/flambda_type.cmi \
     middle_end/flambda2.0/types/kinds/flambda_arity.cmi \

--- a/Makefile
+++ b/Makefile
@@ -332,12 +332,12 @@ MIDDLE_END_FLAMBDA2_SIMPLIFY=\
   middle_end/flambda2.0/simplify/env/continuation_env_and_param_types.cmo \
   middle_end/flambda2.0/simplify/basic/continuation_in_env.cmo \
   middle_end/flambda2.0/simplify/basic/reachable.cmo \
+  middle_end/flambda2.0/simplify/env/simplify_env_and_result_intf.cmo \
+  middle_end/flambda2.0/simplify/env/simplify_env_and_result.cmo \
   middle_end/flambda2.0/simplify/typing_helpers/one_continuation_use.cmo \
   middle_end/flambda2.0/simplify/typing_helpers/continuation_uses.cmo \
   middle_end/flambda2.0/simplify/env/continuation_uses_env.cmo \
   middle_end/flambda2.0/simplify/env/continuation_uses_env_intf.cmo \
-  middle_end/flambda2.0/simplify/env/simplify_env_and_result_intf.cmo \
-  middle_end/flambda2.0/simplify/env/simplify_env_and_result.cmo \
   middle_end/flambda2.0/simplify/env/downwards_acc.cmo \
   middle_end/flambda2.0/simplify/env/upwards_acc.cmo \
   middle_end/flambda2.0/inlining/inlining_cost.cmo \

--- a/middle_end/flambda2.0/compilenv_deps/reg_width_things.ml
+++ b/middle_end/flambda2.0/compilenv_deps/reg_width_things.ml
@@ -186,9 +186,10 @@ module Symbol_data = struct
       Compilation_unit.print compilation_unit
       Linkage_name.print linkage_name
 
-  let hash { compilation_unit; linkage_name; } =
-    Hashtbl.hash (Compilation_unit.hash compilation_unit,
-      Linkage_name.hash linkage_name)
+  let hash { compilation_unit = _; linkage_name; } =
+    (* Linkage names are unique across a whole project, so there's no need
+       to hash the compilation unit. *)
+    Linkage_name.hash linkage_name
 
   let equal t1 t2 =
     if t1 == t2 then true

--- a/middle_end/flambda2.0/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2.0/from_lambda/closure_conversion.ml
@@ -34,6 +34,7 @@ type t = {
   current_unit_id : Ident.t;
   symbol_for_global' : (Ident.t -> Symbol.t);
   filename : string;
+  ilambda_exn_continuation : Continuation.t;
   mutable imported_symbols : Symbol.Set.t;
   (* All symbols in [imported_symbols] are to be of kind [Value]. *)
   mutable declared_symbols : (Symbol.t * Static_const.t) list;
@@ -554,16 +555,48 @@ let rec close t env (ilam : Ilambda.t) : Expr.t * _ =
         params
         params_with_kinds
     in
+    let body, delayed_handlers_body = close t env body in
+    (* If we are still at toplevel, don't un-nest handlers, otherwise we
+       may produce situations where reification of continuation parameters'
+       types (yielding new [Let_symbol] bindings) cause code IDs or symbols to
+       go out of syntactic scope (but not out of dominator scope). *)
+    let still_at_toplevel =
+      (* Same calculation as in [Simplify_expr]. *)
+      Env.still_at_toplevel env
+        && (not is_exn_handler)
+        && Continuation.Set.subset
+              (Name_occurrences.continuations (Expr.free_names body))
+              (Continuation.Set.of_list [name; t.ilambda_exn_continuation])
+    in
+    let body, delayed_handlers_body =
+      if still_at_toplevel then
+        drop_all_handlers delayed_handlers_body ~around:body,
+          Delayed_handlers.empty
+      else
+        let leaving_scope_of =
+          Name_occurrences.singleton_continuation name
+        in
+        drop_handlers delayed_handlers_body ~leaving_scope_of ~around:body
+    in
+    let handler_env =
+      if still_at_toplevel then handler_env
+      else Env.no_longer_at_toplevel handler_env
+    in
     let handler, delayed_handlers_handler = close t handler_env handler in
     let handler, delayed_handlers_handler =
-      let leaving_scope_of =
-        Name_occurrences.add_continuation_in_trap_action
-          (Name_occurrences.add_continuation
-            (Kinded_parameter.List.free_names params)
-            name)
-          name
-      in
-      drop_handlers delayed_handlers_handler ~leaving_scope_of ~around:handler
+      if still_at_toplevel then
+        drop_all_handlers delayed_handlers_handler ~around:handler,
+          Delayed_handlers.empty
+      else
+        let leaving_scope_of =
+          Name_occurrences.add_continuation_in_trap_action
+            (Name_occurrences.add_continuation
+              (Kinded_parameter.List.free_names params)
+              name)
+            name
+        in
+        drop_handlers delayed_handlers_handler ~leaving_scope_of
+          ~around:handler
     in
     let params_and_handler =
       Flambda.Continuation_params_and_handler.create params ~handler
@@ -573,17 +606,16 @@ let rec close t env (ilam : Ilambda.t) : Expr.t * _ =
         ~stub:false
         ~is_exn_handler:is_exn_handler
     in
-    let body, delayed_handlers_body = close t env body in
-    let body, delayed_handlers_body =
-      let leaving_scope_of =
-        Name_occurrences.singleton_continuation name
-      in
-      drop_handlers delayed_handlers_body ~leaving_scope_of ~around:body
-    in
     let delayed_handlers =
       Delayed_handlers.union delayed_handlers_handler delayed_handlers_body
     in
-    body, Delayed_handlers.add_handler delayed_handlers name handler
+    let delayed_handlers =
+      Delayed_handlers.add_handler delayed_handlers name handler
+    in
+    if still_at_toplevel then
+      drop_all_handlers delayed_handlers ~around:body, Delayed_handlers.empty
+    else
+      body, delayed_handlers
   | Apply { kind; func; args; continuation; exn_continuation;
       loc; should_be_tailcall = _; inlined; specialised = _; } ->
     let call_kind =
@@ -1005,6 +1037,7 @@ let ilambda_to_flambda ~backend ~module_ident ~module_block_size_in_words
       declared_symbols = [];
       shareable_constants = Static_const.Map.empty;
       code = [];
+      ilambda_exn_continuation = ilam.exn_continuation.exn_handler;
     }
   in
   let module_symbol = Backend.symbol_for_global' module_ident in

--- a/middle_end/flambda2.0/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2.0/from_lambda/closure_conversion_aux.ml
@@ -20,19 +20,22 @@ module Env = struct
   type t = {
     variables : Variable.t Ident.Map.t;
     globals : Symbol.t Numbers.Int.Map.t;
-    at_toplevel : bool;
     simples_to_substitute : Simple.t Ident.Map.t;
+    still_at_toplevel : bool;
   }
 
   let empty = {
     variables = Ident.Map.empty;
     globals = Numbers.Int.Map.empty;
-    at_toplevel = true;
     simples_to_substitute = Ident.Map.empty;
+    still_at_toplevel = true;
   }
 
   let clear_local_bindings env =
-    { empty with globals = env.globals }
+    { empty with
+      globals = env.globals;
+      still_at_toplevel = false;
+    }
 
   let add_var t id var = { t with variables = Ident.Map.add id var t.variables }
   let add_vars t ids vars = List.fold_left2 add_var t ids vars
@@ -88,10 +91,6 @@ module Env = struct
       Misc.fatal_error ("Closure_conversion.Env.find_global: global "
         ^ string_of_int pos)
 
-  let at_toplevel t = t.at_toplevel
-
-  let not_at_toplevel t = { t with at_toplevel = false; }
-
   let add_simple_to_substitute t id simple =
     if Ident.Map.mem id t.simples_to_substitute then begin
       Misc.fatal_errorf "Cannot redefine [Simple] associated with %a"
@@ -103,6 +102,13 @@ module Env = struct
 
   let find_simple_to_substitute_exn t id =
     Ident.Map.find id t.simples_to_substitute
+
+  let still_at_toplevel t = t.still_at_toplevel
+
+  let no_longer_at_toplevel t =
+    { t with
+      still_at_toplevel = false;
+    }
 end
 
 module Function_decls = struct

--- a/middle_end/flambda2.0/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2.0/from_lambda/closure_conversion_aux.mli
@@ -50,12 +50,12 @@ module Env : sig
   val add_global : t -> int -> Symbol.t -> t
   val find_global : t -> int -> Symbol.t
 
-  val at_toplevel : t -> bool
-  val not_at_toplevel : t -> t
-
   val add_simple_to_substitute : t -> Ident.t -> Simple.t -> t
 
   val find_simple_to_substitute_exn : t -> Ident.t -> Simple.t
+
+  val still_at_toplevel : t -> bool
+  val no_longer_at_toplevel : t -> t
 end
 
 (** Used to represent information about a set of function declarations

--- a/middle_end/flambda2.0/lifting/sort_lifted_constants.ml
+++ b/middle_end/flambda2.0/lifting/sort_lifted_constants.ml
@@ -28,75 +28,67 @@ type result = {
 }
 
 let build_dep_graph dacc lifted_constants =
-  let all_symbols_being_defined =
-    Symbol.Set.union_list
-      (List.map (fun (bound_symbols, _) ->
-          Bound_symbols.being_defined bound_symbols)
-        lifted_constants)
-  in
   List.fold_left
     (fun (dep_graph, code_id_or_symbol_to_const)
-         ((bound_symbols : Bound_symbols.t), defining_expr) ->
+         ((bound_symbols : Bound_symbols.t), defining_expr, extra_deps) ->
       (*
       Format.eprintf "Input for one set: %a =@ %a\n%!"
         Bound_symbols.print bound_symbols
         Static_const.print defining_expr;
       *)
       let bound_symbols_free_names = Bound_symbols.free_names bound_symbols in
+      let free_names =
+        (* To avoid existing sets of closures (with or without associated
+           code) being pulled apart, we add a dependency from each code ID
+           or closure symbol [being_defined] to all other code IDs and
+           symbols bound by the same binding. *)
+        match bound_symbols with
+        | Singleton _ ->
+          Static_const.free_names defining_expr
+        | Sets_of_closures _ ->
+          Name_occurrences.union bound_symbols_free_names
+            (Static_const.free_names defining_expr)
+      in
+      let free_names = Name_occurrences.union free_names extra_deps in
+      (* Beware: when coming from [Reify_continuation_params] the
+         sets of closures may have dependencies on variables that are
+         now equal to symbols in the environment.  (They haven't been
+         changed to symbols yet as the simplifier hasn't been run on
+         the definitions.)  Some of these symbols may be the ones
+         involved in the current SCC calculation.  For this latter set,
+         we must explicitly add them as dependencies. *)
+      let free_syms =
+        Name_occurrences.fold_names free_names
+          ~init:Symbol.Set.empty
+          ~f:(fun free_syms name ->
+            Name.pattern_match name
+              ~var:(fun var ->
+                let typing_env = DA.typing_env dacc in
+                match
+                  TE.get_canonical_simple_exn typing_env
+                    ~min_name_mode:NM.normal
+                    (Simple.var var)
+                with
+                | exception Not_found -> free_syms
+                | canonical ->
+                  Simple.pattern_match canonical
+                    ~const:(fun _ -> free_syms)
+                    ~name:(fun name ->
+                      Name.pattern_match name
+                        ~var:(fun _var -> free_syms)
+                        ~symbol:(fun sym -> Symbol.Set.add sym free_syms)))
+              ~symbol:(fun sym -> Symbol.Set.add sym free_syms))
+      in
+      let free_code_ids =
+        Name_occurrences.code_ids_and_newer_version_of_code_ids free_names
+      in
+      let deps =
+        CIS.Set.union (CIS.set_of_symbol_set free_syms)
+          (CIS.set_of_code_id_set free_code_ids)
+      in
       CIS.Set.fold
         (fun (being_defined : CIS.t)
              (dep_graph, code_id_or_symbol_to_const) ->
-          let free_names =
-            (* To avoid existing sets of closures (with or without associated
-               code) being pulled apart, we add a dependency from each code ID
-               or closure symbol [being_defined] to all other code IDs and
-               symbols bound by the same binding. *)
-            match bound_symbols with
-            | Singleton _ ->
-              Static_const.free_names defining_expr
-            | Sets_of_closures _ ->
-              Name_occurrences.union bound_symbols_free_names
-                (Static_const.free_names defining_expr)
-          in
-          (* Beware: when coming from [Reify_continuation_params] the
-             sets of closures may have dependencies on variables that are
-             now equal to symbols in the environment.  (They haven't been
-             changed to symbols yet as the simplifier hasn't been run on
-             the definitions.)  Some of these symbols may be the ones
-             involved in the current SCC calculation.  For this latter set,
-             we must explicitly add them as dependencies. *)
-          let free_syms =
-            Name_occurrences.fold_names free_names
-              ~init:Symbol.Set.empty
-              ~f:(fun free_syms name ->
-                Name.pattern_match name
-                  ~var:(fun var ->
-                    let typing_env = DA.typing_env dacc in
-                    match
-                      TE.get_canonical_simple_exn typing_env
-                        ~min_name_mode:NM.normal
-                        (Simple.var var)
-                    with
-                    | exception Not_found -> free_syms
-                    | canonical ->
-                      Simple.pattern_match canonical
-                        ~const:(fun _ -> free_syms)
-                        ~name:(fun name ->
-                          Name.pattern_match name
-                            ~var:(fun _var -> free_syms)
-                            ~symbol:(fun sym ->
-                              if Symbol.Set.mem sym all_symbols_being_defined
-                              then Symbol.Set.add sym free_syms
-                              else free_syms)))
-                  ~symbol:(fun sym -> Symbol.Set.add sym free_syms))
-          in
-          let free_code_ids =
-            Name_occurrences.code_ids_and_newer_version_of_code_ids free_names
-          in
-          let deps =
-            CIS.Set.union (CIS.set_of_symbol_set free_syms)
-              (CIS.set_of_code_id_set free_code_ids)
-          in
           let dep_graph = CIS.Map.add being_defined deps dep_graph in
           let code_id_or_symbol_to_const =
             CIS.Map.add being_defined
@@ -110,6 +102,9 @@ let build_dep_graph dacc lifted_constants =
     lifted_constants
 
 let sort dacc lifted_constants =
+  (*
+  Format.eprintf "SORT LIFTED CONSTANTS\n%!";
+  *)
   (* The various lifted constants may exhibit recursion between themselves
      (specifically between closures and/or code).  We use SCC to obtain a
      topological sort of groups that must be coalesced into single

--- a/middle_end/flambda2.0/lifting/sort_lifted_constants.mli
+++ b/middle_end/flambda2.0/lifting/sort_lifted_constants.mli
@@ -27,4 +27,9 @@ type result = private {
   bindings_outermost_last : (Bound_symbols.t * Static_const.t) list;
 }
 
-val sort : DA.t -> (Bound_symbols.t * Static_const.t) list -> result
+(** The [Name_occurrences.t] values specify extra "hidden" dependencies of the
+    associated constant that must be taken into account. *)
+val sort
+   : DA.t
+  -> (Bound_symbols.t * Static_const.t * Name_occurrences.t) list
+  -> result

--- a/middle_end/flambda2.0/simplify/env/continuation_uses_env.ml
+++ b/middle_end/flambda2.0/simplify/env/continuation_uses_env.ml
@@ -53,13 +53,14 @@ let record_continuation_use t cont kind ~typing_env_at_use ~arg_types =
   in
   t, id
 
-let compute_handler_env t ~env_at_fork_plus_params_and_consts cont
+let compute_handler_env t ~env_at_fork_plus_params_and_consts
+      ~consts_lifted_during_body cont
       ~params : Continuation_env_and_param_types.t =
   match Continuation.Map.find cont t.continuation_uses with
   | exception Not_found -> No_uses
   | uses ->
     Continuation_uses.compute_handler_env uses ~params
-      ~env_at_fork_plus_params_and_consts
+      ~env_at_fork_plus_params_and_consts ~consts_lifted_during_body
 
 let num_continuation_uses t cont =
   match Continuation.Map.find cont t.continuation_uses with

--- a/middle_end/flambda2.0/simplify/env/continuation_uses_env_intf.ml
+++ b/middle_end/flambda2.0/simplify/env/continuation_uses_env_intf.ml
@@ -37,6 +37,7 @@ module type S = sig
   val compute_handler_env
      : t
     -> env_at_fork_plus_params_and_consts:Flambda_type.Typing_env.t
+    -> consts_lifted_during_body:Simplify_env_and_result.Lifted_constant.t list
     -> Continuation.t
     -> params:Kinded_parameter.t list
     -> Continuation_env_and_param_types.t

--- a/middle_end/flambda2.0/simplify/env/downwards_acc.ml
+++ b/middle_end/flambda2.0/simplify/env/downwards_acc.ml
@@ -88,10 +88,11 @@ let record_continuation_use t cont use_kind ~typing_env_at_use ~arg_types =
   in
   with_continuation_uses_env t cont_uses_env, id
 
-let compute_handler_env t ~env_at_fork_plus_params_and_consts cont
-      ~params =
+let compute_handler_env t ~env_at_fork_plus_params_and_consts
+      ~consts_lifted_during_body cont ~params =
   CUE.compute_handler_env t.continuation_uses_env
-    ~env_at_fork_plus_params_and_consts cont ~params
+    ~env_at_fork_plus_params_and_consts ~consts_lifted_during_body
+    cont ~params
 
 let num_continuation_uses t cont =
   CUE.num_continuation_uses t.continuation_uses_env cont

--- a/middle_end/flambda2.0/simplify/simplify_common.ml
+++ b/middle_end/flambda2.0/simplify/simplify_common.ml
@@ -199,6 +199,9 @@ let bind_let_bound ~bindings ~body =
 
 let create_let_symbol code_age_relation (bound_symbols : Bound_symbols.t)
       (static_const : Static_const.t) body =
+(*
+  Format.eprintf "create_let_symbol %a\n%!" Bound_symbols.print bound_symbols;
+*)
   let free_names_after = Expr.free_names body in
   match bound_symbols with
   | Singleton sym ->

--- a/middle_end/flambda2.0/simplify/simplify_set_of_closures.rec.ml
+++ b/middle_end/flambda2.0/simplify/simplify_set_of_closures.rec.ml
@@ -792,12 +792,6 @@ let simplify_lifted_set_of_closures0 context ~closure_symbols
       ~closure_bound_names_inside ~closure_elements ~closure_element_types
   in
   let dacc =
-    DA.map_r dacc ~f:(fun r ->
-      R.new_lifted_constant r
-        (Lifted_constant.create_pieces_of_code (DA.denv dacc)
-          code ~newer_versions_of:(C.new_to_old_code_ids_all_sets context)))
-  in
-  let dacc =
     DA.map_denv dacc ~f:(fun denv ->
       (* CR mshinwell: factor out *)
       Code_id.Map.fold (fun code_id params_and_body denv ->

--- a/middle_end/flambda2.0/simplify/typing_helpers/continuation_uses.mli
+++ b/middle_end/flambda2.0/simplify/typing_helpers/continuation_uses.mli
@@ -41,6 +41,7 @@ val add_use
 val compute_handler_env
    : t
   -> env_at_fork_plus_params_and_consts:Flambda_type.Typing_env.t
+  -> consts_lifted_during_body:Simplify_env_and_result.Lifted_constant.t list
   -> params:Kinded_parameter.t list
   -> Continuation_env_and_param_types.t
 

--- a/middle_end/flambda2.0/to_cmm/un_cps_closure.mli
+++ b/middle_end/flambda2.0/to_cmm/un_cps_closure.mli
@@ -27,16 +27,20 @@ val empty_env : env
 val compute_offsets : Flambda_unit.t -> env
 (** Compute offsets for a whole compilation unit. *)
 
-val env_var_offset : env -> Var_within_closure.t -> int
+val env_var_offset : env -> Var_within_closure.t -> int option
 (** Returns the offset computed for an environment variable, in
-    terms of target architecture words. *)
+    terms of target architecture words.
+    If [None] is returned, there is no closure in the program containing the
+    given closure variable. *)
 
-val closure_offset : env -> Closure_id.t -> int
+val closure_offset : env -> Closure_id.t -> int option
 (** Returns the offset computed for a closure id, in terms of
     target architecture words.
     This points to the first field of the closure representation
     within the sets of closures block. Notably, if the offset is not 0,
-    an infix header should be placed just before the returned offset. *)
+    an infix header should be placed just before the returned offset.
+    If [None] is returned, there is no closure in the program containing the
+    given closure ID. *)
 
 val closure_name : Closure_id.t -> string
 (** Returns a cmm name for a closure id. *)

--- a/middle_end/flambda2.0/to_cmm/un_cps_env.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps_env.ml
@@ -456,8 +456,7 @@ let check_scope ~allow_deleted env code_id_or_symbol =
     | Symbol _ -> env
   in
   if in_scope || in_another_unit then updated_env
-  else updated_env
-  (* CR mshinwell: FIXME
+  else
     Misc.fatal_errorf "Use out of scope of %a@.Known names:@.%a@."
       Code_id_or_symbol.print code_id_or_symbol
-      Code_id_or_symbol.Set.print env.names_in_scope *)
+      Code_id_or_symbol.Set.print env.names_in_scope

--- a/middle_end/flambda2.0/to_cmm/un_cps_env.mli
+++ b/middle_end/flambda2.0/to_cmm/un_cps_env.mli
@@ -126,10 +126,10 @@ val get_jump_id : t -> Continuation.t -> int
 
 (** {2 Sets of closures and offsets} *)
 
-val closure_offset : t -> Closure_id.t -> int
+val closure_offset : t -> Closure_id.t -> int option
 (** Wrapper around {!Un_cps_closure.closure_offset}. *)
 
-val env_var_offset : t -> Var_within_closure.t -> int
+val env_var_offset : t -> Var_within_closure.t -> int option
 (** Wrapper around {!Un_cps_closure.env_var_offset}. *)
 
 val layout :

--- a/middle_end/flambda2.0/types/env/typing_env.rec.mli
+++ b/middle_end/flambda2.0/types/env/typing_env.rec.mli
@@ -40,6 +40,8 @@ val add_equation : t -> Name.t -> Type_grammar.t -> t
 
 val add_definitions_of_params : t -> params:Kinded_parameter.t list -> t
 
+val add_symbol_definition : t -> Symbol.t -> t
+
 val add_symbol_definitions : t -> Symbol.Set.t -> t
 
 val add_equations_on_params

--- a/middle_end/flambda2.0/types/flambda_type.mli
+++ b/middle_end/flambda2.0/types/flambda_type.mli
@@ -81,6 +81,8 @@ module Typing_env : sig
 
   val add_definitions_of_params : t -> params:Kinded_parameter.t list -> t
 
+  val add_symbol_definition : t -> Symbol.t -> t
+
   val add_equation : t -> Name.t -> flambda_type -> t
 
   val add_equations_on_params
@@ -131,6 +133,11 @@ module Typing_env : sig
     -> params:Kinded_parameter.t list
     -> unknown_if_defined_at_or_later_than:Scope.t
     -> Typing_env_extension.t * Continuation_extra_params_and_args.t
+
+  val free_names_transitive
+     : t
+    -> flambda_type
+    -> Name_occurrences.t
 end
 
 val meet : Typing_env.t -> t -> t -> (t * Typing_env_extension.t) Or_bottom.t

--- a/testsuite/tests/misc/ephetest2.ml
+++ b/testsuite/tests/misc/ephetest2.ml
@@ -149,5 +149,5 @@ let run test init =
 
 let () =
   for i = 0 to nb_test do
-    ignore (run ("test"^(Int.to_string i)) i);
+    ignore ((Sys.opaque_identity run) ("test"^(Int.to_string i)) i);
   done


### PR DESCRIPTION
1. Don't de-nest continuations at toplevel during closure conversion, with a view to ensuring that dominator scope always coincides with syntactic scope for Let_symbol bindings.

2. For trivial (one use) inlinable joins, take the use environment directly, rather than the result of `join`.  This is both quicker and ensures variables aren't unnecessarily turned into `In_types` variables, which renders them useless for reification.