### PR TITLE
Command-line flags to control various computations

### DIFF
--- a/.depend
+++ b/.depend
@@ -5196,6 +5196,13 @@ middle_end/flambda2.0/compilenv_deps/flambda_colours.cmx : \
     utils/misc.cmx \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmi
 middle_end/flambda2.0/compilenv_deps/flambda_colours.cmi :
+middle_end/flambda2.0/compilenv_deps/flambda_features.cmo : \
+    utils/clflags.cmi \
+    middle_end/flambda2.0/compilenv_deps/flambda_features.cmi
+middle_end/flambda2.0/compilenv_deps/flambda_features.cmx : \
+    utils/clflags.cmx \
+    middle_end/flambda2.0/compilenv_deps/flambda_features.cmi
+middle_end/flambda2.0/compilenv_deps/flambda_features.cmi :
 middle_end/flambda2.0/compilenv_deps/immediate.cmo : \
     utils/targetint.cmi \
     lambda/tag.cmi \
@@ -6328,6 +6335,7 @@ middle_end/flambda2.0/lifting/reify_continuation_param_types.cmo : \
     middle_end/flambda2.0/compilenv_deps/linkage_name.cmi \
     middle_end/flambda2.0/terms/function_declarations.cmi \
     middle_end/flambda2.0/terms/function_declaration.cmi \
+    middle_end/flambda2.0/compilenv_deps/flambda_features.cmi \
     middle_end/flambda2.0/basic/continuation_extra_params_and_args.cmi \
     middle_end/flambda2.0/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda2.0/basic/code_id.cmi \
@@ -6348,6 +6356,7 @@ middle_end/flambda2.0/lifting/reify_continuation_param_types.cmx : \
     middle_end/flambda2.0/compilenv_deps/linkage_name.cmx \
     middle_end/flambda2.0/terms/function_declarations.cmx \
     middle_end/flambda2.0/terms/function_declaration.cmx \
+    middle_end/flambda2.0/compilenv_deps/flambda_features.cmx \
     middle_end/flambda2.0/basic/continuation_extra_params_and_args.cmx \
     middle_end/flambda2.0/compilenv_deps/compilation_unit.cmx \
     middle_end/flambda2.0/basic/code_id.cmx \
@@ -7269,16 +7278,12 @@ middle_end/flambda2.0/simplify/simplify_toplevel.rec.cmo : \
     middle_end/flambda2.0/simplify/simplify_import.cmi \
     utils/misc.cmi \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmi \
-    middle_end/flambda2.0/simplify/env/continuation_uses_env.cmi \
-    middle_end/flambda2.0/basic/continuation.cmi \
     utils/clflags.cmi \
     middle_end/flambda2.0/simplify/simplify_toplevel.rec.cmi
 middle_end/flambda2.0/simplify/simplify_toplevel.rec.cmx : \
     middle_end/flambda2.0/simplify/simplify_import.cmx \
     utils/misc.cmx \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmx \
-    middle_end/flambda2.0/simplify/env/continuation_uses_env.cmx \
-    middle_end/flambda2.0/basic/continuation.cmx \
     utils/clflags.cmx \
     middle_end/flambda2.0/simplify/simplify_toplevel.rec.cmi
 middle_end/flambda2.0/simplify/simplify_toplevel.rec.cmi : \
@@ -7619,6 +7624,7 @@ middle_end/flambda2.0/simplify/typing_helpers/continuation_uses.cmo : \
     middle_end/flambda2.0/basic/name.cmi \
     utils/misc.cmi \
     middle_end/flambda2.0/types/flambda_type.cmi \
+    middle_end/flambda2.0/compilenv_deps/flambda_features.cmi \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda2.0/types/kinds/flambda_arity.cmi \
     middle_end/flambda2.0/basic/continuation_extra_params_and_args.cmi \
@@ -7635,6 +7641,7 @@ middle_end/flambda2.0/simplify/typing_helpers/continuation_uses.cmx : \
     middle_end/flambda2.0/basic/name.cmx \
     utils/misc.cmx \
     middle_end/flambda2.0/types/flambda_type.cmx \
+    middle_end/flambda2.0/compilenv_deps/flambda_features.cmx \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda2.0/types/kinds/flambda_arity.cmx \
     middle_end/flambda2.0/basic/continuation_extra_params_and_args.cmx \
