### PR TITLE
Command-line flags and default changes for denesting etc.

### DIFF
--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -922,6 +922,26 @@ let mk_no_flambda2_lift_inconstants f =
       initialize"
 ;;
 
+let mk_flambda2_expert_denest_at_toplevel f =
+  "-flambda2-expert-denest-at-toplevel", Arg.Unit f,
+    "Denest continuations during Closure_conversion even at toplevel"
+;;
+
+let mk_no_flambda2_expert_denest_at_toplevel f =
+  "-no-flambda2-expert-denest-at-toplevel", Arg.Unit f,
+    "Never denest continuations during Closure_conversion at toplevel"
+;;
+
+let mk_flambda2_expert_code_id_and_symbol_scoping_checks f =
+  "-flambda2-expert-code-id-and-symbol-scoping-checks", Arg.Unit f,
+    "Perform checks on static scopes of code IDs and symbols during Un_cps"
+;;
+
+let mk_no_flambda2_expert_code_id_and_symbol_scoping_checks f =
+  "-no-flambda2-expert-code-id-and-symbol-scoping-checks", Arg.Unit f,
+    "Perform checks on static scopes of code IDs and symbols during Un_cps"
+;;
+
 module type Common_options = sig
   val _absname : unit -> unit
   val _alert : string -> unit
@@ -1131,6 +1151,10 @@ module type Optcommon_options = sig
   val _no_flambda2_unbox_along_intra_function_control_flow : unit -> unit
   val _flambda2_lift_inconstants : unit -> unit
   val _no_flambda2_lift_inconstants : unit -> unit
+  val _flambda2_expert_denest_at_toplevel : unit -> unit
+  val _no_flambda2_expert_denest_at_toplevel : unit -> unit
+  val _flambda2_expert_code_id_and_symbol_scoping_checks : unit -> unit
+  val _no_flambda2_expert_code_id_and_symbol_scoping_checks : unit -> unit
 
   val _dprepared_lambda : unit -> unit
   val _dilambda : unit -> unit
@@ -1504,6 +1528,14 @@ struct
       F._no_flambda2_unbox_along_intra_function_control_flow;
     mk_flambda2_lift_inconstants F._flambda2_lift_inconstants;
     mk_no_flambda2_lift_inconstants F._no_flambda2_lift_inconstants;
+    mk_flambda2_expert_denest_at_toplevel
+      F._flambda2_expert_denest_at_toplevel;
+    mk_no_flambda2_expert_denest_at_toplevel
+      F._no_flambda2_expert_denest_at_toplevel;
+    mk_flambda2_expert_code_id_and_symbol_scoping_checks
+      F._flambda2_expert_code_id_and_symbol_scoping_checks;
+    mk_no_flambda2_expert_code_id_and_symbol_scoping_checks
+      F._no_flambda2_expert_code_id_and_symbol_scoping_checks;
 
     mk_dprepared_lambda F._dprepared_lambda;
     mk_dilambda F._dilambda;
@@ -1620,6 +1652,14 @@ module Make_opttop_options (F : Opttop_options) = struct
       F._no_flambda2_unbox_along_intra_function_control_flow;
     mk_flambda2_lift_inconstants F._flambda2_lift_inconstants;
     mk_no_flambda2_lift_inconstants F._no_flambda2_lift_inconstants;
+    mk_flambda2_expert_denest_at_toplevel
+      F._flambda2_expert_denest_at_toplevel;
+    mk_no_flambda2_expert_denest_at_toplevel
+      F._no_flambda2_expert_denest_at_toplevel;
+    mk_flambda2_expert_code_id_and_symbol_scoping_checks
+      F._flambda2_expert_code_id_and_symbol_scoping_checks;
+    mk_no_flambda2_expert_code_id_and_symbol_scoping_checks
+      F._no_flambda2_expert_code_id_and_symbol_scoping_checks;
 
     mk_dprepared_lambda F._dprepared_lambda;
     mk_dilambda F._dilambda;
@@ -1885,6 +1925,14 @@ module Default = struct
       clear Flambda_2.unbox_along_intra_function_control_flow
     let _flambda2_lift_inconstants = set Flambda_2.lift_inconstants
     let _no_flambda2_lift_inconstants = clear Flambda_2.lift_inconstants
