### PR TITLE
CSE of complex expressions

### DIFF
--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -922,6 +922,11 @@ let mk_no_flambda2_lift_inconstants f =
       initialize"
 ;;
 
+let mk_flambda2_cse_depth f =
+  "-flambda2-cse-depth", Arg.Int f,
+    " Depth threshold for eager tracking of CSE equations (default 2)"
+;;
+
 let mk_flambda2_expert_denest_at_toplevel f =
   "-flambda2-expert-denest-at-toplevel", Arg.Unit f,
     " Denest continuations during Closure_conversion even at toplevel"
@@ -1163,6 +1168,7 @@ module type Optcommon_options = sig
   val _no_flambda2_lift_inconstants : unit -> unit
   val _flambda2_backend_cse_at_toplevel : unit -> unit
   val _no_flambda2_backend_cse_at_toplevel : unit -> unit
+  val _flambda2_cse_depth : int -> unit
   val _flambda2_expert_denest_at_toplevel : unit -> unit
   val _no_flambda2_expert_denest_at_toplevel : unit -> unit
   val _flambda2_expert_code_id_and_symbol_scoping_checks : unit -> unit
@@ -1505,6 +1511,7 @@ struct
     mk_flambda2_backend_cse_at_toplevel F._flambda2_backend_cse_at_toplevel;
     mk_no_flambda2_backend_cse_at_toplevel
       F._no_flambda2_backend_cse_at_toplevel;
+    mk_flambda2_cse_depth F._flambda2_cse_depth;
     mk_flambda2_expert_denest_at_toplevel
       F._flambda2_expert_denest_at_toplevel;
     mk_no_flambda2_expert_denest_at_toplevel
@@ -1643,6 +1650,7 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_flambda2_backend_cse_at_toplevel F._flambda2_backend_cse_at_toplevel;
     mk_no_flambda2_backend_cse_at_toplevel
       F._no_flambda2_backend_cse_at_toplevel;
+    mk_flambda2_cse_depth F._flambda2_cse_depth;
     mk_flambda2_expert_denest_at_toplevel
       F._flambda2_expert_denest_at_toplevel;
     mk_no_flambda2_expert_denest_at_toplevel
@@ -1947,6 +1955,7 @@ module Default = struct
       set Flambda_2.backend_cse_at_toplevel
     let _no_flambda2_backend_cse_at_toplevel =
       clear Flambda_2.backend_cse_at_toplevel
+    let _flambda2_cse_depth n = Flambda_2.cse_depth := n
     let _flambda2_expert_denest_at_toplevel =
       set Flambda_2.Expert.denest_at_toplevel
     let _no_flambda2_expert_denest_at_toplevel =

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -228,6 +228,7 @@ module type Optcommon_options = sig
   val _no_flambda2_lift_inconstants : unit -> unit
   val _flambda2_backend_cse_at_toplevel : unit -> unit
   val _no_flambda2_backend_cse_at_toplevel : unit -> unit
+  val _flambda2_cse_depth : int -> unit
   val _flambda2_expert_denest_at_toplevel : unit -> unit
   val _no_flambda2_expert_denest_at_toplevel : unit -> unit
   val _flambda2_expert_code_id_and_symbol_scoping_checks : unit -> unit

--- a/flambdatest/mlexamples/cse_minus.ml
+++ b/flambdatest/mlexamples/cse_minus.ml
@@ -1,0 +1,13 @@
+(* The issue with this example is that we want to remove the second array
+   bounds check thanks to CSE, but this involves doing two rounds at
+   some point. So this should only work with -flambda-cse-depth of at least 2
+   (the default is 2) *)
+
+external ( - ) : int -> int -> int = "%subint"
+external ( = ) : 'a -> 'a -> bool = "%equal"
+external array_get: 'a array -> int -> 'a = "%array_safe_get"
+external array_set: 'a array -> int -> 'a -> unit = "%array_safe_set"
+
+let f table table c min t =
+ assert (array_get table (c - min) = None);
+ array_set table (c - min) (Some t)

