### PR TITLE
Add a "scoping rule" property to Let_symbol bindings

### DIFF
--- a/flambdatest/mlexamples/lifting.ml
+++ b/flambdatest/mlexamples/lifting.ml
@@ -7,4 +7,4 @@ let r1 = rand ()
 
 let r2 = rand ()
 
-let f x = x + r0 + r1 + r2
+let [@inline always] f x = x + r0 + r1 + r2

--- a/middle_end/flambda2.0/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2.0/from_lambda/closure_conversion.ml
@@ -1085,7 +1085,7 @@ let ilambda_to_flambda ~backend ~module_ident ~module_block_size_in_words
           ~dbg:Debuginfo.none
         |> Expr.create_apply_cont
       in
-      Let_symbol.create (Singleton module_symbol) static_const return
+      Let_symbol.create Syntactic (Singleton module_symbol) static_const return
       |> Flambda.Expr.create_let_symbol
     in
     let block_access : P.Block_access_kind.t =
@@ -1155,7 +1155,7 @@ let ilambda_to_flambda ~backend ~module_ident ~module_block_size_in_words
             set_of_closures = Set_of_closures.empty; 
           }]
         in
-        Let_symbol.create bound_symbols static_const body
+        Let_symbol.create Syntactic bound_symbols static_const body
         |> Flambda.Expr.create_let_symbol)
       body
       t.code
@@ -1176,7 +1176,7 @@ let ilambda_to_flambda ~backend ~module_ident ~module_block_size_in_words
   end;
   let body =
     List.fold_left (fun body (symbol, static_const) ->
-        Let_symbol.create (Singleton symbol) static_const body
+        Let_symbol.create Syntactic (Singleton symbol) static_const body
         |> Flambda.Expr.create_let_symbol)
       body
       t.declared_symbols

--- a/middle_end/flambda2.0/lifting/reify_continuation_param_types.ml
+++ b/middle_end/flambda2.0/lifting/reify_continuation_param_types.ml
@@ -296,7 +296,7 @@ let lift_via_reification_of_continuation_param_types0 dacc ~params
         Format.eprintf "Creating Let_symbol for:@ %a\n%!"
           Bound_symbols.print bound_symbols;
         *)
-        Let_symbol.create bound_symbols defining_expr handler
+        Let_symbol.create Dominator bound_symbols defining_expr handler
         |> Expr.create_let_symbol)
       handler
       reified_definitions.bindings_outermost_last

--- a/middle_end/flambda2.0/simplify/simplify_common.ml
+++ b/middle_end/flambda2.0/simplify/simplify_common.ml
@@ -197,7 +197,7 @@ let bind_let_bound ~bindings ~body =
     body
     (List.rev bindings)
 
-let create_let_symbol code_age_relation (bound_symbols : Bound_symbols.t)
+let create_let_symbol0 code_age_relation (bound_symbols : Bound_symbols.t)
       (static_const : Static_const.t) body =
 (*
   Format.eprintf "create_let_symbol %a\n%!" Bound_symbols.print bound_symbols;
@@ -207,7 +207,7 @@ let create_let_symbol code_age_relation (bound_symbols : Bound_symbols.t)
   | Singleton sym ->
     if not (Name_occurrences.mem_symbol free_names_after sym) then body
     else
-      Let_symbol.create bound_symbols static_const body
+      Let_symbol.create Syntactic bound_symbols static_const body
       |> Expr.create_let_symbol
   | Sets_of_closures _ ->
     let bound_names_unused =
@@ -282,5 +282,14 @@ let create_let_symbol code_age_relation (bound_symbols : Bound_symbols.t)
                 else code))
           (Static_const.must_be_sets_of_closures static_const)
       in
-      Let_symbol.create bound_symbols (Sets_of_closures sets) body
+      Let_symbol.create Syntactic bound_symbols (Sets_of_closures sets) body
       |> Expr.create_let_symbol
+
+let create_let_symbol (scoping_rule : Let_symbol.Scoping_rule.t)
+      code_age_relation bound_symbols static_const body =
+  match scoping_rule with
+  | Syntactic ->
+    create_let_symbol0 code_age_relation bound_symbols static_const body
+  | Dominator ->
+    Let_symbol.create Dominator bound_symbols static_const body
+    |> Expr.create_let_symbol

--- a/middle_end/flambda2.0/simplify/simplify_common.mli
+++ b/middle_end/flambda2.0/simplify/simplify_common.mli
@@ -71,7 +71,8 @@ val bind_let_bound
   -> Flambda.Expr.t
 
 val create_let_symbol
-   : Code_age_relation.t
+   : Flambda.Let_symbol_expr.Scoping_rule.t
+  -> Code_age_relation.t
   -> Flambda.Let_symbol_expr.Bound_symbols.t
   -> Flambda.Static_const.t
   -> Flambda.Expr.t

--- a/middle_end/flambda2.0/simplify/simplify_expr.rec.ml
+++ b/middle_end/flambda2.0/simplify/simplify_expr.rec.ml
@@ -49,6 +49,7 @@ and simplify_let_symbol
       LS.print let_symbol_expr
   end;
   let module Bound_symbols = LS.Bound_symbols in