+    let _flambda2_expert_denest_at_toplevel =
+      set Flambda_2.Expert.denest_at_toplevel
+    let _no_flambda2_expert_denest_at_toplevel =
+      clear Flambda_2.Expert.denest_at_toplevel
+    let _flambda2_expert_code_id_and_symbol_scoping_checks =
+      set Flambda_2.Expert.code_id_and_symbol_scoping_checks
+    let _no_flambda2_expert_code_id_and_symbol_scoping_checks =
+      clear Flambda_2.Expert.code_id_and_symbol_scoping_checks
 
     let _dprepared_lambda = set dump_prepared_lambda
     let _dilambda = set dump_ilambda

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -226,6 +226,10 @@ module type Optcommon_options = sig
   val _no_flambda2_unbox_along_intra_function_control_flow : unit -> unit
   val _flambda2_lift_inconstants : unit -> unit
   val _no_flambda2_lift_inconstants : unit -> unit
+  val _flambda2_expert_denest_at_toplevel : unit -> unit
+  val _no_flambda2_expert_denest_at_toplevel : unit -> unit
+  val _flambda2_expert_code_id_and_symbol_scoping_checks : unit -> unit
+  val _no_flambda2_expert_code_id_and_symbol_scoping_checks : unit -> unit
 
   (** Flambda 2 debugging flags *)
   val _dprepared_lambda : unit -> unit

--- a/middle_end/flambda2.0/compilenv_deps/flambda_features.ml
+++ b/middle_end/flambda2.0/compilenv_deps/flambda_features.ml
@@ -18,3 +18,9 @@ let join_points () = !Clflags.Flambda_2.join_points
 let unbox_along_intra_function_control_flow () =
   !Clflags.Flambda_2.unbox_along_intra_function_control_flow
 let lift_inconstants () = !Clflags.Flambda_2.lift_inconstants
+
+module Expert = struct
+  let denest_at_toplevel () = !Clflags.Flambda_2.Expert.denest_at_toplevel
+  let code_id_and_symbol_scoping_checks () =
+    !Clflags.Flambda_2.Expert.code_id_and_symbol_scoping_checks
+end

--- a/middle_end/flambda2.0/compilenv_deps/flambda_features.mli
+++ b/middle_end/flambda2.0/compilenv_deps/flambda_features.mli
@@ -17,3 +17,8 @@
 val join_points : unit -> bool
 val unbox_along_intra_function_control_flow : unit -> bool
 val lift_inconstants : unit -> bool
+
+module Expert : sig
+  val denest_at_toplevel : unit -> bool
+  val code_id_and_symbol_scoping_checks : unit -> bool
+end

--- a/middle_end/flambda2.0/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2.0/from_lambda/closure_conversion.ml
@@ -563,6 +563,7 @@ let rec close t env (ilam : Ilambda.t) : Expr.t * _ =
     let still_at_toplevel =
       (* Same calculation as in [Simplify_expr]. *)
       Env.still_at_toplevel env
+        && not (Flambda_features.Expert.denest_at_toplevel ())
         && (not is_exn_handler)
         && Continuation.Set.subset
               (Name_occurrences.continuations (Expr.free_names body))

--- a/middle_end/flambda2.0/to_cmm/un_cps_env.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps_env.ml
@@ -455,7 +455,9 @@ let check_scope ~allow_deleted env code_id_or_symbol =
         }
     | Symbol _ -> env
   in
-  if in_scope || in_another_unit then updated_env
+  if in_scope || in_another_unit
+    || (not (Flambda_features.Expert.code_id_and_symbol_scoping_checks ()))
+  then updated_env
   else
     Misc.fatal_errorf "Use out of scope of %a@.Known names:@.%a@."
       Code_id_or_symbol.print code_id_or_symbol

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -427,6 +427,11 @@ module Flambda_2 = struct
   let join_points = ref true
   let unbox_along_intra_function_control_flow = ref true
   let lift_inconstants = ref true
+
+  module Expert = struct
+    let denest_at_toplevel = ref false
+    let code_id_and_symbol_scoping_checks = ref false
+  end
 end
 
 (* This is used by the -stop-after option. *)

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -247,6 +247,11 @@ module Flambda_2 : sig
   val join_points : bool ref
   val unbox_along_intra_function_control_flow : bool ref
   val lift_inconstants : bool ref
+
+  module Expert : sig
+    val denest_at_toplevel : bool ref
+    val code_id_and_symbol_scoping_checks : bool ref
+  end
 end
 
 module Compiler_pass : sig


### PR DESCRIPTION
1. To enable/disable denesting of continuations in Closure_conversion.
2. To enable/disable the symbol/code ID static scoping check in Un_cps.

The defaults are changed so:
- denesting is allowed
- the scoping check is off.

We need to discuss more, but I think the dominator-based scoping is the way to go for `Let_symbol`.  The other approach seems too fragile.