### PR TITLE
Fix proving functions for Is_int / Get_tag

### DIFF
--- a/flambdatest/mlexamples/lazy_invalid.ml
+++ b/flambdatest/mlexamples/lazy_invalid.ml
@@ -1,0 +1,2 @@
+let x = (fun () -> (fun _ -> Lazy.force (lazy "")) ()) ()
+

--- a/lambda/tag.ml
+++ b/lambda/tag.ml
@@ -63,6 +63,7 @@ let string_tag = Obj.string_tag
 let double_tag = Obj.double_tag
 let double_array_tag = Obj.double_array_tag
 let custom_tag = Obj.custom_tag
+let infix_tag = Obj.infix_tag
 let closure_tag = Obj.closure_tag
 let object_tag = Obj.object_tag
 

--- a/lambda/tag.mli
+++ b/lambda/tag.mli
@@ -36,6 +36,7 @@ val zero : t
 (* CR mshinwell: Remove "_tag" suffixes *)
 val string_tag : t
 val closure_tag : t
+val infix_tag : t
 val double_tag : t
 val double_array_tag : t
 val custom_tag : t

--- a/middle_end/flambda2.0/inlining/inlining_decision.ml
+++ b/middle_end/flambda2.0/inlining/inlining_decision.ml
@@ -14,7 +14,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-[@@@ocaml.warning "+a-4-30-40-41-42"]
+[@@@ocaml.warning "+a-30-40-41-42"]
 
 open! Flambda.Import
 
@@ -131,27 +131,30 @@ let make_decision_for_call_site denv ~function_decl_rec_info
   if (not (DE.can_inline denv)) then
     Environment_says_never_inline
   else
-    match Rec_info.unroll_to function_decl_rec_info with
-    | Some unroll_to ->
-      if Rec_info.depth function_decl_rec_info >= unroll_to then
-        Unrolling_depth_exceeded
-      else
-        Inline { attribute = None; unroll_to = None; }
-    | None ->
-      if apply_inlining_depth >= max_inlining_depth then
-        Max_inlining_depth_exceeded
-      else
-        match inline with
-        | Never_inline -> Never_inline_attribute
-        | Default_inline ->
-          if Rec_info.depth function_decl_rec_info >= max_rec_depth then
-            Recursion_depth_exceeded
-          else
-            Inline { attribute = None; unroll_to = None; }
-        | Unroll unroll_to ->
-          let unroll_to =
-            Rec_info.depth function_decl_rec_info + unroll_to
-          in
-          Inline { attribute = Some Unroll; unroll_to = Some unroll_to; }
-        | Always_inline ->
-          Inline { attribute = Some Always; unroll_to = None; }
+    match inline with
+    | Never_inline -> Never_inline_attribute
+    | Default_inline | Unroll _ | Always_inline ->
+      match Rec_info.unroll_to function_decl_rec_info with
+      | Some unroll_to ->
+        if Rec_info.depth function_decl_rec_info >= unroll_to then
+          Unrolling_depth_exceeded
+        else
+          Inline { attribute = None; unroll_to = None; }
+      | None ->
+        if apply_inlining_depth >= max_inlining_depth then
+          Max_inlining_depth_exceeded
+        else
+          match inline with
+          | Never_inline -> assert false
+          | Default_inline ->
+            if Rec_info.depth function_decl_rec_info >= max_rec_depth then
+              Recursion_depth_exceeded
+            else
+              Inline { attribute = None; unroll_to = None; }
+          | Unroll unroll_to ->
+            let unroll_to =
+              Rec_info.depth function_decl_rec_info + unroll_to
+            in
+            Inline { attribute = Some Unroll; unroll_to = Some unroll_to; }
+          | Always_inline ->
+            Inline { attribute = Some Always; unroll_to = None; }

--- a/middle_end/flambda2.0/types/template/flambda_type.templ.ml
+++ b/middle_end/flambda2.0/types/template/flambda_type.templ.ml
@@ -282,7 +282,7 @@ let prove_is_int env t : bool proof =
         else Unknown
     end
   | Value (Ok (Boxed_float _ | Boxed_int32 _ | Boxed_int64 _
-      | Boxed_nativeint _ | Closures _ | String _ | Array _)) -> Proved true
+      | Boxed_nativeint _ | Closures _ | String _ | Array _)) -> Proved false
   | Value Unknown -> Unknown
   | Value Bottom -> Invalid
   | Naked_immediate _ -> wrong_kind ()