--- a/flambdatest/mlexamples/emitcode_repro.ml
+++ b/flambdatest/mlexamples/emitcode_repro.ml
@@ -1,0 +1,24 @@
+type t =
+  | C0
+  | C1
+  | B0 of int
+  | B1 of int
+
+let out _x =
+  Sys.opaque_identity ()
+[@@inline never] [@@local never]
+
+let emit_instr = function
+  | C0 -> out (0, 0)
+  | C1 -> out (0, 1)
+  | B0 _ -> out (1, 0)
+  | B1 _ -> out (1, 1)
+
+let rec emit = function
+  | [] -> ()
+  | C0 :: B0 k :: rem when Sys.opaque_identity false ->
+    out (2, 1); emit rem
+  | B1 _ :: rem ->
+    out (2, 2); emit rem
+  | instr :: rem ->
+    emit_instr instr; emit rem

--- a/flambdatest/mlexamples/emitcode_repro.mli
+++ b/flambdatest/mlexamples/emitcode_repro.mli
@@ -1,0 +1,7 @@
+type t =
+  | C0
+  | C1
+  | B0 of int
+  | B1 of int
+
+val emit : t list -> unit

--- a/middle_end/flambda2.0/basic/continuation_extra_params_and_args.ml
+++ b/middle_end/flambda2.0/basic/continuation_extra_params_and_args.ml
@@ -87,3 +87,25 @@ let add t ~extra_param ~extra_args =
   { extra_params = extra_param :: t.extra_params;
     extra_args;
   }
+
+let concat t1 t2 =
+  if is_empty t2 then t1
+  else if is_empty t1 then t2
+  else begin
+    let extra_args =
+      Apply_cont_rewrite_id.Map.merge (fun id extra_args1 extra_args2 ->
+          match extra_args1, extra_args2 with
+          | None, None -> None
+          | Some _, None
+          | None, Some _ ->
+            Misc.fatal_errorf "concat: mismatching domains on id %a"
+              Apply_cont_rewrite_id.print id
+          | Some extra_args1, Some extra_args2 ->
+            Some (extra_args1 @ extra_args2))
+        t1.extra_args
+        t2.extra_args
+    in
+    { extra_params = t1.extra_params @ t2.extra_params;
+      extra_args;
+    }
+  end

--- a/middle_end/flambda2.0/basic/continuation_extra_params_and_args.mli
+++ b/middle_end/flambda2.0/basic/continuation_extra_params_and_args.mli
@@ -46,3 +46,5 @@ val add
   -> extra_param:Kinded_parameter.t
   -> extra_args:Extra_arg.t Apply_cont_rewrite_id.Map.t
   -> t
+
+val concat : t -> t -> t

--- a/middle_end/flambda2.0/compilenv_deps/flambda_features.ml
+++ b/middle_end/flambda2.0/compilenv_deps/flambda_features.ml
@@ -19,6 +19,7 @@ let unbox_along_intra_function_control_flow () =
   !Clflags.Flambda_2.unbox_along_intra_function_control_flow
 let lift_inconstants () = !Clflags.Flambda_2.lift_inconstants
 let backend_cse_at_toplevel () = !Clflags.Flambda_2.backend_cse_at_toplevel
+let cse_depth () = !Clflags.Flambda_2.cse_depth
 
 module Expert = struct
   let denest_at_toplevel () = !Clflags.Flambda_2.Expert.denest_at_toplevel

--- a/middle_end/flambda2.0/compilenv_deps/flambda_features.mli
+++ b/middle_end/flambda2.0/compilenv_deps/flambda_features.mli
@@ -18,6 +18,7 @@ val join_points : unit -> bool
 val unbox_along_intra_function_control_flow : unit -> bool
 val lift_inconstants : unit -> bool
 val backend_cse_at_toplevel : unit -> bool
+val cse_depth : unit -> int
 
 module Expert : sig
   val denest_at_toplevel : unit -> bool

--- a/middle_end/flambda2.0/types/env/typing_env_level.rec.ml
+++ b/middle_end/flambda2.0/types/env/typing_env_level.rec.ml
@@ -659,10 +659,36 @@ module Rhs_kind = struct
   end)
 end
 
