### PR TITLE
Cherry-pick upstream PR#9392 (Visit registers at most once in Coloring.iter_preferred)

### DIFF
--- a/asmcomp/coloring.ml
+++ b/asmcomp/coloring.ml
@@ -74,18 +74,13 @@ let allocate_registers() =
   (* Iterate over all registers preferred by the given register (transitive) *)
   let iter_preferred f reg =
     let rec walk r w =
-      if not r.visited then begin
+      if not (Reg.is_visited r) then begin
+        Reg.mark_visited r;
         f r w;
-        begin match r.prefer with
-            [] -> ()
-          | p  -> r.visited <- true;
-                  List.iter (fun (r1, w1) -> walk r1 (min w w1)) p;
-                  r.visited <- false
-        end
+        List.iter (fun (r1, w1) -> walk r1 (min w w1)) r.prefer
       end in
-    reg.visited <- true;
     List.iter (fun (r, w) -> walk r w) reg.prefer;
-    reg.visited <- false in
+    Reg.clear_visited_marks () in
 
   (* Where to start the search for a suitable register.
      Used to introduce some "randomness" in the choice between registers

--- a/asmcomp/reg.ml
+++ b/asmcomp/reg.ml
@@ -45,7 +45,7 @@ type t =
     mutable prefer: (t * int) list;
     mutable degree: int;
     mutable spill_cost: int;
-    mutable visited: bool }
+    mutable visited: int }
 
 and location =
     Unknown
@@ -62,16 +62,30 @@ type reg = t
 let dummy =
   { raw_name = Raw_name.Anon; stamp = 0; typ = Int; loc = Unknown;
     spill = false; interf = []; prefer = []; degree = 0; spill_cost = 0;
-    visited = false; part = None;
+    visited = 0; part = None;
   }
 
 let currstamp = ref 0
 let reg_list = ref([] : t list)
 
+
+let visit_generation = ref 1
+
+let mark_visited r =
+  r.visited <- !visit_generation
+
+let is_visited r =
+  r.visited = !visit_generation
+
+let clear_visited_marks () =
+  incr visit_generation
+
+let unvisited () = !visit_generation - 1
+
 let create ty =
   let r = { raw_name = Raw_name.Anon; stamp = !currstamp; typ = ty;
             loc = Unknown; spill = false; interf = []; prefer = []; degree = 0;
-            spill_cost = 0; visited = false; part = None; } in
+            spill_cost = 0; visited = unvisited (); part = None; } in
   reg_list := r :: !reg_list;
   incr currstamp;
   r
@@ -96,7 +110,7 @@ let clone r =
 let at_location ty loc =
   let r = { raw_name = Raw_name.R; stamp = !currstamp; typ = ty; loc;
             spill = false; interf = []; prefer = []; degree = 0;
-            spill_cost = 0; visited = false; part = None; } in
+            spill_cost = 0; visited = unvisited (); part = None; } in
   incr currstamp;
   r
 

--- a/asmcomp/reg.mli
+++ b/asmcomp/reg.mli
@@ -31,7 +31,7 @@ type t =
     mutable prefer: (t * int) list;     (* Preferences for other regs *)
     mutable degree: int;                (* Number of other regs live sim. *)
     mutable spill_cost: int;            (* Estimate of spilling cost *)
-    mutable visited: bool }             (* For graph walks *)
+    mutable visited: int }              (* For graph walks *)
 
 and location =
     Unknown
@@ -68,3 +68,7 @@ val reset: unit -> unit
 val all_registers: unit -> t list
 val num_registers: unit -> int
 val reinit: unit -> unit
+
+val mark_visited : t -> unit
+val is_visited : t -> bool
+val clear_visited_marks : unit -> unit


### PR DESCRIPTION
This should negate the need for `-linscan` on certain examples.