--- a/middle_end/flambda2.0/types/template/flambda_type.templ.ml
+++ b/middle_end/flambda2.0/types/template/flambda_type.templ.ml
@@ -281,7 +281,8 @@ let prove_is_int env t : bool proof =
         if is_bottom env imms then Proved false
         else Unknown
     end
-  | Value (Ok _) -> Invalid
+  | Value (Ok (Boxed_float _ | Boxed_int32 _ | Boxed_int64 _
+      | Boxed_nativeint _ | Closures _ | String _ | Array _)) -> Proved true
   | Value Unknown -> Unknown
   | Value Bottom -> Invalid
   | Naked_immediate _ -> wrong_kind ()
@@ -315,7 +316,11 @@ let prove_tags_must_be_a_block env t : Tag.Set.t proof =
             if Tag.Set.is_empty tags then Invalid
             else Proved tags
     end
-  | Value (Ok _) -> Invalid
+  | Value (Ok (Boxed_float _ | Boxed_int32 _ | Boxed_int64 _
+      | Boxed_nativeint _)) -> Proved (Tag.Set.singleton Tag.custom_tag)
+  | Value (Ok (Closures _)) -> Proved (Tag.Set.singleton Tag.closure_tag)
+  | Value (Ok (String _)) -> Proved (Tag.Set.singleton Tag.string_tag)
+  | Value (Ok (Array _)) -> Proved (Tag.Set.singleton Tag.zero)
   | Value Unknown -> Unknown
   | Value Bottom -> Invalid
   (* CR mshinwell: Here and elsewhere, use or-patterns. *)
@@ -654,7 +659,7 @@ let prove_strings env t : String_info.Set.t proof =
   | Const _ ->
     if K.equal (kind t) K.value then Invalid
     else wrong_kind ()
-  | Value (Ok (String strs)) -> Proved strs      
+  | Value (Ok (String strs)) -> Proved strs
   | Value (Ok _) -> Invalid
   | Value Unknown -> Unknown
   | Value Bottom -> Invalid

--- a/middle_end/flambda2.0/types/template/flambda_type.templ.ml
+++ b/middle_end/flambda2.0/types/template/flambda_type.templ.ml
@@ -318,9 +318,11 @@ let prove_tags_must_be_a_block env t : Tag.Set.t proof =
     end
   | Value (Ok (Boxed_float _ | Boxed_int32 _ | Boxed_int64 _
       | Boxed_nativeint _)) -> Proved (Tag.Set.singleton Tag.custom_tag)
-  | Value (Ok (Closures _)) -> Proved (Tag.Set.singleton Tag.closure_tag)
+  | Value (Ok (Closures _)) ->
+    Proved (Tag.Set.of_list [Tag.closure_tag; Tag.infix_tag])
   | Value (Ok (String _)) -> Proved (Tag.Set.singleton Tag.string_tag)
-  | Value (Ok (Array _)) -> Proved (Tag.Set.singleton Tag.zero)
+  | Value (Ok (Array _)) ->
+    Proved (Tag.Set.of_list [Tag.zero; Tag.double_array_tag])
   | Value Unknown -> Unknown
   | Value Bottom -> Invalid
   (* CR mshinwell: Here and elsewhere, use or-patterns. *)

--- a/middle_end/flambda2.0/types/type_of_kind/type_of_kind_value0.rec.mli
+++ b/middle_end/flambda2.0/types/type_of_kind/type_of_kind_value0.rec.mli
@@ -26,6 +26,7 @@ type t =
       by_closure_id : Row_like.For_closures_entry_by_set_of_closures_contents.t;
     }
   | String of String_info.Set.t
+  (* CR-someday mshinwell: [Array] should know what kind of array it is. *)
   | Array of { length : Type_grammar.t; }
 
 include Type_head_intf.S


### PR DESCRIPTION
The lazy-force code in `Matching` uses `Pisint` on `String_tag` values.  I've fixed our proving function to allow this.  I also noticed that the one for proving tags returns `Invalid` in too many cases, so fixed that too.

There is also a minor fix to `Inlining_decision` to make sure `[@inlined never]` takes precedence over anything else; this was found whilst debugging the same test case.