-let cse_with_eligible_lhs ~env_at_fork envs_with_levels ~params =
+let cse_with_eligible_lhs ~env_at_fork envs_with_levels ~params prev_cse
+      (extra_bindings: Continuation_extra_params_and_args.t) =
   let module EP = Flambda_primitive.Eligible_for_cse in
   let params = Kinded_parameter.List.simple_set params in
   List.fold_left (fun eligible (env_at_use, id, _, t) ->
+      let find_new_name =
+        if Continuation_extra_params_and_args.is_empty extra_bindings
+        then (fun _arg -> None)
+        else begin
+          let extra_args =
+            Apply_cont_rewrite_id.Map.find id
+              extra_bindings.extra_args
+          in
+          let rec find_name simple params args =
+            match args, params with
+            | [], [] -> None
+            | [], _ | _, [] ->
+              Misc.fatal_error "Mismatching params and args arity"
+            | arg :: args, param :: params ->
+              begin
+              match (arg : Continuation_extra_params_and_args.Extra_arg.t) with
+              | Already_in_scope arg when Simple.equal arg simple ->
+                Some (Kinded_parameter.simple param)
+              | Already_in_scope _ | New_let_binding _ ->
+                find_name simple params args
+              end
+          in
+          (fun arg -> find_name arg extra_bindings.extra_params extra_args)
+        end
+      in
       EP.Map.fold (fun prim bound_to eligible ->
         let prim =
           EP.filter_map_args prim ~f:(fun arg ->
@@ -672,12 +698,19 @@ let cse_with_eligible_lhs ~env_at_fork envs_with_levels ~params =
             with
             | exception Not_found -> None
             | arg ->
-              if Typing_env.mem_simple env_at_fork arg
-              then Some arg
-              else None)
+              begin match find_new_name arg with
+              | None ->
+                if Typing_env.mem_simple env_at_fork arg
+                then Some arg
+                else None
+              | Some _ as arg_opt -> arg_opt
+              end)
         in
         match prim with
         | None -> eligible
+        | Some prim when EP.Map.mem prim prev_cse ->
+          (* We've already got it from a previous round *)
+          eligible
         | Some prim ->
           match
             Typing_env.get_canonical_simple_exn env_at_use bound_to
@@ -856,6 +889,7 @@ let construct_joined_level envs_with_levels ~allowed ~joined_types ~cse =
   }
 
 let join ~env_at_fork envs_with_levels ~params =
+  let module EP = Flambda_primitive.Eligible_for_cse in
   (*
   Format.eprintf "JOIN\n%!";
   Format.eprintf "At fork:@ %a\n%!" Typing_env.print env_at_fork;
@@ -895,24 +929,6 @@ let join ~env_at_fork envs_with_levels ~params =
   (*
   Format.eprintf "joined_types:@ %a\n%!"
     (Name.Map.print Type_grammar.print) joined_types;
-  *)
-  (* CSE equations have a left-hand side specifying a primitive and a
-     right-hand side specifying a [Simple].  The left-hand side is matched
-     against portions of terms.  As such, the [Simple]s therein must have
-     name mode [Normal], since we do not do CSE for phantom bindings (see
-     [Simplify_common]).  It follows that any CSE equation whose left-hand side
-     involves a name not defined at the fork point, having canonicalised such
-     name, cannot be propagated.  This step also canonicalises the right-hand
-     sides of the CSE equations. *)
-  (*
-  Format.eprintf "params:@ %a\n%!" Kinded_parameter.List.print params;
-  *)
-  let cse = cse_with_eligible_lhs ~env_at_fork envs_with_levels ~params in
-  (*
-  Format.eprintf "CSE with eligible LHS:@ %a\n%!"
-    (Flambda_primitive.Eligible_for_cse.Map.print
-      (Apply_cont_rewrite_id.Map.print Rhs_kind.print))
-    cse;
   *)
   (* Next calculate which equations (describing joined types) to propagate to
      the join point.  (Recall that the environment at the fork point includes
@@ -969,14 +985,69 @@ let join ~env_at_fork envs_with_levels ~params =
   (*
   Format.eprintf "allowed (1):@ %a\n%!" Name_occurrences.print allowed;
   *)
+  let compute_cse_one_round prev_cse extra_params extra_equations allowed =
+  (* CSE equations have a left-hand side specifying a primitive and a
+     right-hand side specifying a [Simple].  The left-hand side is matched
+     against portions of terms.  As such, the [Simple]s therein must have
+     name mode [Normal], since we do not do CSE for phantom bindings (see
+     [Simplify_common]).  It follows that any CSE equation whose left-hand side
+     involves a name not defined at the fork point, having canonicalised such
+     name, cannot be propagated.  This step also canonicalises the right-hand
+     sides of the CSE equations. *)
+  (*
+  Format.eprintf "params:@ %a\n%!" Kinded_parameter.List.print params;
+  *)
+    let new_cse =
+      cse_with_eligible_lhs ~env_at_fork envs_with_levels ~params
+        prev_cse extra_params
+    in
+  (*
+  Format.eprintf "CSE with eligible LHS:@ %a\n%!"
+    (Flambda_primitive.Eligible_for_cse.Map.print
+      (Apply_cont_rewrite_id.Map.print Rhs_kind.print))
+    cse;
+  *)
   (* To make use of a CSE equation at or after the join point, its right-hand
      side must have the same value, no matter which path is taken from the
      fork point to the join point.  We filter out equations that do not
      satisfy this.  Sometimes we can force an equation to satisfy the
      property by explicitly passing the value of the right-hand side as an
      extra parameter to the continuation at the join point. *)
+    let cse', extra_params', extra_equations', allowed =
+      join_cse envs_with_levels new_cse ~allowed
+    in
+    let need_other_round =
+      (* If we introduce new parameters, then CSE equations involving the
+         corresponding arguments can be considered again, so we need
+         another round. *)
+      not (Continuation_extra_params_and_args.is_empty extra_params')
+    in
+    let cse = EP.Map.disjoint_union prev_cse cse' in
+    let extra_params =
+      Continuation_extra_params_and_args.concat extra_params' extra_params
+    in
+    let extra_equations =
+      Name.Map.disjoint_union extra_equations extra_equations'
+    in
+    cse, extra_params, extra_equations, allowed, need_other_round
+  in
   let cse, extra_params, extra_equations, allowed =
-    join_cse envs_with_levels cse ~allowed
+    let rec do_rounds current_round cse extra_params extra_equations allowed =
+      let cse, extra_params, extra_equations, allowed, need_other_round =
+        compute_cse_one_round cse extra_params extra_equations allowed
+      in
+      if need_other_round && current_round < Flambda_features.cse_depth ()
+      then begin
+        do_rounds (succ current_round)
+          cse extra_params extra_equations allowed
+      end else begin
+        (* Either a fixpoint has been reached or we've already explored far
+           enough *)
+        cse, extra_params, extra_equations, allowed
+      end
+    in
+    do_rounds 1 EP.Map.empty Continuation_extra_params_and_args.empty
+      Name.Map.empty allowed
   in
   let joined_types =
     Name.Map.union (fun name _ty_join _ty_cse ->

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -428,6 +428,7 @@ module Flambda_2 = struct
   let unbox_along_intra_function_control_flow = ref true
   let lift_inconstants = ref true
   let backend_cse_at_toplevel = ref false
+  let cse_depth = ref 2
 
   module Expert = struct
     let denest_at_toplevel = ref false

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -248,6 +248,7 @@ module Flambda_2 : sig
   val unbox_along_intra_function_control_flow : bool ref
   val lift_inconstants : bool ref
   val backend_cse_at_toplevel : bool ref
+  val cse_depth : int ref
 
   module Expert : sig
     val denest_at_toplevel : bool ref


### PR DESCRIPTION
The join in Typing_env_level for CSE equations is now going through several rounds, with the next round enabling the variables from the previous rounds to appear in primitive arguments.
This is controlled by the new flag `-flambda-cse-depth`, which roughly corresponds to the maximal depth (or height) of expressions that we're interested in sharing.
The default setting is 2, and is chosen so that expressions like `(< (+ index offset) length`, which appear frequently with array accesses, can be eliminated.
A setting of 1 would restore the previous behaviour.