+  let scoping_rule = LS.scoping_rule let_symbol_expr in
   let bound_symbols = LS.bound_symbols let_symbol_expr in
   (* CR mshinwell: We can't do this in conjunction with the current
      reification scheme for continuation parameters; that has to put the
@@ -159,8 +160,8 @@ Format.eprintf "All bindings:@ %a\n%!"
   in
   let expr =
     List.fold_left (fun body (bound_symbols, defining_expr) ->
-        Simplify_common.create_let_symbol (UA.code_age_relation uacc)
-          bound_symbols defining_expr body)
+        Simplify_common.create_let_symbol scoping_rule
+          (UA.code_age_relation uacc) bound_symbols defining_expr body)
       body
       sorted_lifted_constants.bindings_outermost_last
   in

--- a/middle_end/flambda2.0/simplify/simplify_named.rec.ml
+++ b/middle_end/flambda2.0/simplify/simplify_named.rec.ml
@@ -51,6 +51,9 @@ let simplify_named0 dacc ~(bound_vars : Bindable_let_bound.t)
     (* CR mshinwell: Add check along the lines of: types are unknown
        whenever [not (P.With_fixed_value.eligible prim)] holds. *)
     let defining_expr, dacc, ty =
+      (* CR mshinwell: We should be able to do the equivalent of
+         [Reify_continuation_param_types] here so long as we are
+         at toplevel. *)
       Reification.try_to_reify dacc term ~bound_to:bound_var
     in
     let defining_expr =

--- a/middle_end/flambda2.0/terms/flambda.mli
+++ b/middle_end/flambda2.0/terms/flambda.mli
@@ -248,9 +248,22 @@ end and Let_symbol_expr : sig
     include Expr_std.S with type t := t
   end
 
+  module Scoping_rule : sig
+    type t =
+      | Syntactic
+      | Dominator
+  end
+
   type t
 
-  val create : Bound_symbols.t -> Static_const.t -> Expr.t -> t
+  val create
+     : Scoping_rule.t
+    -> Bound_symbols.t
+    -> Static_const.t
+    -> Expr.t
+    -> t
+
+  val scoping_rule : t -> Scoping_rule.t
 
   val bound_symbols : t -> Bound_symbols.t
 

--- a/middle_end/flambda2.0/terms/let_symbol_expr.rec.ml
+++ b/middle_end/flambda2.0/terms/let_symbol_expr.rec.ml
@@ -149,18 +149,32 @@ module Bound_symbols = struct
         (List.map Code_and_set_of_closures.free_names sets)
 end
 
+module Scoping_rule = struct
+  type t =
+    | Syntactic
+    | Dominator
+
+  let print ppf t =
+    match t with
+    | Syntactic -> Format.fprintf ppf "Syntactic"
+    | Dominator -> Format.fprintf ppf "Dominator"
+end
+
 type t = {
+  scoping_rule : Scoping_rule.t;
   bound_symbols : Bound_symbols.t;
   defining_expr : Static_const.t;
   body : Expr.t;
 }
 