@@ -9885,6 +9892,7 @@ middle_end/flambda2.0/unboxing/unbox_continuation_params.cmo : \
     utils/misc.cmi \
     middle_end/flambda2.0/compilenv_deps/immediate.cmi \
     utils/identifiable.cmi \
+    middle_end/flambda2.0/compilenv_deps/flambda_features.cmi \
     middle_end/flambda2.0/basic/closure_id.cmi \
     middle_end/flambda2.0/basic/apply_cont_rewrite_id.cmi \
     middle_end/flambda2.0/unboxing/unbox_continuation_params.cmi
@@ -9902,6 +9910,7 @@ middle_end/flambda2.0/unboxing/unbox_continuation_params.cmx : \
     utils/misc.cmx \
     middle_end/flambda2.0/compilenv_deps/immediate.cmx \
     utils/identifiable.cmx \
+    middle_end/flambda2.0/compilenv_deps/flambda_features.cmx \
     middle_end/flambda2.0/basic/closure_id.cmx \
     middle_end/flambda2.0/basic/apply_cont_rewrite_id.cmx \
     middle_end/flambda2.0/unboxing/unbox_continuation_params.cmi

--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,8 @@ MIDDLE_END_FLAMBDA2_COMPILENV_DEPS=\
   middle_end/flambda2.0/compilenv_deps/rec_info.cmo \
   middle_end/flambda2.0/compilenv_deps/reg_width_things.cmo \
   middle_end/flambda2.0/compilenv_deps/symbol.cmo \
-  middle_end/flambda2.0/compilenv_deps/variable.cmo
+  middle_end/flambda2.0/compilenv_deps/variable.cmo \
+  middle_end/flambda2.0/compilenv_deps/flambda_flags.cmo
 
 MIDDLE_END_FLAMBDA2_BASIC=\
   middle_end/flambda2.0/types/kinds/flambda_kind.cmo \

--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ MIDDLE_END_FLAMBDA2_COMPILENV_DEPS=\
   middle_end/flambda2.0/compilenv_deps/reg_width_things.cmo \
   middle_end/flambda2.0/compilenv_deps/symbol.cmo \
   middle_end/flambda2.0/compilenv_deps/variable.cmo \
-  middle_end/flambda2.0/compilenv_deps/flambda_flags.cmo
+  middle_end/flambda2.0/compilenv_deps/flambda_features.cmo
 
 MIDDLE_END_FLAMBDA2_BASIC=\
   middle_end/flambda2.0/types/kinds/flambda_kind.cmo \

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -890,6 +890,38 @@ let mk__ f =
   "<file>  Treat <file> as a file name (even if it starts with `-')"
 ;;
 
+let mk_flambda2_join_points f =
+  "-flambda2-join-points", Arg.Unit f, "Propagate information from incoming \
+    edges at a join point"
+;;
+
+let mk_no_flambda2_join_points f =
+  "-no-flambda2-join-points", Arg.Unit f, "Propagate information only from the \
+    fork point to a join point"
+;;
+
+let mk_flambda2_unbox_along_intra_function_control_flow f =
+  "-flambda2-unbox-along-intra-function-control-flow", Arg.Unit f,
+    "Pass values within a function as unboxed where possible"
+;;
+
+let mk_no_flambda2_unbox_along_intra_function_control_flow f =
+  "-no-flambda2-unbox-along-intra-function-control-flow", Arg.Unit f,
+    "Pass values within a function in their normal representation"
+;;
+
+let mk_flambda2_lift_inconstants f =
+  "-flambda2-lift-inconstants", Arg.Unit f,
+    "Attempt to statically-allocate values that require computations to \
+      initialize"
+;;
+
+let mk_no_flambda2_lift_inconstants f =
+  "-no-flambda2-lift-inconstants", Arg.Unit f,
+    "Attempt to statically-allocate values that require computations to \
+      initialize"
+;;
+
 module type Common_options = sig
   val _absname : unit -> unit
   val _alert : string -> unit
@@ -1067,11 +1099,8 @@ module type Optcommon_options = sig
   val _no_float_const_prop : unit -> unit
 
   val _clambda_checks : unit -> unit
-  val _dprepared_lambda : unit -> unit
-  val _dilambda : unit -> unit
   val _dflambda : unit -> unit
   val _drawflambda : unit -> unit
