### PR TITLE
Fix invariant check in Simplify_set_of_closures

### DIFF
--- a/middle_end/flambda2.0/simplify/env/simplify_env_and_result.ml
+++ b/middle_end/flambda2.0/simplify/env/simplify_env_and_result.ml
@@ -725,7 +725,7 @@ end = struct
 
   let create denv bound_symbols defining_expr ~types_of_symbols =
     let being_defined = Let_symbol.Bound_symbols.being_defined bound_symbols in
-    if not (Symbol.Set.subset (Symbol.Map.keys types_of_symbols) being_defined)
+    if not (Symbol.Set.equal (Symbol.Map.keys types_of_symbols) being_defined)
     then begin
       Misc.fatal_errorf "[types_of_symbols]:@ %a@ does not cover all symbols \
           in the definition:@ %a"

--- a/middle_end/flambda2.0/simplify/simplify_set_of_closures.rec.ml
+++ b/middle_end/flambda2.0/simplify/simplify_set_of_closures.rec.ml
@@ -489,10 +489,10 @@ let simplify_set_of_closures0 dacc context set_of_closures
       denv
       |> DE.map_typing_env ~f:(fun typing_env ->
         TE.with_code_age_relation typing_env code_age_relation)
-      |> DE.add_lifted_constants ~lifted:(R.get_lifted_constants r)
       |> Closure_id.Map.fold (fun _closure_id bound_name denv ->
              DE.define_name_if_undefined denv bound_name K.value)
            closure_bound_names
+      |> DE.add_lifted_constants ~lifted:(R.get_lifted_constants r)
       |> Name_in_binding_pos.Map.fold (fun bound_name closure_type denv ->
              let bound_name = Name_in_binding_pos.to_name bound_name in
              DE.add_equation_on_name denv bound_name closure_type)


### PR DESCRIPTION
Summary: `add_lifted_constants` adds constants that may refer to the currently defined symbols in their types, so these symbol definitions must be added first to the environment.

Also, I think the sanity check on `Lifted_constant.create` was calling `subset` in the wrong order, so I switched it to `equal` to be sure (maybe I should have updated the error message, too)