### PR TITLE
Another liveness hack

### DIFF
--- a/asmcomp/liveness.ml
+++ b/asmcomp/liveness.ml
@@ -30,6 +30,44 @@ let initial_env =
     last_regular_trywith_handler = Reg.Set.empty;
   }
 
+let same_env env1 env2 =
+  List.for_all2 (fun (nfail1, live_regs1) (nfail2, live_regs2) ->
+      nfail1 = nfail2 && Reg.Set.equal live_regs1 live_regs2)
+    env1.at_exit
+    env2.at_exit
+  && Reg.Set.equal env1.at_raise env2.at_raise
+  && Reg.Set.equal env1.last_regular_trywith_handler
+       env2.last_regular_trywith_handler
+
+type cache_entry =
+  { free_conts : Numbers.Int.Set.t; (* free continuation of the handler,
+                                       including delayed exception handlers *)
+    restricted_env : liveness_env;  (* last used environment,
+                                       restricted to the live conts *)
+    at_join : Reg.Set.t;            (* last used set at join *)
+    before_handler : Reg.Set.t;    (* last computed result *)
+}
+
+let fixpoint_cache : cache_entry Numbers.Int.Map.t ref =
+ ref Numbers.Int.Map.empty
+
+let reset_cache () = fixpoint_cache := Numbers.Int.Map.empty
+
+let free_conts_of_handler (_nfail, ts, instr) =
+  let module S = Numbers.Int.Set in
+  let rec add_exn_conts conts = function
+    | Uncaught -> conts
+    | Generic_trap ts -> add_exn_conts conts ts
+    | Specific_trap (nfail, ts) -> add_exn_conts (S.add nfail conts) ts
+  in
+  add_exn_conts (free_conts instr) ts
+
+let restrict_env env conts =
+  { env with at_exit =
+               List.filter (fun (n, _) -> Numbers.Int.Set.mem n conts)
+                 env.at_exit;
+  }
+
 let find_live_at_exit env k =
   try
     List.assoc k env.at_exit
