### PR TITLE
Fix for unbound names in Continuation_uses

### DIFF
--- a/middle_end/flambda2.0/simplify/typing_helpers/continuation_uses.ml
+++ b/middle_end/flambda2.0/simplify/typing_helpers/continuation_uses.ml
@@ -138,14 +138,21 @@ Format.eprintf "Unknown at or later than %a\n%!"
            discovered whilst simplifying the corresponding body. *)
         let use_env =
           List.fold_left (fun use_env const ->
+              Symbol.Map.fold (fun symbol _ty use_env ->
+                  let symbol' = Name.symbol symbol in
+                  (* CR mshinwell: Add a function in [TE] to do this.  That
+                      can in fact just blindly add to [defined_symbols]. *)
+                  if TE.mem use_env symbol' then use_env
+                  else TE.add_symbol_definition use_env symbol)
+                (LC.types_of_symbols const)
+                use_env)
+            use_env
+            consts_lifted_during_body
+        in
+        let use_env =
+          List.fold_left (fun use_env const ->
               Symbol.Map.fold (fun symbol ty use_env ->
                   let symbol' = Name.symbol symbol in
-                  let use_env =
-                    (* CR mshinwell: Add a function in [TE] to do this.  That
-                       can in fact just blindly add to [defined_symbols]. *)
-                    if TE.mem use_env symbol' then use_env
-                    else TE.add_symbol_definition use_env symbol
-                  in
                   TE.add_equation use_env symbol' ty)
                 (LC.types_of_symbols const)
                 use_env)


### PR DESCRIPTION
In the inlinable case, when propagating lifted constants, I think the symbols need to be defined first before the equations are added.