-  val _drawflambda2 : unit -> unit
   val _dflambda_invariants : unit -> unit
   val _dflambda_no_invariants : unit -> unit
   val _dflambda_let : int -> unit
@@ -1095,6 +1124,17 @@ module type Optcommon_options = sig
   val _dlinear :  unit -> unit
   val _dinterval : unit -> unit
   val _dstartup :  unit -> unit
+
+  val _flambda2_join_points : unit -> unit
+  val _no_flambda2_join_points : unit -> unit
+  val _flambda2_unbox_along_intra_function_control_flow : unit -> unit
+  val _no_flambda2_unbox_along_intra_function_control_flow : unit -> unit
+  val _flambda2_lift_inconstants : unit -> unit
+  val _no_flambda2_lift_inconstants : unit -> unit
+
+  val _dprepared_lambda : unit -> unit
+  val _dilambda : unit -> unit
+  val _drawflambda2 : unit -> unit
 end;;
 
 module type Optcomp_options = sig
@@ -1428,11 +1468,8 @@ struct
     mk_dlambda F._dlambda;
     mk_drawclambda F._drawclambda;
     mk_dclambda F._dclambda;
-    mk_dprepared_lambda F._dprepared_lambda;
-    mk_dilambda F._dilambda;
     mk_dflambda F._dflambda;
     mk_drawflambda F._drawflambda;
-    mk_drawflambda2 F._drawflambda2;
     mk_dflambda_invariants F._dflambda_invariants;
     mk_dflambda_no_invariants F._dflambda_no_invariants;
     mk_dflambda_let F._dflambda_let;
@@ -1458,6 +1495,19 @@ struct
     mk_dprofile F._dprofile;
     mk_dump_into_file F._dump_into_file;
     mk_dump_pass F._dump_pass;
+
+    mk_flambda2_join_points F._flambda2_join_points;
+    mk_no_flambda2_join_points F._no_flambda2_join_points;
+    mk_flambda2_unbox_along_intra_function_control_flow
+      F._flambda2_unbox_along_intra_function_control_flow;
+    mk_no_flambda2_unbox_along_intra_function_control_flow
+      F._no_flambda2_unbox_along_intra_function_control_flow;
+    mk_flambda2_lift_inconstants F._flambda2_lift_inconstants;
+    mk_no_flambda2_lift_inconstants F._no_flambda2_lift_inconstants;
+
+    mk_dprepared_lambda F._dprepared_lambda;
+    mk_dilambda F._dilambda;
+    mk_drawflambda2 F._drawflambda2;
 
     mk_args F._args;
     mk_args0 F._args0;
@@ -1542,7 +1592,6 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_drawclambda F._drawclambda;
     mk_dclambda F._dclambda;
     mk_drawflambda F._drawflambda;
-    mk_drawflambda2 F._drawflambda2;
     mk_dflambda F._dflambda;
     mk_dcmm F._dcmm;
     mk_dsel F._dsel;
@@ -1562,6 +1611,19 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_dinterval F._dinterval;
     mk_dstartup F._dstartup;
     mk_dump_pass F._dump_pass;
+
+    mk_flambda2_join_points F._flambda2_join_points;
+    mk_no_flambda2_join_points F._no_flambda2_join_points;
+    mk_flambda2_unbox_along_intra_function_control_flow
+      F._flambda2_unbox_along_intra_function_control_flow;
+    mk_no_flambda2_unbox_along_intra_function_control_flow
+      F._no_flambda2_unbox_along_intra_function_control_flow;
+    mk_flambda2_lift_inconstants F._flambda2_lift_inconstants;
+    mk_no_flambda2_lift_inconstants F._no_flambda2_lift_inconstants;
+
+    mk_dprepared_lambda F._dprepared_lambda;
+    mk_dilambda F._dilambda;
+    mk_drawflambda2 F._drawflambda2;
   ]
 end;;
 
@@ -1736,9 +1798,6 @@ module Default = struct
     let _dprefer = set dump_prefer
     let _drawclambda = set dump_rawclambda
     let _drawflambda = set dump_rawflambda
-    let _drawflambda2 = set dump_rawflambda2
-    let _dprepared_lambda = set dump_prepared_lambda
-    let _dilambda = set dump_ilambda
     let _dreload = set dump_reload
     let _drunavail () = debug_runavail := true
     let _dscheduling = set dump_scheduling