-let create bound_symbols defining_expr body =
-  { bound_symbols;
+let create scoping_rule bound_symbols defining_expr body =
+  { scoping_rule;
+    bound_symbols;
     defining_expr;
     body;
   }
 
+let scoping_rule t = t.scoping_rule
 let bound_symbols t = t.bound_symbols
 let defining_expr t = t.defining_expr
 let body t = t.body
@@ -174,19 +188,21 @@ type flattened_for_printing = {
   second_or_later_binding_within_one_set : bool;
   second_or_later_set_of_closures : bool;
   descr : flattened_for_printing_descr;
+  scoping_rule : Scoping_rule.t;
 }
 
-let triangle_colour descr =
+let shape_colour descr =
   match descr with
   | Code _ -> Flambda_colours.code_id ()
   | Set_of_closures _ | Other _ -> Flambda_colours.symbol ()
 
-let flatten_for_printing { bound_symbols; defining_expr; _ } =
+let flatten_for_printing { scoping_rule; bound_symbols; defining_expr; _ } =
   match bound_symbols with
   | Singleton symbol ->
     [{ second_or_later_binding_within_one_set = false;
        second_or_later_set_of_closures = false;
        descr = Other (symbol, defining_expr);
+       scoping_rule;
     }]
   | Sets_of_closures bound_symbol_components ->
     let code_and_sets_of_closures =
@@ -205,6 +221,7 @@ let flatten_for_printing { bound_symbols; defining_expr; _ } =
                   { second_or_later_binding_within_one_set = not first;
                     second_or_later_set_of_closures;
                     descr = Code (code_id, code);
+                    scoping_rule;
                   }
                 in
                 flattened :: flattened', false)
@@ -220,6 +237,7 @@ let flatten_for_printing { bound_symbols; defining_expr; _ } =
               [{ second_or_later_binding_within_one_set;
                  second_or_later_set_of_closures;
                  descr = Set_of_closures (closure_symbols, set_of_closures);
+                 scoping_rule;
               }]
           in
           let flattened_acc =
@@ -264,6 +282,7 @@ let print_flattened ppf
       { second_or_later_binding_within_one_set;
         second_or_later_set_of_closures;
         descr;
+        scoping_rule;
       } =
   fprintf ppf "@[<hov 1>";
   if second_or_later_set_of_closures
@@ -277,8 +296,14 @@ let print_flattened ppf
       (Flambda_colours.elide ())
       (Flambda_colours.normal ())
   end else begin
-    fprintf ppf "@<0>%s@<1>\u{25b6} @<0>%s"
-      (triangle_colour descr)
+    let shape =
+      match scoping_rule with
+      | Syntactic -> "\u{25b6}" (* filled triangle *)
+      | Dominator -> "\u{25b7}" (* unfilled triangle *)
+    in
+    fprintf ppf "@<0>%s@<1>%s @<0>%s"
+      shape
+      (shape_colour descr)
       (Flambda_colours.normal ())
   end;
   fprintf ppf
@@ -323,11 +348,12 @@ let print_with_cache ~cache ppf t =
 
 let print ppf t = print_with_cache ~cache:(Printing_cache.create ()) ppf t
 
-let invariant env { bound_symbols = _; defining_expr = _; body; } =
+let invariant env
+      { scoping_rule = _; bound_symbols = _; defining_expr = _; body; } =
   (* Static_const.invariant env defining_expr; *) (* CR mshinwell: FIXME *)
   Expr.invariant env body
 
-let free_names { bound_symbols; defining_expr; body; } =
+let free_names { scoping_rule = _; bound_symbols; defining_expr; body; } =
   let from_bound_symbols = Bound_symbols.free_names bound_symbols in
   let from_defining_expr =
     match bound_symbols with
@@ -339,12 +365,14 @@ let free_names { bound_symbols; defining_expr; body; } =
   Name_occurrences.union from_defining_expr
     (Name_occurrences.diff (Expr.free_names body) from_bound_symbols)
 
-let apply_name_permutation ({ bound_symbols; defining_expr; body; } as t) perm =
+let apply_name_permutation
+      ({ scoping_rule; bound_symbols; defining_expr; body; } as t) perm =
   let defining_expr' = Static_const.apply_name_permutation defining_expr perm in
   let body' = Expr.apply_name_permutation body perm in
   if defining_expr == defining_expr' && body == body' then t
   else
-    { bound_symbols;
+    { scoping_rule;
+      bound_symbols;
       defining_expr = defining_expr';
       body = body';
     }

--- a/middle_end/flambda2.0/terms/let_symbol_expr.rec.ml
+++ b/middle_end/flambda2.0/terms/let_symbol_expr.rec.ml
@@ -302,8 +302,8 @@ let print_flattened ppf
       | Dominator -> "\u{25b7}" (* unfilled triangle *)
     in
     fprintf ppf "@<0>%s@<1>%s @<0>%s"
-      shape
       (shape_colour descr)
+      shape
       (Flambda_colours.normal ())
   end;
   fprintf ppf

--- a/middle_end/flambda2.0/terms/let_symbol_expr.rec.mli
+++ b/middle_end/flambda2.0/terms/let_symbol_expr.rec.mli
@@ -55,9 +55,17 @@ module Bound_symbols : sig
   include Expr_std.S with type t := t
 end
 
+module Scoping_rule : sig
+  type t =
+    | Syntactic
+    | Dominator
+end
+
 type t
 
-val create : Bound_symbols.t -> Static_const.t -> Expr.t -> t
+val create : Scoping_rule.t -> Bound_symbols.t -> Static_const.t -> Expr.t -> t
+
+val scoping_rule : t -> Scoping_rule.t
 
 val bound_symbols : t -> Bound_symbols.t
 

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -431,7 +431,7 @@ module Flambda_2 = struct
   let cse_depth = ref 2
 
   module Expert = struct
-    let denest_at_toplevel = ref false
+    let denest_at_toplevel = ref true
     let code_id_and_symbol_scoping_checks = ref false
   end
 end


### PR DESCRIPTION
"Syntactic" causes them to be treated with the normal syntactic scope.  This is the case for all Let_symbol bindings except ones produced by Reify_continuation_param_types; and except ones from deeper down a program that end up being placed at a Let_symbol that is already of Dominator scoping rule.  (This latter behaviour should be conservative; a more clever version might float up ones that can be of Syntactic scoping to the nearest-enclosing Syntactic binding if that doesn't cause names to go out of scope.)

Simplify_common will not delete Dominator-scoped Let_symbol bindings at all at the moment, which with luck will stop the linking errors.  This behaviour should be ok for now; there aren't generally that many of this kind of symbol binding anyway.

The checks in Un_cps haven't yet been updated.  These should be able to check the dominator-scoped once fairly easily I would hope, because they only occur in toplevel contexts, not under any control flow and never under a lambda.