### PR TITLE
Fix destroyed_at_oper for Iexit with traps

### DIFF
--- a/asmcomp/amd64/proc.ml
+++ b/asmcomp/amd64/proc.ml
@@ -310,6 +310,11 @@ let destroyed_at_alloc =
   in
   Array.concat [regs; destroyed_by_plt_stub]
 
+let rec has_push_traps = function
+  | [] -> false
+  | Pop :: traps -> has_push_traps traps
+  | Push _ :: _ -> true
+
 let destroyed_at_oper = function
     Iop(Icall_ind _ | Icall_imm _ | Iextcall { alloc = true; }) ->
     all_phys_regs
@@ -326,6 +331,7 @@ let destroyed_at_oper = function
       [| loc_spacetime_node_hole |]
   | Iswitch(_, _) -> [| rax; rdx |]
   | Itrywith _ -> [| r11 |]
+  | Iexit (_, traps) when has_push_traps traps -> [| r11 |]
   | _ ->
     if fp then
 (* prevent any use of the frame pointer ! *)

--- a/asmcomp/i386/proc.ml
+++ b/asmcomp/i386/proc.ml
@@ -200,6 +200,11 @@ let regs_are_volatile rs =
 let destroyed_at_c_call =               (* ebx, esi, edi, ebp preserved *)
   [|eax; ecx; edx|]
 
+let rec has_push_traps = function
+  | [] -> false
+  | Pop :: traps -> has_push_traps traps
+  | Push _ :: _ -> true
+
 let destroyed_at_oper = function
     Iop(Icall_ind _ | Icall_imm _ | Iextcall { alloc = true; _}) ->
     all_phys_regs
@@ -211,6 +216,7 @@ let destroyed_at_oper = function
   | Iop(Iintoffloat) -> [| eax |]
   | Iifthenelse(Ifloattest _, _, _) -> [| eax |]
   | Itrywith _ -> [| edx |]
+  | Iexit (_, traps) when has_push_traps traps -> [| edx |]
   | _ -> [||]
 
 let destroyed_at_raise = all_phys_regs


### PR DESCRIPTION
It seems that only the x86 architectures needs to clobber a register in trywith, so I only updated those.