@@ -113,7 +151,29 @@ let rec live env i finally =
       let aux env (nfail, ts, handler) (nfail', before_handler) =
         assert(nfail = nfail');
         let env = env_from_trap_stack env ts in
-        let before_handler' = live env handler at_join in
+        let before_handler', free_conts, restricted_env, do_update =
+          match Numbers.Int.Map.find nfail !fixpoint_cache with
+          | exception Not_found ->
+            let free_conts = free_conts_of_handler (nfail, ts, handler) in
+            let restricted_env = restrict_env env free_conts in
+            live env handler at_join, free_conts, restricted_env, true
+          | cache ->
+            let restricted_env = restrict_env env cache.free_conts in
+            if same_env restricted_env cache.restricted_env
+            && Reg.Set.equal at_join cache.at_join
+            then cache.before_handler, cache.free_conts, cache.restricted_env, false
+            else live env handler at_join, cache.free_conts, restricted_env, true
+        in
+        if do_update then begin
+          let cache_entry =
+            { free_conts;
+              restricted_env;
+              at_join;
+              before_handler = before_handler';
+            }
+          in
+          fixpoint_cache := Numbers.Int.Map.add nfail cache_entry !fixpoint_cache
+        end;
         nfail, Reg.Set.union before_handler before_handler'
       in
       let aux_equal (nfail, before_handler) (nfail', before_handler') =
@@ -168,6 +228,7 @@ let rec live env i finally =
       Reg.add_set_array env.at_raise arg
 
 let fundecl f =
+  reset_cache ();
   let initially_live = live initial_env f.fun_body Reg.Set.empty in
   (* Sanity check: only function parameters (and the Spacetime node hole
      register, if profiling) can be live at entrypoint *)

--- a/asmcomp/liveness.ml
+++ b/asmcomp/liveness.ml
@@ -22,12 +22,14 @@ type liveness_env =
   { at_exit : (int * Reg.Set.t) list;
     at_raise : Reg.Set.t;
     last_regular_trywith_handler : Reg.Set.t;
+    free_conts_for_handlers : Numbers.Int.Set.t Numbers.Int.Map.t;
   }
 
-let initial_env =
+let initial_env fundecl =
   { at_exit = [];
     at_raise = Reg.Set.empty;
     last_regular_trywith_handler = Reg.Set.empty;
+    free_conts_for_handlers = Mach.free_conts_for_handlers fundecl;
   }
 
 let same_env env1 env2 =
@@ -40,9 +42,7 @@ let same_env env1 env2 =
        env2.last_regular_trywith_handler
 
 type cache_entry =
-  { free_conts : Numbers.Int.Set.t; (* free continuation of the handler,
-                                       including delayed exception handlers *)
-    restricted_env : liveness_env;  (* last used environment,
+  { restricted_env : liveness_env;  (* last used environment,
                                        restricted to the live conts *)
     at_join : Reg.Set.t;            (* last used set at join *)
     before_handler : Reg.Set.t;    (* last computed result *)
@@ -52,15 +52,6 @@ let fixpoint_cache : cache_entry Numbers.Int.Map.t ref =
  ref Numbers.Int.Map.empty
 
 let reset_cache () = fixpoint_cache := Numbers.Int.Map.empty
-
-let free_conts_of_handler (_nfail, ts, instr) =
-  let module S = Numbers.Int.Set in
-  let rec add_exn_conts conts = function
-    | Uncaught -> conts
-    | Generic_trap ts -> add_exn_conts conts ts
-    | Specific_trap (nfail, ts) -> add_exn_conts (S.add nfail conts) ts
-  in
-  add_exn_conts (free_conts instr) ts
 
 let restrict_env env conts =
   { env with at_exit =
@@ -151,23 +142,22 @@ let rec live env i finally =
       let aux env (nfail, ts, handler) (nfail', before_handler) =
         assert(nfail = nfail');
         let env = env_from_trap_stack env ts in
-        let before_handler', free_conts, restricted_env, do_update =
+        let free_conts = Numbers.Int.Map.find nfail env.free_conts_for_handlers in
+        let before_handler', restricted_env, do_update =
           match Numbers.Int.Map.find nfail !fixpoint_cache with
           | exception Not_found ->
-            let free_conts = free_conts_of_handler (nfail, ts, handler) in
             let restricted_env = restrict_env env free_conts in
-            live env handler at_join, free_conts, restricted_env, true
+            live env handler at_join, restricted_env, true
           | cache ->
-            let restricted_env = restrict_env env cache.free_conts in
+            let restricted_env = restrict_env env free_conts in
             if same_env restricted_env cache.restricted_env
             && Reg.Set.equal at_join cache.at_join
-            then cache.before_handler, cache.free_conts, cache.restricted_env, false
-            else live env handler at_join, cache.free_conts, restricted_env, true
+            then cache.before_handler, cache.restricted_env, false
+            else live env handler at_join, restricted_env, true
         in
         if do_update then begin
           let cache_entry =
-            { free_conts;
-              restricted_env;
+            { restricted_env;
               at_join;
               before_handler = before_handler';
             }
@@ -229,7 +219,7 @@ let rec live env i finally =
 
 let fundecl f =
   reset_cache ();
-  let initially_live = live initial_env f.fun_body Reg.Set.empty in
+  let initially_live = live (initial_env f) f.fun_body Reg.Set.empty in
   (* Sanity check: only function parameters (and the Spacetime node hole
      register, if profiling) can be live at entrypoint *)
   let wrong_live = Reg.Set.diff initially_live (Reg.set_of_array f.fun_args) in

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -211,38 +211,52 @@ let operation_can_raise op =
   | Ialloc _ -> true
   | _ -> false
 
-let rec free_conts i =
+let free_conts_for_handlers fundecl =
   let module S = Numbers.Int.Set in
-  match i.desc with
-  | Iend -> S.empty
-  | desc ->
-    let next_conts = free_conts i.next in
-    match desc with
-    | Iend -> assert false
-    | Iop _ -> next_conts
-    | Ireturn _ -> next_conts
-    | Iifthenelse (_, then_, else_) ->
-      S.union next_conts (S.union (free_conts then_) (free_conts else_))
-    | Iswitch (_, cases) ->
-      Array.fold_left (fun conts instr -> S.union conts (free_conts instr))
-        next_conts cases
-    | Icatch (_rec_flag, handlers, body) ->
-      let conts = S.union next_conts (free_conts body) in
-      let conts =
-        List.fold_left (fun conts (_nfail, _ts, i) ->
-            S.union conts (free_conts i))
-          conts handlers
-      in
-      List.fold_left (fun conts (nfail, _ts, _i) ->
+  let module M = Numbers.Int.Map in
+  let acc = ref M.empty in
+  let rec free_conts i =
+    match i.desc with
+    | Iend -> S.empty
+    | desc ->
+      let next_conts = free_conts i.next in
+      match desc with
+      | Iend -> assert false
+      | Iop _ -> next_conts
+      | Ireturn _ -> next_conts
+      | Iifthenelse (_, then_, else_) ->
+        S.union next_conts (S.union (free_conts then_) (free_conts else_))
+      | Iswitch (_, cases) ->
+        Array.fold_left (fun conts instr -> S.union conts (free_conts instr))
+          next_conts cases
+      | Icatch (_rec_flag, handlers, body) ->
+        let conts = S.union next_conts (free_conts body) in
+        let conts =
+          List.fold_left (fun conts (nfail, ts, i) ->
+            let rec add_exn_conts conts = function
+              | Uncaught -> conts
+              | Generic_trap ts -> add_exn_conts conts ts
+              | Specific_trap (nfail, ts) -> add_exn_conts (S.add nfail conts) ts
+            in
+            let free = add_exn_conts (free_conts i) ts in
+            acc := M.add nfail free !acc;
+            S.union conts free)
+            conts handlers
+        in
+        List.fold_left (fun conts (nfail, _ts, _i) ->
           S.remove nfail conts)
-        conts handlers
-    | Iexit (nfail, _) -> S.add nfail next_conts
-    | Itrywith (body, kind, (_ts, handler)) ->
-      let conts =
-        S.union next_conts (S.union (free_conts body) (free_conts handler))
-      in
-      begin match kind with
-      | Regular -> conts
-      | Delayed nfail -> S.remove nfail conts
-      end
-    | Iraise _ -> next_conts
+          conts handlers
+      | Iexit (nfail, _) -> S.add nfail next_conts
+      | Itrywith (body, kind, (_ts, handler)) ->
+        let conts =
+          S.union next_conts (S.union (free_conts body) (free_conts handler))
+        in
+        begin match kind with
+        | Regular -> conts
+        | Delayed nfail -> S.remove nfail conts
+        end
+      | Iraise _ -> next_conts
+  in
+  let free = free_conts fundecl.fun_body in
+  assert(S.is_empty free);
+  !acc

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -210,3 +210,39 @@ let operation_can_raise op =
   | Iintop (Icheckbound _) | Iintop_imm (Icheckbound _, _)
   | Ialloc _ -> true
   | _ -> false
+
+let rec free_conts i =
+  let module S = Numbers.Int.Set in
+  match i.desc with
+  | Iend -> S.empty
+  | desc ->
+    let next_conts = free_conts i.next in
+    match desc with
+    | Iend -> assert false
+    | Iop _ -> next_conts
+    | Ireturn _ -> next_conts
+    | Iifthenelse (_, then_, else_) ->
+      S.union next_conts (S.union (free_conts then_) (free_conts else_))
+    | Iswitch (_, cases) ->
+      Array.fold_left (fun conts instr -> S.union conts (free_conts instr))
+        next_conts cases
+    | Icatch (_rec_flag, handlers, body) ->
+      let conts = S.union next_conts (free_conts body) in
+      let conts =
+        List.fold_left (fun conts (_nfail, _ts, i) ->
+            S.union conts (free_conts i))
+          conts handlers
+      in
+      List.fold_left (fun conts (nfail, _ts, _i) ->
+          S.remove nfail conts)
+        conts handlers
+    | Iexit (nfail, _) -> S.add nfail next_conts
+    | Itrywith (body, kind, (_ts, handler)) ->
+      let conts =
+        S.union next_conts (S.union (free_conts body) (free_conts handler))
+      in
+      begin match kind with
+      | Regular -> conts
+      | Delayed nfail -> S.remove nfail conts
+      end
+    | Iraise _ -> next_conts

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -147,3 +147,5 @@ val instr_iter: (instruction -> unit) -> instruction -> unit
 val spacetime_node_hole_pointer_is_live_before : instruction -> bool
 
 val operation_can_raise : operation -> bool
+
+val free_conts : instruction -> Numbers.Int.Set.t

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -148,4 +148,4 @@ val spacetime_node_hole_pointer_is_live_before : instruction -> bool
 
 val operation_can_raise : operation -> bool
 
-val free_conts : instruction -> Numbers.Int.Set.t
+val free_conts_for_handlers : fundecl -> Numbers.Int.Set.t Numbers.Int.Map.t

--- a/asmcomp/spill.ml
+++ b/asmcomp/spill.ml
@@ -439,10 +439,6 @@ let rec spill env i finally =
           Reg.Set.diff (Reg.Set.diff before_ifso before_ifnot) destroyed
         and spill_ifnot_branch =
           Reg.Set.diff (Reg.Set.diff before_ifnot before_ifso) destroyed in
-        Format.eprintf "Destroyed_at_fork: %a@.before_ifso: %a@. before_ifnot: %a@.@."
-          Printmach.regset destroyed
-          Printmach.regset before_ifso
-          Printmach.regset before_ifnot;
         (instr_cons
             (Iifthenelse(test, add_spills env spill_ifso_branch new_ifso,
                                add_spills env spill_ifnot_branch new_ifnot))

--- a/asmcomp/spill.mli
+++ b/asmcomp/spill.mli
@@ -17,4 +17,3 @@
    before register allocation. *)
 
 val fundecl: Mach.fundecl -> Mach.fundecl
-val reset : unit -> unit


### PR DESCRIPTION
This tries to avoid exponential blow-up in liveness.
The initial idea from @chambart was to notice if we're recomputing the live set of an expression with the same arguments, in which case we can reuse the previous result.
However, there was a bug because the previous result was read from the `live` field of the next instruction, which can contain an initial empty set or the result of a previous run, but doesn't mean it is actually the result of the analysis.
In addition, the `env` parameter needs to be compared too, and it is not stored anywhere.
So I introduced a cache that remembers, for each handler, the last arguments (`env` and `at_join`) and result (`before_handler`) of the last time we went through it.
Of course, this doesn't help much, because the environment will likely be different each time (otherwise we wouldn't get called again), so I cached the restriction of the environment to the free continuations of the handler, which should be safe and still avoid the exponential blow-up.

I haven't run the libbigarray test yet, but will try it and report if it compiles in a reasonable amount of time.