@@ -1817,6 +1876,19 @@ module Default = struct
     let _unbox_closures = set unbox_closures
     let _unbox_closures_factor f = unbox_closures_factor := f
     let _verbose = set verbose
+
+    let _flambda2_join_points = set Flambda_2.join_points
+    let _no_flambda2_join_points = clear Flambda_2.join_points
+    let _flambda2_unbox_along_intra_function_control_flow =
+      set Flambda_2.unbox_along_intra_function_control_flow
+    let _no_flambda2_unbox_along_intra_function_control_flow =
+      clear Flambda_2.unbox_along_intra_function_control_flow
+    let _flambda2_lift_inconstants = set Flambda_2.lift_inconstants
+    let _no_flambda2_lift_inconstants = clear Flambda_2.lift_inconstants
+
+    let _dprepared_lambda = set dump_prepared_lambda
+    let _dilambda = set dump_ilambda
+    let _drawflambda2 = set dump_rawflambda2
   end
 
   module Compiler = struct

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -918,7 +918,7 @@ let mk_flambda2_lift_inconstants f =
 
 let mk_no_flambda2_lift_inconstants f =
   "-no-flambda2-lift-inconstants", Arg.Unit f,
-    "Attempt to statically-allocate values that require computations to \
+    "Never statically-allocate values that require computations to \
       initialize"
 ;;
 

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -193,11 +193,8 @@ module type Optcommon_options = sig
   val _no_float_const_prop : unit -> unit
 
   val _clambda_checks : unit -> unit
-  val _dprepared_lambda : unit -> unit
-  val _dilambda : unit -> unit
   val _dflambda : unit -> unit
   val _drawflambda : unit -> unit
-  val _drawflambda2 : unit -> unit
   val _dflambda_invariants : unit -> unit
   val _dflambda_no_invariants : unit -> unit
   val _dflambda_let : int -> unit
@@ -221,6 +218,19 @@ module type Optcommon_options = sig
   val _dlinear :  unit -> unit
   val _dinterval : unit -> unit
   val _dstartup :  unit -> unit
+
+  (** Flambda 2 user flags *)
+  val _flambda2_join_points : unit -> unit
+  val _no_flambda2_join_points : unit -> unit
+  val _flambda2_unbox_along_intra_function_control_flow : unit -> unit
+  val _no_flambda2_unbox_along_intra_function_control_flow : unit -> unit
+  val _flambda2_lift_inconstants : unit -> unit
+  val _no_flambda2_lift_inconstants : unit -> unit
+
+  (** Flambda 2 debugging flags *)
+  val _dprepared_lambda : unit -> unit
+  val _dilambda : unit -> unit
+  val _drawflambda2 : unit -> unit
 end;;
 
 module type Optcomp_options = sig

