### PR TITLE
Speed up DE.enter_closure

### DIFF
--- a/middle_end/flambda2.0/simplify/env/simplify_env_and_result.ml
+++ b/middle_end/flambda2.0/simplify/env/simplify_env_and_result.ml
@@ -413,6 +413,11 @@ end = struct
           Symbol.Map.fold (fun sym typ typing_env ->
               let sym = Name.symbol sym in
               let env_extension =
+                (* CR mshinwell: Sometimes we might already have the types
+                   "made suitable" in the [closure_env] field of the typing
+                   environment, perhaps?  For example when lifted constants'
+                   types are coming out of a closure into the enclosing
+                   scope. *)
                 T.make_suitable_for_environment typ
                   denv_at_definition.typing_env
                   ~suitable_for:typing_env

--- a/middle_end/flambda2.0/simplify/env/simplify_env_and_result.ml
+++ b/middle_end/flambda2.0/simplify/env/simplify_env_and_result.ml
@@ -159,7 +159,7 @@ end = struct
                     } =
     { backend;
       round;
-      typing_env = TE.create_using_resolver_and_symbol_bindings_from typing_env;
+      typing_env = TE.closure_env typing_env;
       inlined_debuginfo = Debuginfo.none;
       can_inline;
       inlining_depth_increment;

--- a/middle_end/flambda2.0/types/env/typing_env.rec.mli
+++ b/middle_end/flambda2.0/types/env/typing_env.rec.mli
@@ -24,7 +24,7 @@ val print : Format.formatter -> t -> unit
 
 val create : resolver:(Export_id.t -> Type_grammar.t option) -> t
 
-val create_using_resolver_and_symbol_bindings_from : t -> t
+val closure_env : t -> t
 
 val resolver : t -> (Export_id.t -> Type_grammar.t option)
 

--- a/middle_end/flambda2.0/types/flambda_type.mli
+++ b/middle_end/flambda2.0/types/flambda_type.mli
@@ -69,7 +69,7 @@ module Typing_env : sig
 
   val create : resolver:(Export_id.t -> flambda_type option) -> t
 
-  val create_using_resolver_and_symbol_bindings_from : t -> t
+  val closure_env : t -> t
 
   val resolver : t -> (Export_id.t -> flambda_type option)
 


### PR DESCRIPTION
It looks like `DE.enter_closure` is problematic on very large files.  Indeed I suspect it's quadratic at the moment, since every time we enter a closure, we examine the types of all symbol bindings in the environment thus far (of which there be very many, likewise many closures one after the other).  This implementation with luck is much more efficient and brings `DE.enter_closure` to comparable efficiency as with Flambda 1.