--- a/middle_end/flambda2.0/compilenv_deps/flambda_features.ml
+++ b/middle_end/flambda2.0/compilenv_deps/flambda_features.ml
@@ -1,0 +1,20 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                   Mark Shinwell, Jane Street Europe                    *)
+(*                                                                        *)
+(*   Copyright 2020 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+let join_points () = !Clflags.Flambda_2.join_points
+let unbox_along_intra_function_control_flow () =
+  !Clflags.Flambda_2.unbox_along_intra_function_control_flow
+let lift_inconstants () = !Clflags.Flambda_2.lift_inconstants

--- a/middle_end/flambda2.0/compilenv_deps/flambda_features.mli
+++ b/middle_end/flambda2.0/compilenv_deps/flambda_features.mli
@@ -1,0 +1,19 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                   Mark Shinwell, Jane Street Europe                    *)
+(*                                                                        *)
+(*   Copyright 2020 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+val join_points : unit -> bool
+val unbox_along_intra_function_control_flow : unit -> bool
+val lift_inconstants : unit -> bool

--- a/middle_end/flambda2.0/lifting/reify_continuation_param_types.ml
+++ b/middle_end/flambda2.0/lifting/reify_continuation_param_types.ml
@@ -265,7 +265,7 @@ let reify_types_of_continuation_param_types dacc ~params =
     params
     (dacc, Variable.Map.empty, [], Set_of_closures.Map.empty)
 
-let lift_via_reification_of_continuation_param_types dacc ~params
+let lift_via_reification_of_continuation_param_types0 dacc ~params
       ~(extra_params_and_args : Continuation_extra_params_and_args.t)
       ~(handler : Expr.t) =
 (*  Format.eprintf "-------- REIFY ------------\ndacc = @ %a\n%!"
@@ -299,3 +299,11 @@ let lift_via_reification_of_continuation_param_types dacc ~params
       reified_definitions.bindings_outermost_last
   in
   dacc, handler
+
+let lift_via_reification_of_continuation_param_types dacc ~params
+      ~extra_params_and_args ~handler =
+  if Flambda_features.lift_inconstants () then
+    lift_via_reification_of_continuation_param_types0 dacc ~params
+      ~extra_params_and_args ~handler
+  else
+    dacc, handler

--- a/middle_end/flambda2.0/simplify/typing_helpers/continuation_uses.ml
+++ b/middle_end/flambda2.0/simplify/typing_helpers/continuation_uses.ml
@@ -156,10 +156,14 @@ Format.eprintf "Unknown at or later than %a\n%!"
       | [] | [_, _, (Inlinable | Non_inlinable)]
       | (_, _, (Inlinable | Non_inlinable)) :: _ ->
         let env_extension, extra_params_and_args =
-          TE.cut_and_n_way_join typing_env use_envs_with_ids
-            ~params
-            ~unknown_if_defined_at_or_later_than:
-              (Scope.next definition_scope_level)
+          if Flambda_features.join_points () then
+            TE.cut_and_n_way_join typing_env use_envs_with_ids
+              ~params
+              ~unknown_if_defined_at_or_later_than:
+                (Scope.next definition_scope_level)
+          else
+            T.Typing_env_extension.empty (),
+              Continuation_extra_params_and_args.empty
         in
 (*
 Format.eprintf "handler env extension for %a is:@ %a\n%!"

--- a/middle_end/flambda2.0/unboxing/unbox_continuation_params.ml
+++ b/middle_end/flambda2.0/unboxing/unbox_continuation_params.ml
@@ -1005,7 +1005,7 @@ let rec make_unboxing_decision typing_env ~depth ~arg_types_by_use_id
           in
           try_unboxing unboxed_number_decisions
 
-let make_unboxing_decisions typing_env ~arg_types_by_use_id ~params
+let make_unboxing_decisions0 typing_env ~arg_types_by_use_id ~params
       ~param_types extra_params_and_args =
   assert (List.compare_lengths params param_types = 0);
   let typing_env, param_types_rev, extra_params_and_args =
@@ -1029,3 +1029,11 @@ let make_unboxing_decisions typing_env ~arg_types_by_use_id ~params
   Format.eprintf "EPA:@ %a\n%!" EPA.print extra_params_and_args;
   *)
   typing_env, extra_params_and_args
+
+let make_unboxing_decisions typing_env ~arg_types_by_use_id ~params
+      ~param_types extra_params_and_args =
+  if Flambda_features.unbox_along_intra_function_control_flow () then
+    make_unboxing_decisions0 typing_env ~arg_types_by_use_id ~params
+      ~param_types extra_params_and_args
+  else
+    typing_env, EPA.empty

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -423,6 +423,12 @@ let error_style_reader = {
 
 let unboxed_types = ref false
 
+module Flambda_2 = struct
+  let join_points = ref true
+  let unbox_along_intra_function_control_flow = ref true
+  let lift_inconstants = ref true
+end
+
 (* This is used by the -stop-after option. *)
 module Compiler_pass = struct
   (* If you add a new pass, the following must be updated:

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -243,6 +243,12 @@ val unboxed_types : bool ref
 val insn_sched : bool ref
 val insn_sched_default : bool
 
+module Flambda_2 : sig
+  val join_points : bool ref
+  val unbox_along_intra_function_control_flow : bool ref
+  val lift_inconstants : bool ref
+end
+
 module Compiler_pass : sig
   type t = Parsing | Typing
   val of_string : string -> t option


### PR DESCRIPTION
We need to think about a proper framework for this (which is why I've introduced the `Flambda_flags` module in this PR rather than referencing `Clflags` directly), but for the moment this will suffice.  Three flags are provided to enable certain computations to be turned off:
- join calculations
- unboxing of continuation parameters
- static allocation of values with inconstant initialisers.

This should help with problematic source files until compile-time performance problems are sorted out.