### PR TITLE
Overhaul of block and array kinds etc.

### DIFF
--- a/.depend
+++ b/.depend
@@ -5237,20 +5237,6 @@ middle_end/flambda2.0/compilenv_deps/flambda_features.cmx : \
     utils/clflags.cmx \
     middle_end/flambda2.0/compilenv_deps/flambda_features.cmi
 middle_end/flambda2.0/compilenv_deps/flambda_features.cmi :
-middle_end/flambda2.0/compilenv_deps/target_imm.cmo : \
-    utils/targetint.cmi \
-    lambda/tag.cmi \
-    utils/identifiable.cmi \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi
-middle_end/flambda2.0/compilenv_deps/target_imm.cmx : \
-    utils/targetint.cmx \
-    lambda/tag.cmx \
-    utils/identifiable.cmx \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi
-middle_end/flambda2.0/compilenv_deps/target_imm.cmi : \
-    utils/targetint.cmi \
-    lambda/tag.cmi \
-    utils/identifiable.cmi
 middle_end/flambda2.0/compilenv_deps/linkage_name.cmo : \
     utils/identifiable.cmi \
     middle_end/flambda2.0/compilenv_deps/linkage_name.cmi
@@ -5290,6 +5276,7 @@ middle_end/flambda2.0/compilenv_deps/rec_info.cmi : \
     utils/identifiable.cmi
 middle_end/flambda2.0/compilenv_deps/reg_width_things.cmo : \
     utils/targetint.cmi \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     middle_end/flambda2.0/compilenv_deps/table_by_int_id.cmi \
     middle_end/flambda2.0/compilenv_deps/rec_info.cmi \
     middle_end/flambda2.0/compilenv_deps/patricia_tree.cmi \
@@ -5297,13 +5284,13 @@ middle_end/flambda2.0/compilenv_deps/reg_width_things.cmo : \
     utils/misc.cmi \
     middle_end/flambda2.0/compilenv_deps/linkage_name.cmi \
     utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     utils/identifiable.cmi \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda2.0/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda2.0/compilenv_deps/reg_width_things.cmi
 middle_end/flambda2.0/compilenv_deps/reg_width_things.cmx : \
     utils/targetint.cmx \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     middle_end/flambda2.0/compilenv_deps/table_by_int_id.cmx \
     middle_end/flambda2.0/compilenv_deps/rec_info.cmx \
     middle_end/flambda2.0/compilenv_deps/patricia_tree.cmx \
@@ -5311,18 +5298,17 @@ middle_end/flambda2.0/compilenv_deps/reg_width_things.cmx : \
     utils/misc.cmx \
     middle_end/flambda2.0/compilenv_deps/linkage_name.cmx \
     utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     utils/identifiable.cmx \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda2.0/compilenv_deps/compilation_unit.cmx \
     middle_end/flambda2.0/compilenv_deps/reg_width_things.cmi
 middle_end/flambda2.0/compilenv_deps/reg_width_things.cmi : \
     utils/targetint.cmi \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     middle_end/flambda2.0/compilenv_deps/table_by_int_id.cmi \
     middle_end/flambda2.0/compilenv_deps/rec_info.cmi \
     utils/numbers.cmi \
     middle_end/flambda2.0/compilenv_deps/linkage_name.cmi \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     utils/identifiable.cmi \
     middle_end/flambda2.0/compilenv_deps/compilation_unit.cmi
 middle_end/flambda2.0/compilenv_deps/symbol.cmo : \
@@ -5349,6 +5335,20 @@ middle_end/flambda2.0/compilenv_deps/table_by_int_id.cmx : \
     utils/misc.cmx \
     middle_end/flambda2.0/compilenv_deps/table_by_int_id.cmi
 middle_end/flambda2.0/compilenv_deps/table_by_int_id.cmi :
+middle_end/flambda2.0/compilenv_deps/target_imm.cmo : \
+    utils/targetint.cmi \
+    lambda/tag.cmi \
+    utils/identifiable.cmi \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi
+middle_end/flambda2.0/compilenv_deps/target_imm.cmx : \
+    utils/targetint.cmx \
+    lambda/tag.cmx \
+    utils/identifiable.cmx \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi
+middle_end/flambda2.0/compilenv_deps/target_imm.cmi : \
+    utils/targetint.cmi \
+    lambda/tag.cmi \
+    utils/identifiable.cmi
 middle_end/flambda2.0/compilenv_deps/variable.cmo : \
     middle_end/flambda2.0/compilenv_deps/reg_width_things.cmi \
     utils/misc.cmi \
@@ -5532,10 +5532,13 @@ middle_end/flambda2.0/basic/continuation_extra_params_and_args.cmi : \
     middle_end/flambda2.0/terms/flambda_primitive.cmi \
     middle_end/flambda2.0/basic/apply_cont_rewrite_id.cmi
 middle_end/flambda2.0/basic/effects.cmo : \
+    middle_end/flambda2.0/basic/mutable_or_immutable.cmi \
     middle_end/flambda2.0/basic/effects.cmi
 middle_end/flambda2.0/basic/effects.cmx : \
+    middle_end/flambda2.0/basic/mutable_or_immutable.cmx \
     middle_end/flambda2.0/basic/effects.cmi
-middle_end/flambda2.0/basic/effects.cmi :
+middle_end/flambda2.0/basic/effects.cmi : \
+    middle_end/flambda2.0/basic/mutable_or_immutable.cmi
 middle_end/flambda2.0/basic/effects_and_coeffects.cmo : \
     middle_end/flambda2.0/basic/effects.cmi \
     middle_end/flambda2.0/basic/coeffects.cmi \
@@ -5693,10 +5696,13 @@ middle_end/flambda2.0/basic/kinded_parameter.cmi : \
     middle_end/flambda2.0/naming/contains_names.cmo \
     middle_end/flambda2.0/naming/bindable.cmo
 middle_end/flambda2.0/basic/mutable_or_immutable.cmo : \
+    parsing/asttypes.cmi \
     middle_end/flambda2.0/basic/mutable_or_immutable.cmi
 middle_end/flambda2.0/basic/mutable_or_immutable.cmx : \
+    parsing/asttypes.cmi \
     middle_end/flambda2.0/basic/mutable_or_immutable.cmi
-middle_end/flambda2.0/basic/mutable_or_immutable.cmi :
+middle_end/flambda2.0/basic/mutable_or_immutable.cmi : \
+    parsing/asttypes.cmi
 middle_end/flambda2.0/basic/name.cmo : \
     middle_end/flambda2.0/compilenv_deps/variable.cmi \
     middle_end/flambda2.0/compilenv_deps/symbol.cmi \
@@ -5850,6 +5856,7 @@ middle_end/flambda2.0/from_lambda/closure_conversion.cmo : \
     middle_end/flambda2.0/naming/var_in_binding_pos.cmi \
     middle_end/flambda2.0/basic/trap_action.cmi \
     utils/targetint.cmi \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     lambda/tag.cmi \
     middle_end/flambda2.0/compilenv_deps/symbol.cmi \
     utils/strongly_connected_components.cmi \
@@ -5869,7 +5876,6 @@ middle_end/flambda2.0/from_lambda/closure_conversion.cmo : \
     lambda/lambda.cmi \
     middle_end/flambda2.0/basic/kinded_parameter.cmi \
     utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     middle_end/flambda2.0/from_lambda/ilambda.cmi \
     typing/ident.cmi \
     middle_end/flambda2.0/terms/flambda_unit.cmi \
@@ -5899,6 +5905,7 @@ middle_end/flambda2.0/from_lambda/closure_conversion.cmx : \
     middle_end/flambda2.0/naming/var_in_binding_pos.cmx \
     middle_end/flambda2.0/basic/trap_action.cmx \
     utils/targetint.cmx \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     lambda/tag.cmx \
     middle_end/flambda2.0/compilenv_deps/symbol.cmx \
     utils/strongly_connected_components.cmx \
@@ -5918,7 +5925,6 @@ middle_end/flambda2.0/from_lambda/closure_conversion.cmx : \
     lambda/lambda.cmx \
     middle_end/flambda2.0/basic/kinded_parameter.cmx \
     utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     middle_end/flambda2.0/from_lambda/ilambda.cmx \
     typing/ident.cmx \
     middle_end/flambda2.0/terms/flambda_unit.cmx \
@@ -6071,40 +6077,49 @@ middle_end/flambda2.0/from_lambda/ilambda.cmi : \
     parsing/asttypes.cmi
 middle_end/flambda2.0/from_lambda/lambda_conversions.cmo : \
     middle_end/flambda2.0/basic/trap_action.cmi \
+    utils/targetint.cmi \
     typing/primitive.cmi \
+    middle_end/flambda2.0/types/basic/or_unknown.cmi \
+    middle_end/flambda2.0/basic/mutable_or_immutable.cmi \
     utils/misc.cmi \
     lambda/lambda.cmi \
     middle_end/flambda2.0/basic/inline_attribute.cmi \
     middle_end/flambda2.0/terms/flambda_primitive.cmi \
     middle_end/flambda2.0/types/kinds/flambda_kind.cmi \
-    middle_end/flambda2.0/basic/effects.cmi \
+    utils/config.cmi \
     middle_end/flambda2.0/terms/call_kind.cmi \
     parsing/asttypes.cmi \
     middle_end/flambda2.0/from_lambda/lambda_conversions.cmi
 middle_end/flambda2.0/from_lambda/lambda_conversions.cmx : \
     middle_end/flambda2.0/basic/trap_action.cmx \
+    utils/targetint.cmx \
     typing/primitive.cmx \
+    middle_end/flambda2.0/types/basic/or_unknown.cmx \
+    middle_end/flambda2.0/basic/mutable_or_immutable.cmx \
     utils/misc.cmx \
     lambda/lambda.cmx \
     middle_end/flambda2.0/basic/inline_attribute.cmx \
     middle_end/flambda2.0/terms/flambda_primitive.cmx \
     middle_end/flambda2.0/types/kinds/flambda_kind.cmx \
-    middle_end/flambda2.0/basic/effects.cmx \
+    utils/config.cmx \
     middle_end/flambda2.0/terms/call_kind.cmx \
     parsing/asttypes.cmi \
     middle_end/flambda2.0/from_lambda/lambda_conversions.cmi
 middle_end/flambda2.0/from_lambda/lambda_conversions.cmi : \
     middle_end/flambda2.0/basic/trap_action.cmi \
+    utils/targetint.cmi \
     typing/primitive.cmi \
+    middle_end/flambda2.0/types/basic/or_unknown.cmi \
+    middle_end/flambda2.0/basic/mutable_or_immutable.cmi \
     lambda/lambda.cmi \
     middle_end/flambda2.0/basic/inline_attribute.cmi \
     middle_end/flambda2.0/terms/flambda_primitive.cmi \
     middle_end/flambda2.0/types/kinds/flambda_kind.cmi \
-    middle_end/flambda2.0/basic/effects.cmi \
     middle_end/flambda2.0/terms/call_kind.cmi \
     parsing/asttypes.cmi
 middle_end/flambda2.0/from_lambda/lambda_to_flambda_primitives.cmo : \
     utils/targetint.cmi \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     lambda/tag.cmi \
     middle_end/flambda2.0/basic/simple.cmi \
     middle_end/flambda2.0/basic/reg_width_const.cmi \
@@ -6113,7 +6128,6 @@ middle_end/flambda2.0/from_lambda/lambda_to_flambda_primitives.cmo : \
     middle_end/flambda2.0/from_lambda/lambda_to_flambda_primitives_helpers.cmi \
     middle_end/flambda2.0/from_lambda/lambda_conversions.cmi \
     lambda/lambda.cmi \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     middle_end/flambda2.0/terms/flambda_primitive.cmi \
     middle_end/flambda2.0/types/kinds/flambda_kind.cmi \
     middle_end/flambda2.0/flambda2_backend_intf.cmi \
@@ -6122,6 +6136,7 @@ middle_end/flambda2.0/from_lambda/lambda_to_flambda_primitives.cmo : \
     middle_end/flambda2.0/from_lambda/lambda_to_flambda_primitives.cmi
 middle_end/flambda2.0/from_lambda/lambda_to_flambda_primitives.cmx : \
     utils/targetint.cmx \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     lambda/tag.cmx \
     middle_end/flambda2.0/basic/simple.cmx \
     middle_end/flambda2.0/basic/reg_width_const.cmx \
@@ -6130,7 +6145,6 @@ middle_end/flambda2.0/from_lambda/lambda_to_flambda_primitives.cmx : \
     middle_end/flambda2.0/from_lambda/lambda_to_flambda_primitives_helpers.cmx \
     middle_end/flambda2.0/from_lambda/lambda_conversions.cmx \
     lambda/lambda.cmx \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     middle_end/flambda2.0/terms/flambda_primitive.cmx \
     middle_end/flambda2.0/types/kinds/flambda_kind.cmx \
     middle_end/flambda2.0/flambda2_backend_intf.cmi \
@@ -6150,11 +6164,11 @@ middle_end/flambda2.0/from_lambda/lambda_to_flambda_primitives_helpers.cmo : \
     middle_end/flambda2.0/compilenv_deps/variable.cmi \
     middle_end/flambda2.0/naming/var_in_binding_pos.cmi \
     middle_end/flambda2.0/basic/trap_action.cmi \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     lambda/tag.cmi \
     middle_end/flambda2.0/basic/simple.cmi \
     middle_end/flambda2.0/naming/name_mode.cmi \
     utils/misc.cmi \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     middle_end/flambda2.0/terms/flambda_primitive.cmi \
     middle_end/flambda2.0/flambda2_backend_intf.cmi \
     middle_end/flambda2.0/terms/flambda.cmi \
@@ -6167,11 +6181,11 @@ middle_end/flambda2.0/from_lambda/lambda_to_flambda_primitives_helpers.cmx : \
     middle_end/flambda2.0/compilenv_deps/variable.cmx \
     middle_end/flambda2.0/naming/var_in_binding_pos.cmx \
     middle_end/flambda2.0/basic/trap_action.cmx \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     lambda/tag.cmx \
     middle_end/flambda2.0/basic/simple.cmx \
     middle_end/flambda2.0/naming/name_mode.cmx \
     utils/misc.cmx \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     middle_end/flambda2.0/terms/flambda_primitive.cmx \
     middle_end/flambda2.0/flambda2_backend_intf.cmi \
     middle_end/flambda2.0/terms/flambda.cmx \
@@ -6194,10 +6208,10 @@ middle_end/flambda2.0/from_lambda/prepare_lambda.cmo : \
     lambda/tag.cmi \
     lambda/simplif.cmi \
     lambda/printlambda.cmi \
+    typing/primitive.cmi \
     utils/numbers.cmi \
     utils/misc.cmi \
     lambda/matching.cmi \
-    parsing/location.cmi \
     middle_end/flambda2.0/from_lambda/lambda_conversions.cmi \
     lambda/lambda.cmi \
     typing/ident.cmi \
@@ -6208,10 +6222,10 @@ middle_end/flambda2.0/from_lambda/prepare_lambda.cmx : \
     lambda/tag.cmx \
     lambda/simplif.cmx \
     lambda/printlambda.cmx \
+    typing/primitive.cmx \
     utils/numbers.cmx \
     utils/misc.cmx \
     lambda/matching.cmx \
-    parsing/location.cmx \
     middle_end/flambda2.0/from_lambda/lambda_conversions.cmx \
     lambda/lambda.cmx \
     typing/ident.cmx \
@@ -6221,6 +6235,7 @@ middle_end/flambda2.0/from_lambda/prepare_lambda.cmi : \
     utils/numbers.cmi \
     lambda/lambda.cmi
 middle_end/flambda2.0/inlining/inlining_cost.cmo : \
+    utils/targetint.cmi \
     lambda/switch.cmi \
     middle_end/flambda2.0/simplify/env/simplify_env_and_result.cmi \
     middle_end/flambda2.0/basic/simple.cmi \
@@ -6228,12 +6243,14 @@ middle_end/flambda2.0/inlining/inlining_cost.cmo : \
     middle_end/flambda2.0/terms/function_declarations.cmi \
     middle_end/flambda2.0/terms/function_declaration.cmi \
     middle_end/flambda2.0/terms/flambda_primitive.cmi \
+    middle_end/flambda2.0/types/kinds/flambda_kind.cmi \
     middle_end/flambda2.0/terms/flambda.cmi \
     middle_end/flambda2.0/basic/continuation.cmi \
     middle_end/flambda2.0/basic/closure_id.cmi \
     utils/clflags.cmi \
     middle_end/flambda2.0/inlining/inlining_cost.cmi
 middle_end/flambda2.0/inlining/inlining_cost.cmx : \
+    utils/targetint.cmx \
     lambda/switch.cmx \
     middle_end/flambda2.0/simplify/env/simplify_env_and_result.cmx \
     middle_end/flambda2.0/basic/simple.cmx \
@@ -6241,6 +6258,7 @@ middle_end/flambda2.0/inlining/inlining_cost.cmx : \
     middle_end/flambda2.0/terms/function_declarations.cmx \
     middle_end/flambda2.0/terms/function_declaration.cmx \
     middle_end/flambda2.0/terms/flambda_primitive.cmx \
+    middle_end/flambda2.0/types/kinds/flambda_kind.cmx \
     middle_end/flambda2.0/terms/flambda.cmx \
     middle_end/flambda2.0/basic/continuation.cmx \
     middle_end/flambda2.0/basic/closure_id.cmx \
@@ -6400,6 +6418,7 @@ middle_end/flambda2.0/lifting/reify_continuation_param_types.cmi : \
     middle_end/flambda2.0/simplify/env/downwards_acc.cmi \
     middle_end/flambda2.0/basic/continuation_extra_params_and_args.cmi
 middle_end/flambda2.0/lifting/sort_lifted_constants.cmo : \
+    middle_end/flambda2.0/compilenv_deps/variable.cmi \
     middle_end/flambda2.0/compilenv_deps/symbol.cmi \
     utils/strongly_connected_components.cmi \
     middle_end/flambda2.0/simplify/simplify_import.cmi \
@@ -6407,9 +6426,12 @@ middle_end/flambda2.0/lifting/sort_lifted_constants.cmo : \
     middle_end/flambda2.0/naming/name_occurrences.cmi \
     middle_end/flambda2.0/basic/name.cmi \
     utils/misc.cmi \
+    middle_end/flambda2.0/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda2.0/basic/code_id_or_symbol.cmi \
+    utils/clflags.cmi \
     middle_end/flambda2.0/lifting/sort_lifted_constants.cmi
 middle_end/flambda2.0/lifting/sort_lifted_constants.cmx : \
+    middle_end/flambda2.0/compilenv_deps/variable.cmx \
     middle_end/flambda2.0/compilenv_deps/symbol.cmx \
     utils/strongly_connected_components.cmx \
     middle_end/flambda2.0/simplify/simplify_import.cmx \
@@ -6417,7 +6439,9 @@ middle_end/flambda2.0/lifting/sort_lifted_constants.cmx : \
     middle_end/flambda2.0/naming/name_occurrences.cmx \
     middle_end/flambda2.0/basic/name.cmx \
     utils/misc.cmx \
+    middle_end/flambda2.0/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda2.0/basic/code_id_or_symbol.cmx \
+    utils/clflags.cmx \
     middle_end/flambda2.0/lifting/sort_lifted_constants.cmi
 middle_end/flambda2.0/lifting/sort_lifted_constants.cmi : \
     middle_end/flambda2.0/simplify/simplify_import.cmi \
@@ -6756,6 +6780,7 @@ middle_end/flambda2.0/simplify/simplify.cmo : \
     middle_end/flambda2.0/naming/var_in_binding_pos.cmi \
     middle_end/flambda2.0/simplify/env/upwards_acc.cmi \
     middle_end/flambda2.0/unboxing/unbox_continuation_params.cmi \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     lambda/tag.cmi \
     middle_end/flambda2.0/compilenv_deps/symbol.cmi \
     lambda/switch.cmi \
@@ -6786,7 +6811,6 @@ middle_end/flambda2.0/simplify/simplify.cmo : \
     middle_end/flambda2.0/basic/kinded_parameter.cmi \
     middle_end/flambda2.0/inlining/inlining_transforms.cmi \
     middle_end/flambda2.0/inlining/inlining_decision.cmi \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     middle_end/flambda2.0/terms/function_declarations.cmi \
     middle_end/flambda2.0/terms/function_declaration.cmi \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmi \
@@ -6817,6 +6841,7 @@ middle_end/flambda2.0/simplify/simplify.cmx : \
     middle_end/flambda2.0/naming/var_in_binding_pos.cmx \
     middle_end/flambda2.0/simplify/env/upwards_acc.cmx \
     middle_end/flambda2.0/unboxing/unbox_continuation_params.cmx \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     lambda/tag.cmx \
     middle_end/flambda2.0/compilenv_deps/symbol.cmx \
     lambda/switch.cmx \
@@ -6847,7 +6872,6 @@ middle_end/flambda2.0/simplify/simplify.cmx : \
     middle_end/flambda2.0/basic/kinded_parameter.cmx \
     middle_end/flambda2.0/inlining/inlining_transforms.cmx \
     middle_end/flambda2.0/inlining/inlining_decision.cmx \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     middle_end/flambda2.0/terms/function_declarations.cmx \
     middle_end/flambda2.0/terms/function_declaration.cmx \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmx \
@@ -6877,17 +6901,19 @@ middle_end/flambda2.0/simplify/simplify.cmi : \
 middle_end/flambda2.0/simplify/simplify_binary_primitive.cmo : \
     middle_end/flambda2.0/naming/var_in_binding_pos.cmi \
     utils/targetint.cmi \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
+    lambda/tag.cmi \
     middle_end/flambda2.0/simplify/simplify_import.cmi \
     middle_end/flambda2.0/simplify/simplify_common.cmi \
     middle_end/flambda2.0/basic/simple.cmi \
     middle_end/flambda2.0/basic/reg_width_const.cmi \
     middle_end/flambda2.0/simplify/basic/reachable.cmi \
+    middle_end/flambda2.0/types/basic/or_unknown.cmi \
     utils/numbers.cmi \
     middle_end/flambda2.0/simplify/typing_helpers/number_adjuncts.cmi \
     middle_end/flambda2.0/naming/name_mode.cmi \
     middle_end/flambda2.0/basic/name.cmi \
     utils/misc.cmi \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     utils/identifiable.cmi \
     middle_end/flambda2.0/types/flambda_type.cmi \
     lambda/debuginfo.cmi \
@@ -6895,17 +6921,19 @@ middle_end/flambda2.0/simplify/simplify_binary_primitive.cmo : \
 middle_end/flambda2.0/simplify/simplify_binary_primitive.cmx : \
     middle_end/flambda2.0/naming/var_in_binding_pos.cmx \
     utils/targetint.cmx \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
+    lambda/tag.cmx \
     middle_end/flambda2.0/simplify/simplify_import.cmx \
     middle_end/flambda2.0/simplify/simplify_common.cmx \
     middle_end/flambda2.0/basic/simple.cmx \
     middle_end/flambda2.0/basic/reg_width_const.cmx \
     middle_end/flambda2.0/simplify/basic/reachable.cmx \
+    middle_end/flambda2.0/types/basic/or_unknown.cmx \
     utils/numbers.cmx \
     middle_end/flambda2.0/simplify/typing_helpers/number_adjuncts.cmx \
     middle_end/flambda2.0/naming/name_mode.cmx \
     middle_end/flambda2.0/basic/name.cmx \
     utils/misc.cmx \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     utils/identifiable.cmx \
     middle_end/flambda2.0/types/flambda_type.cmx \
     lambda/debuginfo.cmx \
@@ -6980,6 +7008,7 @@ middle_end/flambda2.0/simplify/simplify_expr.rec.cmo : \
     middle_end/flambda2.0/compilenv_deps/variable.cmi \
     middle_end/flambda2.0/basic/var_within_closure.cmi \
     middle_end/flambda2.0/unboxing/unbox_continuation_params.cmi \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     lambda/switch.cmi \
     middle_end/flambda2.0/lifting/sort_lifted_constants.cmi \
     middle_end/flambda2.0/simplify/simplify_import.cmi \
@@ -6999,7 +7028,6 @@ middle_end/flambda2.0/simplify/simplify_expr.rec.cmo : \
     middle_end/flambda2.0/basic/kinded_parameter.cmi \
     middle_end/flambda2.0/inlining/inlining_transforms.cmi \
     middle_end/flambda2.0/inlining/inlining_decision.cmi \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     middle_end/flambda2.0/terms/function_declarations.cmi \
     middle_end/flambda2.0/terms/function_declaration.cmi \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmi \
@@ -7026,6 +7054,7 @@ middle_end/flambda2.0/simplify/simplify_expr.rec.cmx : \
     middle_end/flambda2.0/compilenv_deps/variable.cmx \
     middle_end/flambda2.0/basic/var_within_closure.cmx \
     middle_end/flambda2.0/unboxing/unbox_continuation_params.cmx \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     lambda/switch.cmx \
     middle_end/flambda2.0/lifting/sort_lifted_constants.cmx \
     middle_end/flambda2.0/simplify/simplify_import.cmx \
@@ -7045,7 +7074,6 @@ middle_end/flambda2.0/simplify/simplify_expr.rec.cmx : \
     middle_end/flambda2.0/basic/kinded_parameter.cmx \
     middle_end/flambda2.0/inlining/inlining_transforms.cmx \
     middle_end/flambda2.0/inlining/inlining_decision.cmx \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     middle_end/flambda2.0/terms/function_declarations.cmx \
     middle_end/flambda2.0/terms/function_declaration.cmx \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmx \
@@ -7331,6 +7359,7 @@ middle_end/flambda2.0/simplify/simplify_toplevel.rec.cmi : \
 middle_end/flambda2.0/simplify/simplify_unary_primitive.cmo : \
     middle_end/flambda2.0/naming/var_in_binding_pos.cmi \
     utils/targetint.cmi \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     middle_end/flambda2.0/types/basic/string_info.cmi \
     middle_end/flambda2.0/simplify/simplify_import.cmi \
     middle_end/flambda2.0/simplify/simplify_common.cmi \
@@ -7340,12 +7369,12 @@ middle_end/flambda2.0/simplify/simplify_unary_primitive.cmo : \
     middle_end/flambda2.0/simplify/typing_helpers/number_adjuncts.cmi \
     middle_end/flambda2.0/naming/name_mode.cmi \
     middle_end/flambda2.0/basic/name.cmi \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     middle_end/flambda2.0/basic/closure_id.cmi \
     middle_end/flambda2.0/simplify/simplify_unary_primitive.cmi
 middle_end/flambda2.0/simplify/simplify_unary_primitive.cmx : \
     middle_end/flambda2.0/naming/var_in_binding_pos.cmx \
     utils/targetint.cmx \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     middle_end/flambda2.0/types/basic/string_info.cmx \
     middle_end/flambda2.0/simplify/simplify_import.cmx \
     middle_end/flambda2.0/simplify/simplify_common.cmx \
@@ -7355,7 +7384,6 @@ middle_end/flambda2.0/simplify/simplify_unary_primitive.cmx : \
     middle_end/flambda2.0/simplify/typing_helpers/number_adjuncts.cmx \
     middle_end/flambda2.0/naming/name_mode.cmx \
     middle_end/flambda2.0/basic/name.cmx \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     middle_end/flambda2.0/basic/closure_id.cmx \
     middle_end/flambda2.0/simplify/simplify_unary_primitive.cmi
 middle_end/flambda2.0/simplify/simplify_unary_primitive.cmi : \
@@ -7375,8 +7403,8 @@ middle_end/flambda2.0/simplify/simplify_variadic_primitive.cmo : \
     middle_end/flambda2.0/simplify/basic/reachable.cmi \
     middle_end/flambda2.0/naming/name_mode.cmi \
     middle_end/flambda2.0/basic/name.cmi \
+    middle_end/flambda2.0/basic/mutable_or_immutable.cmi \
     utils/misc.cmi \
-    middle_end/flambda2.0/basic/effects.cmi \
     middle_end/flambda2.0/simplify/simplify_variadic_primitive.cmi
 middle_end/flambda2.0/simplify/simplify_variadic_primitive.cmx : \
     middle_end/flambda2.0/naming/var_in_binding_pos.cmx \
@@ -7387,8 +7415,8 @@ middle_end/flambda2.0/simplify/simplify_variadic_primitive.cmx : \
     middle_end/flambda2.0/simplify/basic/reachable.cmx \
     middle_end/flambda2.0/naming/name_mode.cmx \
     middle_end/flambda2.0/basic/name.cmx \
+    middle_end/flambda2.0/basic/mutable_or_immutable.cmx \
     utils/misc.cmx \
-    middle_end/flambda2.0/basic/effects.cmx \
     middle_end/flambda2.0/simplify/simplify_variadic_primitive.cmi
 middle_end/flambda2.0/simplify/simplify_variadic_primitive.cmi : \
     middle_end/flambda2.0/naming/var_in_binding_pos.cmi \
@@ -7696,11 +7724,11 @@ middle_end/flambda2.0/simplify/typing_helpers/continuation_uses.cmi : \
     middle_end/flambda2.0/basic/apply_cont_rewrite_id.cmi
 middle_end/flambda2.0/simplify/typing_helpers/number_adjuncts.cmo : \
     utils/targetint.cmi \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     middle_end/flambda2.0/basic/simple.cmi \
     middle_end/flambda2.0/basic/reg_width_const.cmi \
     utils/numbers.cmi \
     utils/misc.cmi \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     utils/identifiable.cmi \
     middle_end/flambda2.0/types/flambda_type.cmi \
     middle_end/flambda2.0/types/kinds/flambda_kind.cmi \
@@ -7708,11 +7736,11 @@ middle_end/flambda2.0/simplify/typing_helpers/number_adjuncts.cmo : \
     middle_end/flambda2.0/simplify/typing_helpers/number_adjuncts.cmi
 middle_end/flambda2.0/simplify/typing_helpers/number_adjuncts.cmx : \
     utils/targetint.cmx \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     middle_end/flambda2.0/basic/simple.cmx \
     middle_end/flambda2.0/basic/reg_width_const.cmx \
     utils/numbers.cmx \
     utils/misc.cmx \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     utils/identifiable.cmx \
     middle_end/flambda2.0/types/flambda_type.cmx \
     middle_end/flambda2.0/types/kinds/flambda_kind.cmx \
@@ -7720,9 +7748,9 @@ middle_end/flambda2.0/simplify/typing_helpers/number_adjuncts.cmx : \
     middle_end/flambda2.0/simplify/typing_helpers/number_adjuncts.cmi
 middle_end/flambda2.0/simplify/typing_helpers/number_adjuncts.cmi : \
     utils/targetint.cmi \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     middle_end/flambda2.0/basic/reg_width_const.cmi \
     utils/numbers.cmi \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     utils/identifiable.cmi \
     middle_end/flambda2.0/types/flambda_type.cmi \
     middle_end/flambda2.0/types/kinds/flambda_kind.cmi \
@@ -7899,6 +7927,7 @@ middle_end/flambda2.0/terms/continuation_params_and_handler.rec.cmi : \
 middle_end/flambda2.0/terms/expr.rec.cmo : \
     middle_end/flambda2.0/compilenv_deps/variable.cmi \
     middle_end/flambda2.0/naming/var_in_binding_pos.cmi \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     lambda/switch.cmi \
     middle_end/flambda2.0/basic/simple.cmi \
     utils/printing_cache.cmi \
@@ -7907,7 +7936,6 @@ middle_end/flambda2.0/terms/expr.rec.cmo : \
     middle_end/flambda2.0/naming/name_mode.cmi \
     utils/misc.cmi \
     middle_end/flambda2.0/basic/invalid_term_semantics.cmi \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmi \
     utils/clflags.cmi \
     middle_end/flambda2.0/naming/bindable_let_bound.cmi \
@@ -7916,6 +7944,7 @@ middle_end/flambda2.0/terms/expr.rec.cmo : \
 middle_end/flambda2.0/terms/expr.rec.cmx : \
     middle_end/flambda2.0/compilenv_deps/variable.cmx \
     middle_end/flambda2.0/naming/var_in_binding_pos.cmx \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     lambda/switch.cmx \
     middle_end/flambda2.0/basic/simple.cmx \
     utils/printing_cache.cmx \
@@ -7924,7 +7953,6 @@ middle_end/flambda2.0/terms/expr.rec.cmx : \
     middle_end/flambda2.0/naming/name_mode.cmx \
     utils/misc.cmx \
     middle_end/flambda2.0/basic/invalid_term_semantics.cmx \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmx \
     utils/clflags.cmx \
     middle_end/flambda2.0/naming/bindable_let_bound.cmx \
@@ -7932,11 +7960,11 @@ middle_end/flambda2.0/terms/expr.rec.cmx : \
     middle_end/flambda2.0/terms/expr.rec.cmi
 middle_end/flambda2.0/terms/expr.rec.cmi : \
     middle_end/flambda2.0/naming/var_in_binding_pos.cmi \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     lambda/switch.cmi \
     middle_end/flambda2.0/basic/simple.cmi \
     middle_end/flambda2.0/basic/kinded_parameter.cmi \
     middle_end/flambda2.0/basic/invalid_term_semantics.cmi \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     middle_end/flambda2.0/basic/expr_std.cmo \
     middle_end/flambda2.0/naming/bindable_let_bound.cmi \
     middle_end/flambda2.0/terms/apply_cont_expr.cmi
@@ -7944,6 +7972,7 @@ middle_end/flambda2.0/terms/flambda.cmo : \
     middle_end/flambda2.0/compilenv_deps/variable.cmi \
     middle_end/flambda2.0/naming/var_in_binding_pos.cmi \
     utils/targetint.cmi \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     lambda/tag.cmi \
     middle_end/flambda2.0/compilenv_deps/symbol.cmi \
     middle_end/flambda2.0/terms/switch_expr.cmi \
@@ -7964,7 +7993,6 @@ middle_end/flambda2.0/terms/flambda.cmo : \
     middle_end/flambda2.0/basic/kinded_parameter.cmi \
     middle_end/flambda2.0/basic/invariant_env.cmi \
     middle_end/flambda2.0/basic/invalid_term_semantics.cmi \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     utils/identifiable.cmi \
     middle_end/flambda2.0/terms/function_declarations.cmi \
     middle_end/flambda2.0/terms/function_declaration.cmi \
@@ -7992,6 +8020,7 @@ middle_end/flambda2.0/terms/flambda.cmx : \
     middle_end/flambda2.0/compilenv_deps/variable.cmx \
     middle_end/flambda2.0/naming/var_in_binding_pos.cmx \
     utils/targetint.cmx \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     lambda/tag.cmx \
     middle_end/flambda2.0/compilenv_deps/symbol.cmx \
     middle_end/flambda2.0/terms/switch_expr.cmx \
@@ -8012,7 +8041,6 @@ middle_end/flambda2.0/terms/flambda.cmx : \
     middle_end/flambda2.0/basic/kinded_parameter.cmx \
     middle_end/flambda2.0/basic/invariant_env.cmx \
     middle_end/flambda2.0/basic/invalid_term_semantics.cmx \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     utils/identifiable.cmx \
     middle_end/flambda2.0/terms/function_declarations.cmx \
     middle_end/flambda2.0/terms/function_declaration.cmx \
@@ -8040,6 +8068,7 @@ middle_end/flambda2.0/terms/flambda.cmi : \
     middle_end/flambda2.0/compilenv_deps/variable.cmi \
     middle_end/flambda2.0/naming/var_in_binding_pos.cmi \
     utils/targetint.cmi \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     lambda/tag.cmi \
     middle_end/flambda2.0/compilenv_deps/symbol.cmi \
     middle_end/flambda2.0/terms/switch_expr.cmi \
@@ -8052,7 +8081,6 @@ middle_end/flambda2.0/terms/flambda.cmi : \
     middle_end/flambda2.0/basic/mutable_or_immutable.cmi \
     middle_end/flambda2.0/basic/kinded_parameter.cmi \
     middle_end/flambda2.0/basic/invalid_term_semantics.cmi \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     utils/identifiable.cmi \
     middle_end/flambda2.0/terms/function_declarations.cmi \
     middle_end/flambda2.0/terms/function_declaration.cmi \
@@ -8075,8 +8103,10 @@ middle_end/flambda2.0/terms/flambda_primitive.cmo : \
     utils/targetint.cmi \
     lambda/tag.cmi \
     middle_end/flambda2.0/basic/simple.cmi \
+    middle_end/flambda2.0/types/basic/or_unknown.cmi \
     middle_end/flambda2.0/naming/name_occurrences.cmi \
     middle_end/flambda2.0/naming/name_mode.cmi \
+    middle_end/flambda2.0/basic/mutable_or_immutable.cmi \
     utils/misc.cmi \
     lambda/lambda.cmi \
     middle_end/flambda2.0/basic/invariant_env.cmi \
@@ -8084,7 +8114,6 @@ middle_end/flambda2.0/terms/flambda_primitive.cmo : \
     middle_end/flambda2.0/types/kinds/flambda_kind.cmi \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda2.0/basic/effects.cmi \
-    utils/config.cmi \
     middle_end/flambda2.0/basic/coeffects.cmi \
     middle_end/flambda2.0/basic/closure_id.cmi \
     utils/clflags.cmi \
@@ -8094,8 +8123,10 @@ middle_end/flambda2.0/terms/flambda_primitive.cmx : \
     utils/targetint.cmx \
     lambda/tag.cmx \
     middle_end/flambda2.0/basic/simple.cmx \
+    middle_end/flambda2.0/types/basic/or_unknown.cmx \
     middle_end/flambda2.0/naming/name_occurrences.cmx \
     middle_end/flambda2.0/naming/name_mode.cmx \
+    middle_end/flambda2.0/basic/mutable_or_immutable.cmx \
     utils/misc.cmx \
     lambda/lambda.cmx \
     middle_end/flambda2.0/basic/invariant_env.cmx \
@@ -8103,7 +8134,6 @@ middle_end/flambda2.0/terms/flambda_primitive.cmx : \
     middle_end/flambda2.0/types/kinds/flambda_kind.cmx \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda2.0/basic/effects.cmx \
-    utils/config.cmx \
     middle_end/flambda2.0/basic/coeffects.cmx \
     middle_end/flambda2.0/basic/closure_id.cmx \
     utils/clflags.cmx \
@@ -8113,7 +8143,9 @@ middle_end/flambda2.0/terms/flambda_primitive.cmi : \
     utils/targetint.cmi \
     lambda/tag.cmi \
     middle_end/flambda2.0/basic/simple.cmi \
+    middle_end/flambda2.0/types/basic/or_unknown.cmi \
     middle_end/flambda2.0/basic/name.cmi \
+    middle_end/flambda2.0/basic/mutable_or_immutable.cmi \
     lambda/lambda.cmi \
     middle_end/flambda2.0/basic/invariant_env.cmi \
     utils/identifiable.cmi \
@@ -8310,6 +8342,7 @@ middle_end/flambda2.0/terms/let_symbol_expr.rec.cmi : \
     middle_end/flambda2.0/basic/closure_id.cmi
 middle_end/flambda2.0/terms/named.rec.cmo : \
     utils/targetint.cmi \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     middle_end/flambda2.0/basic/simple.cmi \
     middle_end/flambda2.0/terms/set_of_closures.cmi \
     middle_end/flambda2.0/basic/reg_width_const.cmi \
@@ -8317,7 +8350,6 @@ middle_end/flambda2.0/terms/named.rec.cmo : \
     utils/numbers.cmi \
     utils/misc.cmi \
     middle_end/flambda2.0/basic/invariant_env.cmi \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     middle_end/flambda2.0/terms/flambda_primitive.cmi \
     middle_end/flambda2.0/types/kinds/flambda_kind.cmi \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmi \
@@ -8325,6 +8357,7 @@ middle_end/flambda2.0/terms/named.rec.cmo : \
     middle_end/flambda2.0/terms/named.rec.cmi
 middle_end/flambda2.0/terms/named.rec.cmx : \
     utils/targetint.cmx \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     middle_end/flambda2.0/basic/simple.cmx \
     middle_end/flambda2.0/terms/set_of_closures.cmx \
     middle_end/flambda2.0/basic/reg_width_const.cmx \
@@ -8332,7 +8365,6 @@ middle_end/flambda2.0/terms/named.rec.cmx : \
     utils/numbers.cmx \
     utils/misc.cmx \
     middle_end/flambda2.0/basic/invariant_env.cmx \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     middle_end/flambda2.0/terms/flambda_primitive.cmx \
     middle_end/flambda2.0/types/kinds/flambda_kind.cmx \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmx \
@@ -8409,6 +8441,7 @@ middle_end/flambda2.0/terms/set_of_closures.cmi : \
 middle_end/flambda2.0/terms/static_const.rec.cmo : \
     middle_end/flambda2.0/compilenv_deps/variable.cmi \
     utils/targetint.cmi \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     lambda/tag.cmi \
     middle_end/flambda2.0/compilenv_deps/symbol.cmi \
     middle_end/flambda2.0/terms/set_of_closures.cmi \
@@ -8420,7 +8453,6 @@ middle_end/flambda2.0/terms/static_const.rec.cmo : \
     middle_end/flambda2.0/naming/name_mode.cmi \
     middle_end/flambda2.0/basic/mutable_or_immutable.cmi \
     utils/misc.cmi \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     utils/identifiable.cmi \
     middle_end/flambda2.0/types/kinds/flambda_kind.cmi \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmi \
@@ -8429,6 +8461,7 @@ middle_end/flambda2.0/terms/static_const.rec.cmo : \
 middle_end/flambda2.0/terms/static_const.rec.cmx : \
     middle_end/flambda2.0/compilenv_deps/variable.cmx \
     utils/targetint.cmx \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     lambda/tag.cmx \
     middle_end/flambda2.0/compilenv_deps/symbol.cmx \
     middle_end/flambda2.0/terms/set_of_closures.cmx \
@@ -8440,7 +8473,6 @@ middle_end/flambda2.0/terms/static_const.rec.cmx : \
     middle_end/flambda2.0/naming/name_mode.cmx \
     middle_end/flambda2.0/basic/mutable_or_immutable.cmx \
     utils/misc.cmx \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     utils/identifiable.cmx \
     middle_end/flambda2.0/types/kinds/flambda_kind.cmx \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmx \
@@ -8449,6 +8481,7 @@ middle_end/flambda2.0/terms/static_const.rec.cmx : \
 middle_end/flambda2.0/terms/static_const.rec.cmi : \
     middle_end/flambda2.0/compilenv_deps/variable.cmi \
     utils/targetint.cmi \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     lambda/tag.cmi \
     middle_end/flambda2.0/compilenv_deps/symbol.cmi \
     middle_end/flambda2.0/terms/set_of_closures.cmi \
@@ -8456,27 +8489,26 @@ middle_end/flambda2.0/terms/static_const.rec.cmi : \
     utils/numbers.cmi \
     middle_end/flambda2.0/naming/name_occurrences.cmi \
     middle_end/flambda2.0/basic/mutable_or_immutable.cmi \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     utils/identifiable.cmi \
     middle_end/flambda2.0/naming/contains_names.cmo \
     middle_end/flambda2.0/basic/code_id.cmi
 middle_end/flambda2.0/terms/switch_expr.cmo : \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     middle_end/flambda2.0/basic/simple.cmi \
     middle_end/flambda2.0/naming/name_occurrences.cmi \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda2.0/terms/apply_cont_expr.cmi \
     middle_end/flambda2.0/terms/switch_expr.cmi
 middle_end/flambda2.0/terms/switch_expr.cmx : \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     middle_end/flambda2.0/basic/simple.cmx \
     middle_end/flambda2.0/naming/name_occurrences.cmx \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda2.0/terms/apply_cont_expr.cmx \
     middle_end/flambda2.0/terms/switch_expr.cmi
 middle_end/flambda2.0/terms/switch_expr.cmi : \
-    middle_end/flambda2.0/basic/simple.cmi \
     middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
+    middle_end/flambda2.0/basic/simple.cmi \
     middle_end/flambda2.0/basic/expr_std.cmo \
     middle_end/flambda2.0/terms/apply_cont_expr.cmi
 middle_end/flambda2.0/to_cmm/un_cps.cmo : \
@@ -8489,6 +8521,7 @@ middle_end/flambda2.0/to_cmm/un_cps.cmo : \
     middle_end/flambda2.0/to_cmm/un_cps_env.cmi \
     middle_end/flambda2.0/to_cmm/un_cps_closure.cmi \
     utils/targetint.cmi \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     middle_end/flambda2.0/compilenv_deps/symbol.cmi \
     lambda/switch.cmi \
     middle_end/flambda2.0/basic/simple.cmi \
@@ -8506,13 +8539,13 @@ middle_end/flambda2.0/to_cmm/un_cps.cmo : \
     middle_end/flambda2.0/compilenv_deps/linkage_name.cmi \
     lambda/lambda.cmi \
     middle_end/flambda2.0/basic/kinded_parameter.cmi \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     typing/ident.cmi \
     middle_end/flambda2.0/terms/function_declarations.cmi \
     middle_end/flambda2.0/terms/function_declaration.cmi \
     middle_end/flambda2.0/terms/flambda_unit.cmi \
     middle_end/flambda2.0/terms/flambda_primitive.cmi \
     middle_end/flambda2.0/types/kinds/flambda_kind.cmi \
+    middle_end/flambda2.0/compilenv_deps/flambda_features.cmi \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda2.0/terms/flambda.cmi \
     middle_end/flambda2.0/basic/exn_continuation.cmi \
@@ -8543,6 +8576,7 @@ middle_end/flambda2.0/to_cmm/un_cps.cmx : \
     middle_end/flambda2.0/to_cmm/un_cps_env.cmx \
     middle_end/flambda2.0/to_cmm/un_cps_closure.cmx \
     utils/targetint.cmx \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     middle_end/flambda2.0/compilenv_deps/symbol.cmx \
     lambda/switch.cmx \
     middle_end/flambda2.0/basic/simple.cmx \
@@ -8560,13 +8594,13 @@ middle_end/flambda2.0/to_cmm/un_cps.cmx : \
     middle_end/flambda2.0/compilenv_deps/linkage_name.cmx \
     lambda/lambda.cmx \
     middle_end/flambda2.0/basic/kinded_parameter.cmx \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     typing/ident.cmx \
     middle_end/flambda2.0/terms/function_declarations.cmx \
     middle_end/flambda2.0/terms/function_declaration.cmx \
     middle_end/flambda2.0/terms/flambda_unit.cmx \
     middle_end/flambda2.0/terms/flambda_primitive.cmx \
     middle_end/flambda2.0/types/kinds/flambda_kind.cmx \
+    middle_end/flambda2.0/compilenv_deps/flambda_features.cmx \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda2.0/terms/flambda.cmx \
     middle_end/flambda2.0/basic/exn_continuation.cmx \
@@ -8675,6 +8709,7 @@ middle_end/flambda2.0/to_cmm/un_cps_helper.cmo : \
     utils/targetint.cmi \
     lambda/tag.cmi \
     typing/primitive.cmi \
+    middle_end/flambda2.0/basic/mutable_or_immutable.cmi \
     utils/misc.cmi \
     lambda/lambda.cmi \
     middle_end/flambda2.0/terms/flambda_primitive.cmi \
@@ -8693,6 +8728,7 @@ middle_end/flambda2.0/to_cmm/un_cps_helper.cmx : \
     utils/targetint.cmx \
     lambda/tag.cmx \
     typing/primitive.cmx \
+    middle_end/flambda2.0/basic/mutable_or_immutable.cmx \
     utils/misc.cmx \
     lambda/lambda.cmx \
     middle_end/flambda2.0/terms/flambda_primitive.cmx \
@@ -8710,6 +8746,7 @@ middle_end/flambda2.0/to_cmm/un_cps_helper.cmi : \
     middle_end/flambda2.0/basic/trap_action.cmi \
     utils/targetint.cmi \
     typing/primitive.cmi \
+    middle_end/flambda2.0/basic/mutable_or_immutable.cmi \
     lambda/lambda.cmi \
     middle_end/flambda2.0/terms/flambda_primitive.cmi \
     middle_end/flambda2.0/types/kinds/flambda_kind.cmi \
@@ -8743,6 +8780,7 @@ middle_end/flambda2.0/to_cmm/un_cps_static.cmo : \
     middle_end/flambda2.0/to_cmm/un_cps_env.cmi \
     middle_end/flambda2.0/to_cmm/un_cps_closure.cmi \
     utils/targetint.cmi \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     lambda/tag.cmi \
     middle_end/flambda2.0/compilenv_deps/symbol.cmi \
     middle_end/flambda2.0/basic/simple.cmi \
@@ -8755,7 +8793,6 @@ middle_end/flambda2.0/to_cmm/un_cps_static.cmo : \
     utils/misc.cmi \
     middle_end/flambda2.0/compilenv_deps/linkage_name.cmi \
     lambda/lambda.cmi \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     middle_end/flambda2.0/terms/function_declarations.cmi \
     middle_end/flambda2.0/terms/function_declaration.cmi \
     middle_end/flambda2.0/terms/flambda.cmi \
@@ -8775,6 +8812,7 @@ middle_end/flambda2.0/to_cmm/un_cps_static.cmx : \
     middle_end/flambda2.0/to_cmm/un_cps_env.cmx \
     middle_end/flambda2.0/to_cmm/un_cps_closure.cmx \
     utils/targetint.cmx \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     lambda/tag.cmx \
     middle_end/flambda2.0/compilenv_deps/symbol.cmx \
     middle_end/flambda2.0/basic/simple.cmx \
@@ -8787,7 +8825,6 @@ middle_end/flambda2.0/to_cmm/un_cps_static.cmx : \
     utils/misc.cmx \
     middle_end/flambda2.0/compilenv_deps/linkage_name.cmx \
     lambda/lambda.cmx \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     middle_end/flambda2.0/terms/function_declarations.cmx \
     middle_end/flambda2.0/terms/function_declaration.cmx \
     middle_end/flambda2.0/terms/flambda.cmx \
@@ -8814,6 +8851,7 @@ middle_end/flambda2.0/types/flambda_type.cmo : \
     middle_end/flambda2.0/types/type_head_intf.cmo \
     middle_end/flambda2.0/types/type_descr_intf.cmo \
     utils/targetint.cmi \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     middle_end/flambda2.0/types/basic/tag_or_unknown_and_size.cmi \
     middle_end/flambda2.0/types/basic/tag_and_size.cmi \
     lambda/tag.cmi \
@@ -8844,10 +8882,10 @@ middle_end/flambda2.0/types/flambda_type.cmo : \
     middle_end/flambda2.0/types/structures/lattice_ops_intf.cmo \
     middle_end/flambda2.0/basic/kinded_parameter.cmi \
     middle_end/flambda2.0/basic/inline_attribute.cmi \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     utils/identifiable.cmi \
     middle_end/flambda2.0/terms/flambda_primitive.cmi \
     middle_end/flambda2.0/types/kinds/flambda_kind.cmi \
+    middle_end/flambda2.0/compilenv_deps/flambda_features.cmi \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda2.0/types/kinds/flambda_arity.cmi \
     middle_end/flambda2.0/basic/export_id.cmi \
@@ -8873,6 +8911,7 @@ middle_end/flambda2.0/types/flambda_type.cmx : \
     middle_end/flambda2.0/types/type_head_intf.cmx \
     middle_end/flambda2.0/types/type_descr_intf.cmx \
     utils/targetint.cmx \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     middle_end/flambda2.0/types/basic/tag_or_unknown_and_size.cmx \
     middle_end/flambda2.0/types/basic/tag_and_size.cmx \
     lambda/tag.cmx \
@@ -8903,10 +8942,10 @@ middle_end/flambda2.0/types/flambda_type.cmx : \
     middle_end/flambda2.0/types/structures/lattice_ops_intf.cmx \
     middle_end/flambda2.0/basic/kinded_parameter.cmx \
     middle_end/flambda2.0/basic/inline_attribute.cmx \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     utils/identifiable.cmx \
     middle_end/flambda2.0/terms/flambda_primitive.cmx \
     middle_end/flambda2.0/types/kinds/flambda_kind.cmx \
+    middle_end/flambda2.0/compilenv_deps/flambda_features.cmx \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda2.0/types/kinds/flambda_arity.cmx \
     middle_end/flambda2.0/basic/export_id.cmx \
@@ -8928,6 +8967,7 @@ middle_end/flambda2.0/types/flambda_type.cmi : \
     middle_end/flambda2.0/basic/var_within_closure.cmi \
     middle_end/flambda2.0/naming/var_in_binding_pos.cmi \
     utils/targetint.cmi \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     lambda/tag.cmi \
     middle_end/flambda2.0/compilenv_deps/symbol.cmi \
     middle_end/flambda2.0/types/basic/string_info.cmi \
@@ -8948,7 +8988,6 @@ middle_end/flambda2.0/types/flambda_type.cmi : \
     middle_end/flambda2.0/basic/kinded_parameter.cmi \
     middle_end/flambda2.0/basic/invariant_env.cmi \
     middle_end/flambda2.0/basic/inline_attribute.cmi \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     middle_end/flambda2.0/terms/flambda_primitive.cmi \
     middle_end/flambda2.0/types/kinds/flambda_kind.cmi \
     middle_end/flambda2.0/types/kinds/flambda_arity.cmi \
@@ -9032,6 +9071,7 @@ middle_end/flambda2.0/types/type_grammar.rec.cmo : \
     middle_end/flambda2.0/compilenv_deps/variable.cmi \
     middle_end/flambda2.0/basic/var_within_closure.cmi \
     utils/targetint.cmi \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     lambda/tag.cmi \
     middle_end/flambda2.0/types/basic/string_info.cmi \
     middle_end/flambda2.0/basic/simple.cmi \
@@ -9046,7 +9086,6 @@ middle_end/flambda2.0/types/type_grammar.rec.cmo : \
     middle_end/flambda2.0/basic/name.cmi \
     utils/misc.cmi \
     middle_end/flambda2.0/types/structures/lattice_ops_intf.cmo \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     middle_end/flambda2.0/types/kinds/flambda_kind.cmi \
     middle_end/flambda2.0/basic/closure_id.cmi \
     middle_end/flambda2.0/types/env/binding_time.cmi \
@@ -9055,6 +9094,7 @@ middle_end/flambda2.0/types/type_grammar.rec.cmx : \
     middle_end/flambda2.0/compilenv_deps/variable.cmx \
     middle_end/flambda2.0/basic/var_within_closure.cmx \
     utils/targetint.cmx \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     lambda/tag.cmx \
     middle_end/flambda2.0/types/basic/string_info.cmx \
     middle_end/flambda2.0/basic/simple.cmx \
@@ -9069,7 +9109,6 @@ middle_end/flambda2.0/types/type_grammar.rec.cmx : \
     middle_end/flambda2.0/basic/name.cmx \
     utils/misc.cmx \
     middle_end/flambda2.0/types/structures/lattice_ops_intf.cmx \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     middle_end/flambda2.0/types/kinds/flambda_kind.cmx \
     middle_end/flambda2.0/basic/closure_id.cmx \
     middle_end/flambda2.0/types/env/binding_time.cmx \
@@ -9078,6 +9117,7 @@ middle_end/flambda2.0/types/type_grammar.rec.cmi : \
     middle_end/flambda2.0/compilenv_deps/variable.cmi \
     middle_end/flambda2.0/basic/var_within_closure.cmi \
     utils/targetint.cmi \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     lambda/tag.cmi \
     middle_end/flambda2.0/basic/simple.cmi \
     middle_end/flambda2.0/basic/reg_width_const.cmi \
@@ -9089,7 +9129,6 @@ middle_end/flambda2.0/types/type_grammar.rec.cmi : \
     utils/numbers.cmi \
     middle_end/flambda2.0/basic/name.cmi \
     middle_end/flambda2.0/basic/inline_attribute.cmi \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     middle_end/flambda2.0/types/kinds/flambda_kind.cmi \
     middle_end/flambda2.0/types/kinds/flambda_arity.cmi \
     lambda/debuginfo.cmi \
@@ -9417,6 +9456,7 @@ middle_end/flambda2.0/types/env/typing_env_level.rec.cmo : \
     utils/identifiable.cmi \
     middle_end/flambda2.0/terms/flambda_primitive.cmi \
     middle_end/flambda2.0/types/kinds/flambda_kind.cmi \
+    middle_end/flambda2.0/compilenv_deps/flambda_features.cmi \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda2.0/basic/continuation_extra_params_and_args.cmi \
     middle_end/flambda2.0/types/structures/code_age_relation.cmi \
@@ -9440,6 +9480,7 @@ middle_end/flambda2.0/types/env/typing_env_level.rec.cmx : \
     utils/identifiable.cmx \
     middle_end/flambda2.0/terms/flambda_primitive.cmx \
     middle_end/flambda2.0/types/kinds/flambda_kind.cmx \
+    middle_end/flambda2.0/compilenv_deps/flambda_features.cmx \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda2.0/basic/continuation_extra_params_and_args.cmx \
     middle_end/flambda2.0/types/structures/code_age_relation.cmx \
@@ -9475,22 +9516,22 @@ middle_end/flambda2.0/types/kinds/flambda_arity.cmi : \
     middle_end/flambda2.0/types/kinds/flambda_kind.cmi
 middle_end/flambda2.0/types/kinds/flambda_kind.cmo : \
     utils/targetint.cmi \
-    utils/numbers.cmi \
     middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
+    utils/numbers.cmi \
     utils/identifiable.cmi \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda2.0/types/kinds/flambda_kind.cmi
 middle_end/flambda2.0/types/kinds/flambda_kind.cmx : \
     utils/targetint.cmx \
-    utils/numbers.cmx \
     middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
+    utils/numbers.cmx \
     utils/identifiable.cmx \
     middle_end/flambda2.0/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda2.0/types/kinds/flambda_kind.cmi
 middle_end/flambda2.0/types/kinds/flambda_kind.cmi : \
     utils/targetint.cmi \
-    utils/numbers.cmi \
     middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
+    utils/numbers.cmi \
     utils/identifiable.cmi
 middle_end/flambda2.0/types/structures/closures_entry.rec.cmo : \
     utils/printing_cache.cmi \
@@ -9564,22 +9605,22 @@ middle_end/flambda2.0/types/structures/function_declaration_type.rec.cmi : \
 middle_end/flambda2.0/types/structures/lattice_ops.rec.cmo : \
     middle_end/flambda2.0/basic/var_within_closure.cmi \
     utils/targetint.cmi \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     lambda/tag.cmi \
     middle_end/flambda2.0/types/basic/string_info.cmi \
     middle_end/flambda2.0/types/basic/or_bottom.cmi \
     middle_end/flambda2.0/types/basic/meet_or_join_op.cmi \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     utils/identifiable.cmi \
     middle_end/flambda2.0/basic/closure_id.cmi \
     middle_end/flambda2.0/types/structures/lattice_ops.rec.cmi
 middle_end/flambda2.0/types/structures/lattice_ops.rec.cmx : \
     middle_end/flambda2.0/basic/var_within_closure.cmx \
     utils/targetint.cmx \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     lambda/tag.cmx \
     middle_end/flambda2.0/types/basic/string_info.cmx \
     middle_end/flambda2.0/types/basic/or_bottom.cmx \
     middle_end/flambda2.0/types/basic/meet_or_join_op.cmx \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     utils/identifiable.cmx \
     middle_end/flambda2.0/basic/closure_id.cmx \
     middle_end/flambda2.0/types/structures/lattice_ops.rec.cmi
@@ -9587,18 +9628,18 @@ middle_end/flambda2.0/types/structures/lattice_ops.rec.cmi : \
     middle_end/flambda2.0/types/structures/lattice_ops_intf.cmo
 middle_end/flambda2.0/types/structures/lattice_ops_intf.cmo : \
     utils/targetint.cmi \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     middle_end/flambda2.0/types/basic/string_info.cmi \
     middle_end/flambda2.0/types/basic/or_bottom.cmi \
     utils/numbers.cmi \
-    middle_end/flambda2.0/types/basic/meet_or_join_op.cmi \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi
+    middle_end/flambda2.0/types/basic/meet_or_join_op.cmi
 middle_end/flambda2.0/types/structures/lattice_ops_intf.cmx : \
     utils/targetint.cmx \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     middle_end/flambda2.0/types/basic/string_info.cmx \
     middle_end/flambda2.0/types/basic/or_bottom.cmx \
     utils/numbers.cmx \
-    middle_end/flambda2.0/types/basic/meet_or_join_op.cmx \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmx
+    middle_end/flambda2.0/types/basic/meet_or_join_op.cmx
 middle_end/flambda2.0/types/structures/product.rec.cmo : \
     middle_end/flambda2.0/basic/var_within_closure.cmi \
     utils/targetint.cmi \
@@ -9736,6 +9777,7 @@ middle_end/flambda2.0/types/type_of_kind/type_of_kind_naked_float0.rec.cmi : \
     utils/numbers.cmi
  \
     middle_end/flambda2.0/types/type_of_kind/type_of_kind_naked_immediate0.rec.cmo : \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     lambda/tag.cmi \
     middle_end/flambda2.0/compilenv_deps/rec_info.cmi \
     utils/printing_cache.cmi \
@@ -9744,10 +9786,10 @@ middle_end/flambda2.0/types/type_of_kind/type_of_kind_naked_float0.rec.cmi : \
     middle_end/flambda2.0/naming/name_occurrences.cmi \
     utils/misc.cmi \
     middle_end/flambda2.0/types/structures/lattice_ops_intf.cmo \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     middle_end/flambda2.0/types/type_of_kind/type_of_kind_naked_immediate0.rec.cmi
  \
     middle_end/flambda2.0/types/type_of_kind/type_of_kind_naked_immediate0.rec.cmx : \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     lambda/tag.cmx \
     middle_end/flambda2.0/compilenv_deps/rec_info.cmx \
     utils/printing_cache.cmx \
@@ -9756,7 +9798,6 @@ middle_end/flambda2.0/types/type_of_kind/type_of_kind_naked_float0.rec.cmi : \
     middle_end/flambda2.0/naming/name_occurrences.cmx \
     utils/misc.cmx \
     middle_end/flambda2.0/types/structures/lattice_ops_intf.cmx \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     middle_end/flambda2.0/types/type_of_kind/type_of_kind_naked_immediate0.rec.cmi
  \
     middle_end/flambda2.0/types/type_of_kind/type_of_kind_naked_immediate0.rec.cmi : \
@@ -9863,13 +9904,13 @@ middle_end/flambda2.0/types/type_of_kind/variant.rec.cmi : \
     middle_end/flambda2.0/types/type_of_kind/boilerplate/type_of_kind_naked_float.rec.cmi : \
     middle_end/flambda2.0/types/type_descr_intf.cmo
  \
-    middle_end/flambda2.0/types/type_of_kind/boilerplate/type_of_kind_naked_target_imm.rec.cmo : \
-    middle_end/flambda2.0/types/type_of_kind/boilerplate/type_of_kind_naked_target_imm.rec.cmi
+    middle_end/flambda2.0/types/type_of_kind/boilerplate/type_of_kind_naked_immediate.rec.cmo : \
+    middle_end/flambda2.0/types/type_of_kind/boilerplate/type_of_kind_naked_immediate.rec.cmi
  \
-    middle_end/flambda2.0/types/type_of_kind/boilerplate/type_of_kind_naked_target_imm.rec.cmx : \
-    middle_end/flambda2.0/types/type_of_kind/boilerplate/type_of_kind_naked_target_imm.rec.cmi
+    middle_end/flambda2.0/types/type_of_kind/boilerplate/type_of_kind_naked_immediate.rec.cmx : \
+    middle_end/flambda2.0/types/type_of_kind/boilerplate/type_of_kind_naked_immediate.rec.cmi
  \
-    middle_end/flambda2.0/types/type_of_kind/boilerplate/type_of_kind_naked_target_imm.rec.cmi : \
+    middle_end/flambda2.0/types/type_of_kind/boilerplate/type_of_kind_naked_immediate.rec.cmi : \
     middle_end/flambda2.0/types/type_descr_intf.cmo
  \
     middle_end/flambda2.0/types/type_of_kind/boilerplate/type_of_kind_naked_int32.rec.cmo : \
@@ -9912,6 +9953,7 @@ middle_end/flambda2.0/unboxing/unbox_continuation_params.cmo : \
     middle_end/flambda2.0/basic/var_within_closure.cmi \
     middle_end/flambda2.0/naming/var_in_binding_pos.cmi \
     utils/targetint.cmi \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     lambda/tag.cmi \
     middle_end/flambda2.0/simplify/simplify_import.cmi \
     middle_end/flambda2.0/basic/simple.cmi \
@@ -9919,7 +9961,6 @@ middle_end/flambda2.0/unboxing/unbox_continuation_params.cmo : \
     middle_end/flambda2.0/naming/name_in_binding_pos.cmi \
     middle_end/flambda2.0/basic/name.cmi \
     utils/misc.cmi \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmi \
     utils/identifiable.cmi \
     middle_end/flambda2.0/compilenv_deps/flambda_features.cmi \
     middle_end/flambda2.0/basic/closure_id.cmi \
@@ -9930,6 +9971,7 @@ middle_end/flambda2.0/unboxing/unbox_continuation_params.cmx : \
     middle_end/flambda2.0/basic/var_within_closure.cmx \
     middle_end/flambda2.0/naming/var_in_binding_pos.cmx \
     utils/targetint.cmx \
+    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     lambda/tag.cmx \
     middle_end/flambda2.0/simplify/simplify_import.cmx \
     middle_end/flambda2.0/basic/simple.cmx \
@@ -9937,7 +9979,6 @@ middle_end/flambda2.0/unboxing/unbox_continuation_params.cmx : \
     middle_end/flambda2.0/naming/name_in_binding_pos.cmx \
     middle_end/flambda2.0/basic/name.cmx \
     utils/misc.cmx \
-    middle_end/flambda2.0/compilenv_deps/target_imm.cmx \
     utils/identifiable.cmx \
     middle_end/flambda2.0/compilenv_deps/flambda_features.cmx \
     middle_end/flambda2.0/basic/closure_id.cmx \
@@ -10399,6 +10440,8 @@ toplevel/opttoploop.cmo : \
     typing/includemod.cmi \
     typing/ident.cmi \
     toplevel/genprintval.cmi \
+    middle_end/flambda2.0/flambda2_middle_end.cmi \
+    middle_end/flambda2.0/flambda2_backend_intf.cmi \
     typing/env.cmi \
     utils/config.cmi \
     driver/compmisc.cmi \
@@ -10444,6 +10487,8 @@ toplevel/opttoploop.cmx : \
     typing/includemod.cmx \
     typing/ident.cmx \
     toplevel/genprintval.cmx \
+    middle_end/flambda2.0/flambda2_middle_end.cmx \
+    middle_end/flambda2.0/flambda2_backend_intf.cmi \
     typing/env.cmx \
     utils/config.cmx \
     driver/compmisc.cmx \

--- a/Makefile
+++ b/Makefile
@@ -260,6 +260,7 @@ MIDDLE_END_FLAMBDA2_BASIC=\
   middle_end/flambda2.0/basic/coeffects.cmo \
   middle_end/flambda2.0/basic/effects.cmo \
   middle_end/flambda2.0/basic/export_id.cmo \
+  middle_end/flambda2.0/types/basic/or_unknown.cmo \
   middle_end/flambda2.0/terms/flambda_primitive.cmo \
   middle_end/flambda2.0/basic/recursive.cmo \
   middle_end/flambda2.0/basic/scope.cmo \
@@ -296,7 +297,6 @@ MIDDLE_END_FLAMBDA2_TYPES=\
   middle_end/flambda2.0/types/basic/string_info.cmo \
   middle_end/flambda2.0/types/structures/lattice_ops_intf.cmo \
   middle_end/flambda2.0/types/basic/or_bottom_or_absorbing.cmo \
-  middle_end/flambda2.0/types/basic/or_unknown.cmo \
   middle_end/flambda2.0/types/basic/or_unknown_or_bottom.cmo \
   middle_end/flambda2.0/types/structures/code_age_relation.cmo \
   middle_end/flambda2.0/types/structures/type_structure_intf.cmo \

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -703,6 +703,17 @@ let float_array_set arr ofs newval dbg =
   Cop(Cstore (Double_u, Lambda.Assignment),
     [array_indexing log2_size_float arr ofs dbg; newval], dbg)
 
+(* Get the field of a block given a possibly inconstant index *)
+
+let get_field_computed imm_or_ptr mut ~block ~index dbg =
+  let kind =
+    match imm_or_ptr with
+    | Lambda.Immediate -> Word_int
+    | Lambda.Pointer -> Word_val
+  in
+  let field_address = array_indexing log2_size_addr block index dbg in
+  Cop (Cload (kind, mut), [field_address], dbg)
+
 (* String length *)
 
 (* Length of string block *)

--- a/asmcomp/cmm_helpers.mli
+++ b/asmcomp/cmm_helpers.mli
@@ -189,6 +189,16 @@ val field_address : expression -> int -> Debuginfo.t -> expression
 val get_field_gen :
   Asttypes.mutable_flag -> expression -> int -> Debuginfo.t -> expression
 
+(** Get the field of the given [block] whose index is specified by the
+    Cmm expresson [index] (in words). *)
+val get_field_computed
+   : Lambda.immediate_or_pointer
+  -> Asttypes.mutable_flag
+  -> block:expression
+  -> index:expression
+  -> Debuginfo.t
+  -> expression
+
 (** [set_field ptr n newval init dbg] returns an expression for setting the
     [n]th field of the block pointed to by [ptr] to [newval] *)
 val set_field :

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -111,7 +111,8 @@ let preserve_tailcall_for_prim = function
     Pidentity | Popaque | Pdirapply | Prevapply | Psequor | Psequand ->
       true
   | Pbytes_to_string | Pbytes_of_string | Pignore | Pgetglobal _ | Psetglobal _
-  | Pmakeblock _ | Pfield _ | Pfield_computed _ | Psetfield _
+  | Pmakeblock _ | Pmakefloatblock _
+  | Pfield _ | Pfield_computed _ | Psetfield _
   | Psetfield_computed _ | Pfloatfield _ | Psetfloatfield _ | Pduprecord _
   | Pccall _ | Praise _ | Pnot | Pnegint | Paddint | Psubint | Pmulint
   | Pdivint _ | Pmodint _ | Pandint | Porint | Pxorint | Plslint | Plsrint
@@ -208,7 +209,8 @@ let rec size_of_lambda env = function
   | Lprim(Pmakeblock _, args, _) -> RHS_block (List.length args)
   | Lprim (Pmakearray ((Paddrarray|Pintarray), _), args, _) ->
       RHS_block (List.length args)
-  | Lprim (Pmakearray (Pfloatarray, _), args, _) ->
+  | Lprim (Pmakearray (Pfloatarray, _), args, _)
+  | Lprim (Pmakefloatblock _, args, _) ->
       RHS_floatblock (List.length args)
   | Lprim (Pmakearray (Pgenarray, _), _, _) ->
      (* Pgenarray is excluded from recursive bindings by the
@@ -732,6 +734,9 @@ let rec comp_expr env exp sz cont =
         (Kpush::
          Kconst (Const_base (Const_int n))::
          Kaddint::cont)
+  | Lprim (Pmakefloatblock _mut, args, loc) ->
+      let cont = add_pseudo_event loc !compunit_name cont in
+      comp_args env args sz (Kmakefloatblock (List.length args) :: cont)
   | Lprim(Pmakearray (kind, _), args, loc) ->
       let cont = add_pseudo_event loc !compunit_name cont in
       begin match kind with

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -230,7 +230,7 @@ let rec transl_const = function
         (fun c -> Obj.set_field block !pos (transl_const c); incr pos)
         fields;
       block
-  | Const_float_array fields ->
+  | Const_float_block fields | Const_float_array fields ->
       let res = Array.Floatarray.create (List.length fields) in
       List.iteri (fun i f -> Array.Floatarray.set res i (float_of_string f))
         fields;

--- a/flambdatest/mlexamples/int_array_modify.ml
+++ b/flambdatest/mlexamples/int_array_modify.ml
@@ -1,0 +1,4 @@
+let f x =
+  let a = Array.make 42 0 in
+  Array.unsafe_set a 0 x;
+  a

--- a/lambda/dissect_letrec.ml
+++ b/lambda/dissect_letrec.ml
@@ -228,7 +228,8 @@ let rec prepare_letrec
       | None -> dead_code lam letrec
       (* We know that [args] are all "simple" at this point, so no effects *)
     end
-  | Lprim (Pmakearray (Pfloatarray, _), args, _) -> begin
+  | Lprim (Pmakearray (Pfloatarray, _), args, _)
+  | Lprim (Pmakefloatblock _, args, _) -> begin
       match current_let with
       | Some cl -> build_block cl (List.length args) Boxed_float lam letrec
       | None -> dead_code lam letrec

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -344,6 +344,7 @@ type structured_constant =
     Const_base of constant
   | Const_pointer of int
   | Const_block of int * structured_constant list
+  | Const_float_block of string list
   | Const_float_array of string list
   | Const_immstring of string
 

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -344,9 +344,9 @@ type structured_constant =
     Const_base of constant
   | Const_pointer of int
   | Const_block of int * structured_constant list
-  | Const_float_block of string list
   | Const_float_array of string list
   | Const_immstring of string
+  | Const_float_block of string list
 
 type inline_attribute =
   | Always_inline (* [@inline] or [@inline always] *)

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -1124,7 +1124,8 @@ let rec size_of_lambda' env = function
   | Lprim(Pmakeblock _, args, _) -> RHS_block (List.length args)
   | Lprim (Pmakearray ((Paddrarray|Pintarray), _), args, _) ->
       RHS_block (List.length args)
-  | Lprim (Pmakearray (Pfloatarray, _), args, _) ->
+  | Lprim (Pmakearray (Pfloatarray, _), args, _)
+  | Lprim (Pmakefloatblock _, args, _) ->
       RHS_floatblock (List.length args)
   | Lprim (Pmakearray (Pgenarray, _), _, _) ->
      (* Pgenarray is excluded from recursive bindings by the

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -69,6 +69,7 @@ type primitive =
   | Psetglobal of Ident.t
   (* Operations on heap blocks *)
   | Pmakeblock of int * mutable_flag * block_shape
+  | Pmakefloatblock of mutable_flag
   | Pfield of field_info * field_read_semantics
   | Pfield_computed of field_read_semantics
   | Psetfield of field_info * immediate_or_pointer * initialization_or_assignment
@@ -269,6 +270,7 @@ let primitive_can_raise = function
   | Pgetglobal _
   | Psetglobal _
   | Pmakeblock _
+  | Pmakefloatblock _
   | Pfield _
   | Pfield_computed _
   | Psetfield _

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -225,9 +225,9 @@ type structured_constant =
     Const_base of constant
   | Const_pointer of int
   | Const_block of int * structured_constant list
-  | Const_float_block of string list
   | Const_float_array of string list
   | Const_immstring of string
+  | Const_float_block of string list
 
 type inline_attribute =
   | Always_inline (* [@inline] or [@inline always] *)

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -75,6 +75,7 @@ type primitive =
   | Psetglobal of Ident.t
   (* Operations on heap blocks *)
   | Pmakeblock of int * mutable_flag * block_shape
+  | Pmakefloatblock of mutable_flag
   | Pfield of field_info * field_read_semantics
   | Pfield_computed of field_read_semantics
   | Psetfield of field_info * immediate_or_pointer * initialization_or_assignment

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -225,6 +225,7 @@ type structured_constant =
     Const_base of constant
   | Const_pointer of int
   | Const_block of int * structured_constant list
+  | Const_float_block of string list
   | Const_float_array of string list
   | Const_immstring of string
 

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -171,6 +171,8 @@ let primitive ppf = function
       fprintf ppf "makeblock %i%a" tag block_shape shape
   | Pmakeblock(tag, Mutable, shape) ->
       fprintf ppf "makemutable %i%a" tag block_shape shape
+  | Pmakefloatblock Immutable -> fprintf ppf "makefloatblock Immutable"
+  | Pmakefloatblock Mutable -> fprintf ppf "makefloatblock Mutable"
   | Pfield ({index = n; block_info = _;}, sem) ->
       fprintf ppf "field%a %i" field_read_semantics sem n
   | Pfield_computed sem ->
@@ -368,6 +370,7 @@ let name_of_primitive = function
   | Pgetglobal _ -> "Pgetglobal"
   | Psetglobal _ -> "Psetglobal"
   | Pmakeblock _ -> "Pmakeblock"
+  | Pmakefloatblock _ -> "Pmakefloatblock"
   | Pfield _ -> "Pfield"
   | Pfield_computed _ -> "Pfield_computed"
   | Psetfield _ -> "Psetfield"

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -36,6 +36,12 @@ let rec struct_const ppf = function
       let sconsts ppf scl =
         List.iter (fun sc -> fprintf ppf "@ %a" struct_const sc) scl in
       fprintf ppf "@[<1>[%i:@ @[%a%a@]]@]" tag struct_const sc1 sconsts scl
+  | Const_float_block [] ->
+      fprintf ppf "[|b |]"
+  | Const_float_block (f1 :: fl) ->
+      let floats ppf fl =
+        List.iter (fun f -> fprintf ppf "@ %s" f) fl in
+      fprintf ppf "@[<1>[|b@[%s%a@]|]@]" f1 floats fl
   | Const_float_array [] ->
       fprintf ppf "[| |]"
   | Const_float_array (f1 :: fl) ->

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -949,7 +949,7 @@ and transl_record ~scopes loc env fields repres opt_init_expr =
         | Record_inlined tag -> Lconst(Const_block(tag, cl))
         | Record_unboxed _ -> Lconst(match cl with [v] -> v | _ -> assert false)
         | Record_float ->
-            Lconst(Const_float_array(List.map extract_float cl))
+            Lconst(Const_float_block(List.map extract_float cl))
         | Record_extension _ ->
             raise Not_constant
       with Not_constant ->

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -961,7 +961,7 @@ and transl_record ~scopes loc env fields repres opt_init_expr =
             Lprim(Pmakeblock(tag, mut, Some shape), ll, loc)
         | Record_unboxed _ -> (match ll with [v] -> v | _ -> assert false)
         | Record_float ->
-            Lprim(Pmakearray (Pfloatarray, mut), ll, loc)
+            Lprim(Pmakefloatblock mut, ll, loc)
         | Record_extension path ->
             let slot = transl_extension_path loc env path in
             Lprim(Pmakeblock(0, mut, Some (Pgenval :: shape)), slot :: ll, loc)

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -786,7 +786,8 @@ let lambda_primitive_needs_event_after = function
   | Pbbswap _ -> true
 
   | Pidentity | Pbytes_to_string | Pbytes_of_string | Pignore | Psetglobal _
-  | Pgetglobal _ | Pmakeblock _ | Pfield _ | Pfield_computed _ | Psetfield _
+  | Pgetglobal _ | Pmakeblock _ | Pmakefloatblock _
+  | Pfield _ | Pfield_computed _ | Psetfield _
   | Psetfield_computed _ | Pfloatfield _ | Psetfloatfield _ | Praise _
   | Psequor | Psequand | Pnot | Pnegint | Paddint | Psubint | Pmulint
   | Pdivint _ | Pmodint _ | Pandint | Porint | Pxorint | Plslint | Plsrint

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -878,6 +878,9 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
         | Const_pointer n -> Uconst_ptr n
         | Const_block (tag, fields) ->
             str (Uconst_block (tag, List.map transl fields))
+        | Const_float_block sl ->
+            (* CR mshinwell: Add [Uconst_float_block]? *)
+            str (Uconst_float_array (List.map float_of_string sl))
         | Const_float_array sl ->
             (* constant float arrays are really immutable *)
             str (Uconst_float_array (List.map float_of_string sl))

--- a/middle_end/convert_primitives.ml
+++ b/middle_end/convert_primitives.ml
@@ -26,6 +26,10 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
   match prim with
   | Pmakeblock (tag, mutability, shape) ->
       Pmakeblock (tag, mutability, shape)
+  | Pmakefloatblock mutability ->
+      (* CR mshinwell: Decide if the backend primitives should have
+         [Pmakefloatblock] too *)
+      Pmakearray (Pfloatarray, mutability)
   | Pfield ({ index = field; _ }, _) -> Pfield field
   | Pfield_computed _sem -> Pfield_computed
   | Psetfield ({ index = field; _ }, imm_or_pointer, init_or_assign) ->

--- a/middle_end/flambda/simplify_primitives.ml
+++ b/middle_end/flambda/simplify_primitives.ml
@@ -123,6 +123,7 @@ let primitive (p : Clambda_primitives.primitive) (args, approxs)
   | Pmakearray(_, _) when is_empty approxs ->
     Prim (Pmakeblock(0, Asttypes.Immutable, Some []), [], dbg),
     A.value_block (Tag.create_exn 0) [||], C.Benefit.zero
+  (* CR mshinwell: Work out what to do here with [Pmakefloatblock] *)
   | Pmakearray (Pfloatarray, Mutable) ->
       let approx =
         A.value_mutable_float_array ~size:(List.length args)

--- a/middle_end/flambda2.0/basic/effects.ml
+++ b/middle_end/flambda2.0/basic/effects.ml
@@ -16,36 +16,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* Mutable or immutable *)
-
-type mutable_or_immutable =
-  | Immutable
-  | Mutable
-
-let print_mutable_or_immutable ppf mut =
-  match mut with
-  | Immutable -> Format.pp_print_string ppf "Immutable"
-  | Mutable -> Format.pp_print_string ppf "Mutable"
-
-let compare_mutable_or_immutable mut1 mut2 =
-  match mut1, mut2 with
-  | Immutable, Immutable
-  | Mutable, Mutable -> 0
-  | Immutable, Mutable -> -1
-  | Mutable, Immutable -> 1
-
-let join_mutable_or_immutable mut1 mut2 =
-  match mut1, mut2 with
-  | Immutable, Immutable -> Immutable
-  | Mutable, Mutable
-  | Immutable, Mutable
-  | Mutable, Immutable -> Mutable
-
-(* Effects *)
+[@@@ocaml.warning "+a-30-40-41-42"]
 
 type t =
   | No_effects
-  | Only_generative_effects of mutable_or_immutable
+  | Only_generative_effects of Mutable_or_immutable.t
   | Arbitrary_effects
 
 let print ppf eff =
@@ -54,7 +29,7 @@ let print ppf eff =
       Format.fprintf ppf "no effects"
   | Only_generative_effects mut ->
       Format.fprintf ppf "only generative effects %a"
-        print_mutable_or_immutable mut
+        Mutable_or_immutable.print mut
   | Arbitrary_effects ->
       Format.fprintf ppf "Arbitrary effects"
 
@@ -64,7 +39,7 @@ let compare eff1 eff2 =
   | No_effects, (Only_generative_effects _ | Arbitrary_effects) -> -1
   | Only_generative_effects mut1,
     Only_generative_effects mut2 ->
-      compare_mutable_or_immutable mut1 mut2
+      Mutable_or_immutable.compare mut1 mut2
   | Only_generative_effects _, No_effects -> 1
   | Only_generative_effects _, Arbitrary_effects -> -1
   | Arbitrary_effects, Arbitrary_effects -> 0
@@ -78,7 +53,7 @@ let join eff1 eff2 =
   | Only_generative_effects _, No_effects -> eff1
   | Only_generative_effects mut1,
     Only_generative_effects mut2 ->
-      Only_generative_effects (join_mutable_or_immutable mut1 mut2)
+      Only_generative_effects (Mutable_or_immutable.join mut1 mut2)
   | Only_generative_effects _, Arbitrary_effects -> eff2
   | Arbitrary_effects, No_effects
   | Arbitrary_effects, Only_generative_effects _

--- a/middle_end/flambda2.0/basic/effects.mli
+++ b/middle_end/flambda2.0/basic/effects.mli
@@ -16,21 +16,10 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Mutable or immutable *)
-type mutable_or_immutable =
-  | Immutable
-  | Mutable
+[@@@ocaml.warning "+a-30-40-41-42"]
 
-val print_mutable_or_immutable :
-  Format.formatter -> mutable_or_immutable -> unit
-(** Printing function. *)
+(** Things that a primitive does to the world, or expects from the world. *)
 
-val compare_mutable_or_immutable :
-  mutable_or_immutable -> mutable_or_immutable -> int
-(** Comparison function. *)
-
-
-(** Things that a primitive application does to the world. *)
 type t =
   | No_effects
   (** The primitive does not change the observable state of the world. For
@@ -48,7 +37,7 @@ type t =
       "effects out of the ether" and thus ignored for our determination here
       of effectfulness.  The same goes for floating point operations that may
       cause hardware traps on some platforms. *)
-  | Only_generative_effects of mutable_or_immutable
+  | Only_generative_effects of Mutable_or_immutable.t
   (** The primitive does not change the observable state of the world save for
       possibly affecting the state of the garbage collector by performing an
       allocation. Applications of primitives that only have generative effects

--- a/middle_end/flambda2.0/basic/mutable_or_immutable.ml
+++ b/middle_end/flambda2.0/basic/mutable_or_immutable.ml
@@ -28,3 +28,15 @@ let compare t1 t2 =
   | Mutable, Mutable | Immutable, Immutable -> 0
   | Mutable, Immutable -> -1
   | Immutable, Mutable -> 1
+
+let join t1 t2 =
+  match t1, t2 with
+  | Immutable, Immutable -> Immutable
+  | Mutable, Mutable
+  | Immutable, Mutable
+  | Mutable, Immutable -> Mutable
+
+let to_lambda t : Asttypes.mutable_flag =
+  match t with
+  | Mutable -> Mutable
+  | Immutable -> Immutable

--- a/middle_end/flambda2.0/basic/mutable_or_immutable.mli
+++ b/middle_end/flambda2.0/basic/mutable_or_immutable.mli
@@ -21,3 +21,7 @@ type t = Mutable | Immutable
 val print : Format.formatter -> t -> unit
 
 val compare : t -> t -> int
+
+val join : t -> t -> t
+
+val to_lambda : t -> Asttypes.mutable_flag

--- a/middle_end/flambda2.0/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2.0/from_lambda/closure_conversion.ml
@@ -154,10 +154,11 @@ let tupled_function_call_stub
         let defining_expr =
           let pos = Target_imm.int (Targetint.OCaml.of_int pos) in
           let block_access : P.Block_access_kind.t =
-            Block { elt_kind = Value Anything;
-                    tag = Tag.zero;
-                    size = Known (List.length params);
-                  }
+            Values {
+              tag = Tag.Scannable.zero;
+              size = Known (Targetint.OCaml.of_int (List.length params));
+              field_kind = Any_value;
+            }
           in
           Named.create_prim
             (Binary (
@@ -1089,10 +1090,11 @@ let ilambda_to_flambda ~backend ~module_ident ~module_block_size_in_words
       |> Flambda.Expr.create_let_symbol
     in
     let block_access : P.Block_access_kind.t =
-      Block { elt_kind = Value Anything;
-              tag = Tag.zero;
-              size = Known module_block_size_in_words;
-            }
+      Values {
+        tag = Tag.Scannable.zero;
+        size = Known (Targetint.OCaml.of_int module_block_size_in_words);
+        field_kind = Any_value;
+      }
     in
     List.fold_left (fun body (pos, var) ->
         let var = VB.create var Name_mode.normal in
@@ -1152,7 +1154,7 @@ let ilambda_to_flambda ~backend ~module_ident ~module_block_size_in_words
           in
           Sets_of_closures [{
             code = Code_id.Map.singleton code_id code;
-            set_of_closures = Set_of_closures.empty; 
+            set_of_closures = Set_of_closures.empty;
           }]
         in
         Let_symbol.create Syntactic bound_symbols static_const body

--- a/middle_end/flambda2.0/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2.0/from_lambda/closure_conversion.ml
@@ -254,8 +254,14 @@ let rec declare_const t (const : Lambda.structured_constant)
     register_const t (Boxed_nativeint (Const c)) "nativeint"
   | Const_immstring c ->
     register_const t (Immutable_string c) "immstring"
+  | Const_float_block c ->
+    register_const t
+      (Immutable_float_block
+         (List.map (fun s ->
+           let f = Numbers.Float_by_bit_pattern.create (float_of_string s) in
+           Or_variable.Const f) c))
+      "float_block"
   | Const_float_array c ->
-    (* CR mshinwell: check that Const_float_array is always immutable *)
     register_const t
       (Immutable_float_array
          (List.map (fun s ->

--- a/middle_end/flambda2.0/from_lambda/lambda_conversions.ml
+++ b/middle_end/flambda2.0/from_lambda/lambda_conversions.ml
@@ -20,6 +20,12 @@ module K = Flambda_kind
 module L = Lambda
 module P = Flambda_primitive
 
+let check_float_array_optimisation_enabled () =
+  if not Config.flat_float_array then begin
+    Misc.fatal_error "[Pgenarray] is not expected when the float array \
+      optimisation is disabled"
+  end
+
 let value_kind (value_kind : L.value_kind) =
   match value_kind with
   | Pgenval
@@ -57,10 +63,20 @@ let raise_kind (kind : L.raise_kind) : Trap_action.raise_kind =
   | Raise_reraise -> Reraise
   | Raise_notrace -> No_trace
 
+let convert_block_of_values_field (value_kind : L.value_kind)
+      : P.Block_of_values_field.t =
+  match value_kind with
+  | Pgenval -> Any_value
+  | Pfloatval -> Boxed_float
+  | Pboxedintval Pint32 -> Boxed_int32
+  | Pboxedintval Pint64 -> Boxed_int64
+  | Pboxedintval Pnativeint -> Boxed_nativeint
+  | Pintval -> Immediate
+
 let convert_block_shape (shape : L.block_shape) ~num_fields =
   match shape with
   | None ->
-    List.init num_fields (fun _field : P.Value_kind.t -> Anything)
+    List.init num_fields (fun _field : P.Block_of_values_field.t -> Any_value)
   | Some shape ->
     let shape_length = List.length shape in
     if num_fields <> shape_length then begin
@@ -69,15 +85,10 @@ let convert_block_shape (shape : L.block_shape) ~num_fields =
         num_fields
         shape_length
     end;
-    List.map (fun (kind : L.value_kind) : P.Value_kind.t ->
-        match kind with
-        | Pgenval -> Anything
-        | Pfloatval | Pboxedintval _ -> Definitely_pointer
-        | Pintval -> Definitely_immediate)
-      shape
+    List.map convert_block_of_values_field shape
 
 let convert_mutable_flag (flag : Asttypes.mutable_flag)
-      : Effects.mutable_or_immutable =
+      : Mutable_or_immutable.t =
   match flag with
   | Mutable -> Mutable
   | Immutable -> Immutable
@@ -148,60 +159,37 @@ let standard_int_or_float_of_boxed_integer (bint : L.boxed_integer)
   | Pint32 -> Naked_int32
   | Pint64 -> Naked_int64
 
-(* let const_of_boxed_integer (i:int32) (bint : L.boxed_integer) *)
-(*   : Reg_width_const.t = *)
-(*   match bint with *)
-(*   | Pnativeint -> Naked_nativeint (Targetint.of_int32 i) *)
-(*   | Pint32 -> Naked_int32 i *)
-(*   | Pint64 -> Naked_int64 (Int64.of_int32 i) *)
-
-(* let convert_record_representation (repr : Types.record_representation) *)
-(*    : P.record_representation = *)
-(*   match repr with *)
-(*   | Record_regular -> Regular *)
-(*   | Record_float -> Float *)
-(*   | Record_unboxed inlined -> Unboxed { inlined } *)
-(*   | Record_inlined tag -> Inlined (Tag.Scannable.create_exn tag) *)
-(*   | Record_extension -> Extension *)
-
-let convert_access_kind i_or_p : P.Block_access_kind.t0 =
+let convert_block_access_field_kind i_or_p : P.Block_access_field_kind.t =
   match i_or_p with
-  | L.Immediate -> Value Definitely_immediate
-  | L.Pointer -> Value Anything
+  | L.Immediate -> Immediate
+  | L.Pointer -> Any_value
 
 let convert_init_or_assign (i_or_a : L.initialization_or_assignment)
-   : P.init_or_assign =
+   : P.Init_or_assign.t =
   match i_or_a with
   | Assignment -> Assignment
   | Heap_initialization -> Initialization
-  (* Root initialization cannot exist in lambda. This is
-     represented by the static part of expressions in flambda. *)
-  | Root_initialization -> assert false
+  | Root_initialization ->
+    Misc.fatal_error "[Root_initialization] should not appear in Flambda input"
 
-let convert_array_kind (kind : L.array_kind)
-   : P.Block_access_kind.t =
+let convert_array_kind (kind : L.array_kind) : P.Array_kind.t =
   match kind with
   | Pgenarray ->
-    Generic_array
-      (P.Generic_array_specialisation.no_specialisation ())
-  | Paddrarray -> Array (Value Anything)
-  | Pintarray -> Array (Value Definitely_immediate)
-  | Pfloatarray -> Array Naked_float
+    check_float_array_optimisation_enabled ();
+    Float_array_opt_dynamic
+  | Paddrarray -> Values
+  | Pintarray -> Immediates
+  | Pfloatarray -> Naked_floats
 
-let convert_array_kind_to_duplicate_block_kind (kind : L.array_kind)
-      : P.duplicate_block_kind =
+let convert_array_kind_to_duplicate_array_kind (kind : L.array_kind)
+      : P.Duplicate_array_kind.t =
   match kind with
   | Pgenarray ->
-    Generic_array
-      (P.Generic_array_specialisation.no_specialisation ())
-    (* CR mshinwell: Are these next two cases correct?  Should they be under
-       "generic array"? *)
-  | Paddrarray ->
-    Generic_array (P.Generic_array_specialisation.
-      full_of_arbitrary_values_but_not_floats ())
-  | Pintarray ->
-    Generic_array (P.Generic_array_specialisation.full_of_immediates ())
-  | Pfloatarray -> Full_of_naked_floats { length = None; }
+    check_float_array_optimisation_enabled ();
+    Float_array_opt_dynamic
+  | Paddrarray -> Values
+  | Pintarray -> Immediates
+  | Pfloatarray -> Naked_floats { length = None; }
 
 let convert_bigarray_kind (kind : L.bigarray_kind) : P.bigarray_kind option =
   match kind with
@@ -226,7 +214,12 @@ let convert_bigarray_layout (layout : L.bigarray_layout) : P.bigarray_layout opt
   | Pbigarray_fortran_layout -> Some Fortran
 
 let convert_field_read_semantics (sem : L.field_read_semantics)
-      : Effects.mutable_or_immutable =
+      : Mutable_or_immutable.t =
   match sem with
   | Reads_agree -> Immutable
   | Reads_vary -> Mutable
+
+let convert_lambda_block_size (size : L.block_size) : _ Or_unknown.t =
+  match size with
+  | Unknown -> Unknown
+  | Known size -> Known (Targetint.OCaml.of_int size)

--- a/middle_end/flambda2.0/from_lambda/lambda_conversions.mli
+++ b/middle_end/flambda2.0/from_lambda/lambda_conversions.mli
@@ -33,9 +33,9 @@ val raise_kind : Lambda.raise_kind -> Trap_action.raise_kind
 val convert_block_shape
    : Lambda.block_shape
   -> num_fields:int
-  -> Flambda_primitive.Value_kind.t list
+  -> Flambda_primitive.Block_of_values_field.t list
 
-val convert_mutable_flag : Asttypes.mutable_flag -> Effects.mutable_or_immutable
+val convert_mutable_flag : Asttypes.mutable_flag -> Mutable_or_immutable.t
 
 val convert_integer_comparison_prim
    : Lambda.integer_comparison
@@ -62,21 +62,21 @@ val standard_int_or_float_of_boxed_integer
    : Lambda.boxed_integer
   -> Flambda_kind.Standard_int_or_float.t
 
-val convert_access_kind
+val convert_block_access_field_kind
    : Lambda.immediate_or_pointer
-  -> Flambda_primitive.Block_access_kind.t0
+  -> Flambda_primitive.Block_access_field_kind.t
 
 val convert_init_or_assign
    : Lambda.initialization_or_assignment
-  -> Flambda_primitive.init_or_assign
+  -> Flambda_primitive.Init_or_assign.t
 
 val convert_array_kind
    : Lambda.array_kind
-  -> Flambda_primitive.Block_access_kind.t
+  -> Flambda_primitive.Array_kind.t
 
-val convert_array_kind_to_duplicate_block_kind
+val convert_array_kind_to_duplicate_array_kind
    : Lambda.array_kind
-  -> Flambda_primitive.duplicate_block_kind
+  -> Flambda_primitive.Duplicate_array_kind.t
 
 val convert_bigarray_kind
    : Lambda.bigarray_kind
@@ -88,4 +88,8 @@ val convert_bigarray_layout
 
 val convert_field_read_semantics
    : Lambda.field_read_semantics
-  -> Effects.mutable_or_immutable
+  -> Mutable_or_immutable.t
+
+val convert_lambda_block_size
+   : Lambda.block_size
+  -> Targetint.OCaml.t Or_unknown.t

--- a/middle_end/flambda2.0/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2.0/from_lambda/lambda_to_flambda_primitives.ml
@@ -260,6 +260,9 @@ let convert_lprim ~backend (prim : L.primitive) (args : Simple.t list)
     let shape = C.convert_block_shape shape ~num_fields:(List.length args) in
     let mutability = C.convert_mutable_flag mutability in
     Variadic (Make_block (Values (tag, shape), mutability), args)
+  | Pmakefloatblock mutability, _ ->
+    let mutability = C.convert_mutable_flag mutability in
+    Variadic (Make_block (Naked_floats, mutability), args)
   | Pmakearray (array_kind, mutability), _ ->
     let array_kind = C.convert_array_kind array_kind in
     let mutability = C.convert_mutable_flag mutability in

--- a/middle_end/flambda2.0/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2.0/from_lambda/lambda_to_flambda_primitives.ml
@@ -255,38 +255,46 @@ let convert_lprim ~backend (prim : L.primitive) (args : Simple.t list)
   let module B = (val backend : Flambda2_backend_intf.S) in
   let size_int = B.size_int in
   match prim, args with
-  | Pmakeblock (tag, flag, shape), _ ->
-    let flag = C.convert_mutable_flag flag in
+  | Pmakeblock (tag, mutability, shape), _ ->
+    let tag = Tag.Scannable.create_exn tag in
     let shape = C.convert_block_shape shape ~num_fields:(List.length args) in
-    Variadic (Make_block (
-        Full_of_values (Tag.Scannable.create_exn tag, shape), flag),
-      args)
-  | Pmakearray (kind, mutability), _ ->
-    let flag = C.convert_mutable_flag mutability in
-    let kind, args =
-      let module S = P.Generic_array_specialisation in
-      match kind with
-      | Pgenarray -> S.no_specialisation (), args
-      | Paddrarray -> S.full_of_arbitrary_values_but_not_floats (), args
-      | Pintarray -> S.full_of_immediates (), args
-      | Pfloatarray -> S.full_of_naked_floats (), List.map unbox_float args
+    let mutability = C.convert_mutable_flag mutability in
+    Variadic (Make_block (Values (tag, shape), mutability), args)
+  | Pmakearray (array_kind, mutability), _ ->
+    let array_kind = C.convert_array_kind array_kind in
+    let mutability = C.convert_mutable_flag mutability in
+    let args =
+      match array_kind with
+      | Float_array_opt_dynamic | Immediates | Values -> args
+      | Naked_floats -> List.map unbox_float args
     in
-    Variadic (Make_block (Generic_array kind, flag), args)
+    Variadic (Make_array (array_kind, mutability), args)
   | Popaque, [arg] ->
     Unary (Opaque_identity, arg)
   | Pduprecord (repr, num_fields), [arg] ->
-    let kind : P.duplicate_block_kind =
+    let kind : P.Duplicate_block_kind.t =
       match repr with
-      | Record_regular -> Full_of_values_known_length Tag.Scannable.zero
+      | Record_regular ->
+        Values {
+          tag = Tag.Scannable.zero;
+          length = Targetint.OCaml.of_int num_fields;
+        }
       | Record_float ->
-        Full_of_naked_floats
-          { length = Some (Targetint.OCaml.of_int num_fields) }
+        Naked_floats {
+          length = Targetint.OCaml.of_int num_fields;
+        }
       | Record_unboxed _ ->
         Misc.fatal_error "Pduprecord of unboxed record"
       | Record_inlined tag ->
-        Full_of_values_known_length (Tag.Scannable.create_exn tag)
+        Values {
+          tag = Tag.Scannable.create_exn tag;
+          length = Targetint.OCaml.of_int num_fields;
+        }
       | Record_extension _ ->
-        Full_of_values_known_length Tag.Scannable.zero
+        Values {
+          tag = Tag.Scannable.zero;
+          length = Targetint.OCaml.of_int num_fields;
+        }
     in
     Unary (Duplicate_block {
       kind;
@@ -349,27 +357,33 @@ let convert_lprim ~backend (prim : L.primitive) (args : Simple.t list)
     let block_access : P.Block_access_kind.t =
       (* Pfield_computed is only used for class access, on blocks of tag 0.
          Obj.field uses Parrayref. *)
-      Block { elt_kind = Value Anything; tag = Tag.zero; size = Unknown; }
+      (* CR mshinwell: For robustness, Pfield_computed should carry the
+         tag, as this condition is not obvious. *)
+      Values {
+        tag = Tag.Scannable.zero;
+        size = Unknown;
+        field_kind = Any_value;
+      }
     in
     Binary (Block_load (block_access,
       C.convert_field_read_semantics sem), obj, field)
   | Psetfield_computed (imm_or_pointer, init_or_assign), [obj; field; value] ->
-    let access_kind =
-      C.convert_access_kind imm_or_pointer
-    in
+    let field_kind = C.convert_block_access_field_kind imm_or_pointer in
     let block_access : P.Block_access_kind.t =
-      Block { elt_kind = access_kind; tag = Tag.zero; size = Unknown; }
+      Values {
+        tag = Tag.Scannable.zero;
+        size = Unknown;
+        field_kind;
+      }
     in
     Ternary
-      (Block_set
-         (block_access, C.convert_init_or_assign init_or_assign),
+      (Block_set (block_access, C.convert_init_or_assign init_or_assign),
        obj, field, value)
   | Parraylength kind, [arg] ->
     Unary (Array_length (C.convert_array_kind kind), arg)
   | Pduparray (kind, mutability), [arg] ->
-    Unary (Duplicate_block {
-      (* CR mshinwell: fix this next function *)
-      kind = C.convert_array_kind_to_duplicate_block_kind kind;
+    Unary (Duplicate_array {
+      kind = C.convert_array_kind_to_duplicate_array_kind kind;
       (* CR mshinwell: Check that [Pduparray] is only applied to immutable
          arrays *)
       source_mutability = Immutable;
@@ -579,34 +593,37 @@ let convert_lprim ~backend (prim : L.primitive) (args : Simple.t list)
     in
     Binary (Int_arith (I.Tagged_immediate, Add), arg, Simple const)
   | Pfield ({ index; block_info = { tag; size; }; }, sem), [arg] ->
-    (* CR mshinwell: Cause fatal error if the field value is < 0.
-       We can't do this once we convert to Flambda *)
     let imm = Target_imm.int (Targetint.OCaml.of_int index) in
+    if not (Target_imm.is_non_negative imm) then begin
+      Misc.fatal_errorf "Pfield with negative index %a"
+        Target_imm.print imm
+    end;
     let field = Simple.const (Reg_width_const.tagged_immediate imm) in
     let mutability = C.convert_field_read_semantics sem in
+    let tag = Tag.Scannable.create_exn tag in
+    let size = C.convert_lambda_block_size size in
     let block_access : P.Block_access_kind.t =
-      Block { elt_kind = Value Anything; tag = Tag.create_exn tag; size; }
+      Values { tag; size; field_kind = Any_value; }
     in
-    Binary (Block_load (block_access, mutability), arg,
-      Simple field)
+    Binary (Block_load (block_access, mutability), arg, Simple field)
   | Pfloatfield (field, sem), [arg] ->
     let imm = Target_imm.int (Targetint.OCaml.of_int field) in
     let field = Simple.const (Reg_width_const.tagged_immediate imm) in
     let mutability = C.convert_field_read_semantics sem in
     let block_access : P.Block_access_kind.t =
-      Block { elt_kind = Naked_float; tag = Tag.double_array_tag;
-              size = Unknown; }
+      Naked_floats { size = Unknown; }
     in
     box_float
       (Binary (Block_load (block_access, mutability), arg, Simple field))
   | Psetfield (fi, immediate_or_pointer, initialization_or_assignment),
-    [block; value] ->
+      [block; value] ->
     let { index; block_info = { tag; size; }; } : Lambda.field_info = fi in
-    let access_kind = C.convert_access_kind immediate_or_pointer in
+    let field_kind = C.convert_block_access_field_kind immediate_or_pointer in
     let imm = Target_imm.int (Targetint.OCaml.of_int index) in
     let field = Simple.const (Reg_width_const.tagged_immediate imm) in
+    let size = C.convert_lambda_block_size size in
     let block_access : P.Block_access_kind.t =
-      Block { elt_kind = access_kind; tag = Tag.create_exn tag; size; }
+      Values { tag = Tag.Scannable.create_exn tag; size; field_kind; }
     in
     Ternary (Block_set (block_access,
          C.convert_init_or_assign initialization_or_assignment),
@@ -615,8 +632,7 @@ let convert_lprim ~backend (prim : L.primitive) (args : Simple.t list)
     let imm = Target_imm.int (Targetint.OCaml.of_int field) in
     let field = Simple.const (Reg_width_const.tagged_immediate imm) in
     let block_access : P.Block_access_kind.t =
-      Block { elt_kind = Naked_float; tag = Tag.double_array_tag;
-              size = Unknown; }
+      Naked_floats { size = Unknown; }
     in
     Ternary (Block_set (block_access,
         C.convert_init_or_assign init_or_assign),
@@ -744,22 +760,24 @@ let convert_lprim ~backend (prim : L.primitive) (args : Simple.t list)
       failure = Division_by_zero;
       dbg;
     }
-  | Parrayrefu (Pgenarray | Paddrarray | Pintarray), [array; index] ->
-    (* CR mshinwell: Review all these cases.  Isn't this supposed to
-       produce [Generic_array]? *)
-    Binary (Block_load (Array (Value Anything), Mutable), array, index)
+  | Parrayrefu ((Pgenarray | Paddrarray | Pintarray) as array_kind),
+      [array; index] ->
+    let array_kind = C.convert_array_kind array_kind in
+    Binary (Array_load (array_kind, Mutable), array, index)
   | Parrayrefu Pfloatarray, [array; index] ->
-    box_float (Binary (Block_load (Array Naked_float, Mutable), array, index))
-  | Parrayrefs (Pgenarray | Paddrarray | Pintarray), [array; index] ->
+    box_float (Binary (Array_load (Naked_floats, Mutable), array, index))
+  | Parrayrefs ((Pgenarray | Paddrarray | Pintarray) as array_kind),
+      [array; index] ->
+    let array_kind = C.convert_array_kind array_kind in
     Checked {
       primitive =
-        Binary (Block_load (Array (Value Anything), Mutable), array, index);
+        Binary (Array_load (array_kind, Mutable), array, index);
       validity_conditions = [
         Binary (Int_comp (Tagged_immediate, Signed, Ge), index,
           Simple (Simple.const (Reg_width_const.tagged_immediate
             (Target_imm.int (Targetint.OCaml.zero)))));
         Binary (Int_comp (Tagged_immediate, Signed, Lt), index,
-          Prim (Unary (Array_length (Array (Value Anything)), array)));
+          Prim (Unary (Array_length array_kind, array)));
       ];
       failure = Index_out_of_bounds;
       dbg;
@@ -768,36 +786,36 @@ let convert_lprim ~backend (prim : L.primitive) (args : Simple.t list)
     Checked {
       primitive =
        box_float (
-         Binary (Block_load (Array Naked_float, Mutable), array, index));
+         Binary (Array_load (Naked_floats, Mutable), array, index));
       validity_conditions = [
         Binary (Int_comp (Tagged_immediate, Signed, Ge), index,
           Simple (Simple.const (Reg_width_const.tagged_immediate
             (Target_imm.int (Targetint.OCaml.zero)))));
         Binary (Int_comp (Tagged_immediate, Signed, Lt), index,
-          Prim (Unary (Array_length (Array Naked_float), array)));
+          Prim (Unary (Array_length Naked_floats, array)));
       ];
       failure = Index_out_of_bounds;
       dbg;
     }
-  | Parraysetu (Pgenarray | Paddrarray | Pintarray),
+  | Parraysetu ((Pgenarray | Paddrarray | Pintarray) as array_kind),
       [array; index; new_value] ->
-    Ternary (Block_set (Array (Value Anything), Assignment),
-      array, index, new_value)
+    let array_kind = C.convert_array_kind array_kind in
+    Ternary (Array_set (array_kind, Assignment), array, index, new_value)
   | Parraysetu Pfloatarray, [array; index; new_value] ->
-    Ternary (Block_set (Array Naked_float, Assignment),
-      array, index, unbox_float new_value)
-  | Parraysets (Pgenarray | Paddrarray | Pintarray),
+    let new_value = unbox_float new_value in
+    Ternary (Array_set (Naked_floats, Assignment), array, index, new_value)
+  | Parraysets ((Pgenarray | Paddrarray | Pintarray) as array_kind),
       [array; index; new_value] ->
+    let array_kind = C.convert_array_kind array_kind in
     Checked {
       primitive =
-        Ternary (Block_set (Array (Value Anything), Assignment),
-          array, index, new_value);
+        Ternary (Array_set (array_kind, Assignment), array, index, new_value);
       validity_conditions = [
         Binary (Int_comp (Tagged_immediate, Signed, Ge), index,
           Simple (Simple.const (Reg_width_const.tagged_immediate
             (Target_imm.int (Targetint.OCaml.zero)))));
         Binary (Int_comp (Tagged_immediate, Signed, Lt), index,
-          Prim (Unary (Array_length (Array (Value Anything)), array)));
+          Prim (Unary (Array_length array_kind, array)));
       ];
       failure = Index_out_of_bounds;
       dbg;
@@ -805,14 +823,14 @@ let convert_lprim ~backend (prim : L.primitive) (args : Simple.t list)
   | Parraysets Pfloatarray, [array; index; new_value] ->
     Checked {
       primitive =
-        Ternary (Block_set (Array Naked_float, Assignment),
+        Ternary (Array_set (Naked_floats, Assignment),
           array, index, unbox_float new_value);
       validity_conditions = [
         Binary (Int_comp (Tagged_immediate, Signed, Ge), index,
           Simple (Simple.const (Reg_width_const.tagged_immediate
             (Target_imm.int (Targetint.OCaml.zero)))));
         Binary (Int_comp (Tagged_immediate, Signed, Lt), index,
-          Prim (Unary (Array_length (Array Naked_float), array)));
+          Prim (Unary (Array_length Naked_floats, array)));
       ];
       failure = Index_out_of_bounds;
       dbg;
@@ -833,8 +851,11 @@ let convert_lprim ~backend (prim : L.primitive) (args : Simple.t list)
     }
   | Poffsetref n, [block] ->
     let block_access : P.Block_access_kind.t =
-      Block { elt_kind = Value Definitely_immediate; tag = Tag.zero;
-              size = Known 1; }
+      Values {
+        tag = Tag.Scannable.zero;
+        size = Known Targetint.OCaml.one;
+        field_kind = Immediate;
+      }
     in
     Ternary (Block_set (block_access, Assignment),
       block,

--- a/middle_end/flambda2.0/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2.0/from_lambda/lambda_to_flambda_primitives.ml
@@ -262,7 +262,7 @@ let convert_lprim ~backend (prim : L.primitive) (args : Simple.t list)
     Variadic (Make_block (Values (tag, shape), mutability), args)
   | Pmakefloatblock mutability, _ ->
     let mutability = C.convert_mutable_flag mutability in
-    Variadic (Make_block (Naked_floats, mutability), args)
+    Variadic (Make_block (Naked_floats, mutability), List.map unbox_float args)
   | Pmakearray (array_kind, mutability), _ ->
     let array_kind = C.convert_array_kind array_kind in
     let mutability = C.convert_mutable_flag mutability in

--- a/middle_end/flambda2.0/from_lambda/lambda_to_flambda_primitives_helpers.ml
+++ b/middle_end/flambda2.0/from_lambda/lambda_to_flambda_primitives_helpers.ml
@@ -106,8 +106,7 @@ let expression_for_failure ~backend exn_cont ~register_const_string
       let extra_let_binding =
         Var_in_binding_pos.create exn_bucket Name_mode.normal,
           Named.create_prim (Variadic (Make_block (
-              Full_of_values (Tag.Scannable.zero,
-                  [Definitely_pointer; Definitely_pointer]),
+              Values (Tag.Scannable.zero, [Any_value; Any_value]),
                 Immutable),
               contents_of_exn_bucket))
             dbg

--- a/middle_end/flambda2.0/from_lambda/prepare_lambda.ml
+++ b/middle_end/flambda2.0/from_lambda/prepare_lambda.ml
@@ -338,6 +338,8 @@ let rec prepare env (lam : L.lambda) (k : L.lambda -> L.lambda) =
   | Lprim (Pmakeblock (tag, _, _), _, _)
       when tag < 0 || tag >= Obj.no_scan_tag ->
     Misc.fatal_errorf "Pmakeblock with wrong or non-scannable block tag %d" tag
+  | Lprim (Pmakefloatblock _mut, args, _) when List.length args < 1 ->
+    Misc.fatal_errorf "Pmakefloatblock must have at least one argument"
   | Lprim (prim, args, loc) ->
     prepare_list env args (fun args ->
       k (simplify_primitive prim args loc))

--- a/middle_end/flambda2.0/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2.0/simplify/simplify_binary_primitive.ml
@@ -855,22 +855,19 @@ let simplify_immutable_block_load (access_kind : P.Block_access_kind.t)
        to constrain the type of the block *)
     let tag : _ Or_unknown.t =
       match access_kind with
+      | Values { tag; _ } -> Known (Tag.Scannable.to_tag tag)
       | Naked_floats { size; } ->
-        (* Arrays of naked floats, whether or not the float array
-           optimisation is in effect, always have tag zero.  This means that
-           if we don't know the size here, we don't know the tag. *)
-        begin match size with
+        match size with
         | Known size ->
+          (* We don't expect blocks of naked floats of size zero (it doesn't
+             seem that the frontend currently emits code to create such blocks)
+             and so it isn't clear whether such blocks should have tag zero
+             (like zero-sized naked float arrays) or another tag. *)
           if Targetint.OCaml.equal size Targetint.OCaml.zero then
-            Known Tag.zero
+            Unknown
           else
             Known Tag.double_array_tag
         | Unknown -> Unknown
-        end
-      | Values { tag; _ } ->
-        (* We are dealing here with blocks, not arrays, so even if the size
-           of the block is zero the tag is still as expected. *)
-        Known (Tag.Scannable.to_tag tag)
     in
     Simplify_common.simplify_projection
       dacc ~original_term ~deconstructing:block_ty

--- a/middle_end/flambda2.0/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2.0/simplify/simplify_binary_primitive.ml
@@ -855,21 +855,22 @@ let simplify_immutable_block_load (access_kind : P.Block_access_kind.t)
        to constrain the type of the block *)
     let tag : _ Or_unknown.t =
       match access_kind with
-      | Values { tag; _ } ->
-        (* We are dealing here with blocks, not arrays, so even if the size
-           of the block is zero the tag is still as expected. *)
-        Known (Tag.Scannable.to_tag tag)
       | Naked_floats { size; } ->
         (* Arrays of naked floats, whether or not the float array
            optimisation is in effect, always have tag zero.  This means that
            if we don't know the size here, we don't know the tag. *)
-        match size with
+        begin match size with
         | Known size ->
           if Targetint.OCaml.equal size Targetint.OCaml.zero then
             Known Tag.zero
           else
             Known Tag.double_array_tag
         | Unknown -> Unknown
+        end
+      | Values { tag; _ } ->
+        (* We are dealing here with blocks, not arrays, so even if the size
+           of the block is zero the tag is still as expected. *)
+        Known (Tag.Scannable.to_tag tag)
     in
     Simplify_common.simplify_projection
       dacc ~original_term ~deconstructing:block_ty

--- a/middle_end/flambda2.0/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2.0/simplify/simplify_binary_primitive.ml
@@ -824,8 +824,14 @@ module Binary_int_eq_comp_int64 =
 module Binary_int_eq_comp_nativeint =
   Binary_arith_like (Int_ops_for_binary_eq_comp_nativeint)
 
-let simplify_immutable_block_load ~result_kind dacc ~original_term _dbg
+let simplify_immutable_block_load (access_kind : P.Block_access_kind.t)
+      dacc ~original_term _dbg
       ~arg1:_ ~arg1_ty:block_ty ~arg2:_ ~arg2_ty:index_ty ~result_var =
+  let result_kind =
+    match access_kind with
+    | Values _ -> K.value
+    | Naked_floats _ -> K.naked_float
+  in
   let result_var' = Var_in_binding_pos.var result_var in
   let unchanged () =
     let ty = T.unknown result_kind in
@@ -845,9 +851,29 @@ let simplify_immutable_block_load ~result_kind dacc ~original_term _dbg
     let n =
       Targetint.OCaml.add (Target_imm.to_targetint index) Targetint.OCaml.one
     in
+    (* CR mshinwell: We should be able to use the size in the [access_kind]
+       to constrain the type of the block *)
+    let tag : _ Or_unknown.t =
+      match access_kind with
+      | Values { tag; _ } ->
+        (* We are dealing here with blocks, not arrays, so even if the size
+           of the block is zero the tag is still as expected. *)
+        Known (Tag.Scannable.to_tag tag)
+      | Naked_floats { size; } ->
+        (* Arrays of naked floats, whether or not the float array
+           optimisation is in effect, always have tag zero.  This means that
+           if we don't know the size here, we don't know the tag. *)
+        match size with
+        | Known size ->
+          if Targetint.OCaml.equal size Targetint.OCaml.zero then
+            Known Tag.zero
+          else
+            Known Tag.double_array_tag
+        | Unknown -> Unknown
+    in
     Simplify_common.simplify_projection
       dacc ~original_term ~deconstructing:block_ty
-      ~shape:(T.immutable_block_with_size_at_least ~tag:Unknown ~n
+      ~shape:(T.immutable_block_with_size_at_least ~tag ~n
         ~field_kind:result_kind ~field_n_minus_one:result_var')
       ~result_var ~result_kind
 
@@ -988,10 +1014,8 @@ let simplify_binary_primitive dacc (prim : P.binary_primitive)
         let original_term = Named.create_prim original_prim dbg in
         let simplifier =
           match prim with
-          | Block_load (Block { elt_kind = Value _; _ }, Immutable) ->
-            simplify_immutable_block_load ~result_kind:K.value
-          | Block_load (Block { elt_kind = Naked_float; _ }, Immutable) ->
-            simplify_immutable_block_load ~result_kind:K.naked_float
+          | Block_load (access_kind, Immutable) ->
+            simplify_immutable_block_load access_kind
           | Int_arith (kind, op) ->
             begin match kind with
             | Tagged_immediate -> Binary_int_arith_tagged_immediate.simplify op
@@ -1030,6 +1054,7 @@ let simplify_binary_primitive dacc (prim : P.binary_primitive)
           | Float_comp op -> Binary_float_comp.simplify op
           | Phys_equal (kind, op) -> simplify_phys_equal op kind
           | Block_load _
+          | Array_load _
           | String_or_bigstring_load _
           | Bigarray_load _ ->
             fun dacc ~original_term:_ dbg ~arg1 ~arg1_ty:_ ~arg2 ~arg2_ty:_

--- a/middle_end/flambda2.0/simplify/simplify_static_const.rec.ml
+++ b/middle_end/flambda2.0/simplify/simplify_static_const.rec.ml
@@ -110,6 +110,15 @@ let simplify_static_const_of_kind_value dacc
     in
     let dacc = bind_result_sym ty in
     Boxed_nativeint or_var, dacc
+  | Immutable_float_block fields ->
+    let fields_with_tys =
+      List.map (fun field ->
+          simplify_or_variable dacc (fun f -> T.this_naked_float f) field)
+        fields
+    in
+    let fields, _field_tys = List.split fields_with_tys in
+    let dacc = bind_result_sym (T.any_value ()) in
+    Immutable_float_block fields, dacc
   | Immutable_float_array fields ->
     let fields_with_tys =
       List.map (fun field ->

--- a/middle_end/flambda2.0/simplify/simplify_ternary_primitive.ml
+++ b/middle_end/flambda2.0/simplify/simplify_ternary_primitive.ml
@@ -14,7 +14,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-[@@@ocaml.warning "+a-4-9-30-40-41-42"]
+[@@@ocaml.warning "+a-30-40-41-42"]
 
 open! Simplify_import
 
@@ -66,6 +66,7 @@ let simplify_ternary_primitive dacc (prim : P.ternary_primitive)
         | Ok arg3, _arg3_ty ->
           match prim with
           | Block_set _
+          | Array_set _
           | Bytes_or_bigstring_set _
           | Bigarray_set _ ->
             let named =

--- a/middle_end/flambda2.0/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2.0/simplify/simplify_unary_primitive.ml
@@ -37,12 +37,12 @@ module Int64 = Numbers.Int64
           ((function_decls
             {(thd3/0
               (Ok (Inlinable (code_id thd3_0_tuple_stub/2) (param_arity 𝕍)
-                   (result_arity 𝕍) (stub true) (dbg ) (inline Default_inline) 
+                   (result_arity 𝕍) (stub true) (dbg ) (inline Default_inline)
                    (is_a_functor false) (recursive Non_recursive) (rec_info ((depth 1) (unroll_to None))))))
              (thd3/1
               (Ok (Inlinable (code_id thd3_0/3) (param_arity 𝕍 ⨯ 𝕍 ⨯ 𝕍)
-                   (result_arity 𝕍) (stub false) (dbg tuple_stub.ml:1,9--20) 
-                   (inline Default_inline) (is_a_functor false) (recursive Non_recursive) 
+                   (result_arity 𝕍) (stub false) (dbg tuple_stub.ml:1,9--20)
+                   (inline Default_inline) (is_a_functor false) (recursive Non_recursive)
                    (rec_info ((depth 1) (unroll_to None))))))})
            (closure_types ((components_by_index {(thd3/0 (Val (= Tuple_stub.camlTuple_stub__thd3_2))) (thd3/1 (Val (= Tuple_stub.camlTuple_stub__thd3_3)))})))
            (closure_var_types ((components_by_index {})))))}) (other_tags Bottom)))
@@ -467,6 +467,7 @@ let simplify_unary_primitive dacc (prim : P.unary_primitive)
         | Boolean_not -> simplify_boolean_not
         | Int_as_pointer
         | Bigarray_length _
+        | Duplicate_array _
         | Duplicate_block _
         | Opaque_identity ->
           (* CR mshinwell: In these cases, the type of the argument should

--- a/middle_end/flambda2.0/simplify/simplify_variadic_primitive.ml
+++ b/middle_end/flambda2.0/simplify/simplify_variadic_primitive.ml
@@ -37,7 +37,6 @@ let simplify_make_block_of_values dacc _prim dbg tag ~shape
   (* CR mshinwell: This could probably be done more neatly. *)
   let found_bottom = ref false in
   let fields =
-    assert (List.compare_lengths shape args_with_tys = 0);
     List.map2 (fun ((arg : Simple.t), arg_ty) _block_of_values_kind ->
         (* CR mshinwell: There should be a meet against a skeleton type
            computed from [block_of_values_kind]. *)

--- a/middle_end/flambda2.0/simplify/simplify_variadic_primitive.ml
+++ b/middle_end/flambda2.0/simplify/simplify_variadic_primitive.ml
@@ -18,9 +18,8 @@
 
 open! Simplify_import
 
-let simplify_make_block dacc _prim dbg
-      ~(make_block_kind : P.make_block_kind)
-      ~(mutable_or_immutable : Effects.mutable_or_immutable)
+let simplify_make_block_of_values dacc _prim dbg tag ~shape
+      ~(mutable_or_immutable : Mutable_or_immutable.t)
       args_with_tys ~result_var =
   let denv = DA.denv dacc in
   let args, _arg_tys = List.split args_with_tys in
@@ -29,51 +28,47 @@ let simplify_make_block dacc _prim dbg
     let env_extension = TEE.one_equation (Name.var result_var) ty in
     Reachable.invalid (), env_extension, dacc
   in
-  match make_block_kind with
-  | Full_of_values (tag, value_kinds) ->
-    if List.compare_lengths value_kinds args <> 0 then begin
-      (* CR mshinwell: improve message *)
-      Misc.fatal_errorf "GC value_kind indications in [Make_block] don't \
-          match up 1:1 with arguments: %a"
-        Simple.List.print args
-    end;
-    (* CR mshinwell: This could probably be done more neatly. *)
-    let found_bottom = ref false in
-    let fields =
-      assert (List.compare_lengths value_kinds args_with_tys = 0);
-      List.map2 (fun ((arg : Simple.t), arg_ty) _value_kind ->
-          if T.is_bottom (DE.typing_env denv) arg_ty then begin
-           found_bottom := true
-          end;
-          Simple.pattern_match arg
-            ~const:(fun _ -> arg_ty)
-            ~name:(fun name -> T.alias_type_of K.value (Simple.name name)))
-        args_with_tys value_kinds
+  if List.compare_lengths shape args <> 0 then begin
+    (* CR mshinwell: improve message *)
+    Misc.fatal_errorf "GC value_kind indications in [Make_block] don't \
+        match up 1:1 with arguments: %a"
+      Simple.List.print args
+  end;
+  (* CR mshinwell: This could probably be done more neatly. *)
+  let found_bottom = ref false in
+  let fields =
+    assert (List.compare_lengths shape args_with_tys = 0);
+    List.map2 (fun ((arg : Simple.t), arg_ty) _block_of_values_kind ->
+        (* CR mshinwell: There should be a meet against a skeleton type
+           computed from [block_of_values_kind]. *)
+        if T.is_bottom (DE.typing_env denv) arg_ty then begin
+          found_bottom := true
+        end;
+        Simple.pattern_match arg
+          ~const:(fun _ -> arg_ty)
+          ~name:(fun name -> T.alias_type_of K.value (Simple.name name)))
+      args_with_tys shape
+  in
+  if !found_bottom then begin
+    invalid ()
+  end else begin
+    assert (List.compare_lengths fields shape = 0);
+    let term : Named.t =
+      Named.create_prim
+        (Variadic (
+          Make_block (Values (tag, shape), mutable_or_immutable),
+          args))
+        dbg
     in
-    if !found_bottom then begin
-      invalid ()
-    end else begin
-      assert (List.compare_lengths fields value_kinds = 0);
-      let term : Named.t =
-        Named.create_prim
-          (Variadic (
-            Make_block (Full_of_values (tag, value_kinds),
-              mutable_or_immutable),
-            args))
-          dbg
-      in
-      let tag = Tag.Scannable.to_tag tag in
-      let ty =
-        match mutable_or_immutable with
-        | Immutable -> T.immutable_block tag ~field_kind:K.value ~fields
-        | Mutable -> T.any_value ()
-      in
-      let env_extension = TEE.one_equation (Name.var result_var) ty in
-      Reachable.reachable term, env_extension, dacc
-    end
-  (* CR mshinwell: Implement these *)
-  | Full_of_naked_floats -> Misc.fatal_error "Not yet implemented"
-  | Generic_array _spec -> Misc.fatal_error "Not yet implemented"
+    let tag = Tag.Scannable.to_tag tag in
+    let ty =
+      match mutable_or_immutable with
+      | Immutable -> T.immutable_block tag ~field_kind:K.value ~fields
+      | Mutable -> T.any_value ()
+    in
+    let env_extension = TEE.one_equation (Name.var result_var) ty in
+    Reachable.reachable term, env_extension, dacc
+  end
 
 let try_cse dacc ~original_prim prim args ~min_name_mode ~result_var
       : Simplify_common.cse =
@@ -128,11 +123,12 @@ let simplify_variadic_primitive dacc ~original_named ~original_prim
       invalid (T.bottom result_kind)
     | args_changed, Ok args_with_tys ->
       match prim with
-      | Make_block ((Full_of_values _) as make_block_kind,
-          mutable_or_immutable) ->
-        simplify_make_block dacc prim dbg ~make_block_kind ~mutable_or_immutable
+      | Make_block (Values (tag, shape), mutable_or_immutable) ->
+        simplify_make_block_of_values dacc prim dbg tag ~shape
+          ~mutable_or_immutable
           args_with_tys ~result_var:result_var'
-      | Make_block _ ->
+      | Make_block (Naked_floats, _) | Make_array _ ->
+        (* CR mshinwell: The typing here needs to be improved *)
         let named =
           match args_changed with
           | Changed ->

--- a/middle_end/flambda2.0/terms/flambda.mli
+++ b/middle_end/flambda2.0/terms/flambda.mli
@@ -438,7 +438,7 @@ end and Continuation_params_and_handler : sig
       -> handler:Expr.t
       -> 'a)
     -> 'a
-  
+
   (** Choose members of two bindings' alpha-equivalence classes using the same
       parameters. *)
   val pattern_match_pair
@@ -613,6 +613,7 @@ end and Static_const : sig
     | Boxed_int32 of Int32.t Or_variable.t
     | Boxed_int64 of Int64.t Or_variable.t
     | Boxed_nativeint of Targetint.t Or_variable.t
+    | Immutable_float_block of Numbers.Float_by_bit_pattern.t Or_variable.t list
     | Immutable_float_array of Numbers.Float_by_bit_pattern.t Or_variable.t list
     | Mutable_string of { initial_value : string; }
     | Immutable_string of string

--- a/middle_end/flambda2.0/terms/flambda_primitive.ml
+++ b/middle_end/flambda2.0/terms/flambda_primitive.ml
@@ -72,7 +72,7 @@ module Block_kind = struct
       let c = Tag.Scannable.compare tag1 tag2 in
       if c <> 0 then c
       else Misc.Stdlib.List.compare Block_of_values_field.compare shape1 shape2
-    | Naked_floats, Naked_floats
+    | Naked_floats, Naked_floats -> 0
     | Values _, _ -> -1
     | _, Values _ -> 1
 

--- a/middle_end/flambda2.0/terms/flambda_primitive.ml
+++ b/middle_end/flambda2.0/terms/flambda_primitive.ml
@@ -27,214 +27,246 @@ type classification_for_printing =
   | Destructive
   | Neither
 
-module Value_kind = struct
+module Block_of_values_field = struct
   type t =
-    | Anything
-    | Definitely_pointer
-    | Definitely_immediate
+    | Any_value
+    | Immediate
+    | Boxed_float
+    | Boxed_int32
+    | Boxed_int64
+    | Boxed_nativeint
 
   let print ppf t =
     match t with
-    | Anything -> Format.pp_print_string ppf "Anything"
-    | Definitely_pointer -> Format.pp_print_string ppf "Definitely_pointer"
-    | Definitely_immediate -> Format.pp_print_string ppf "Definitely_immediate"
-
-  let to_int t =
-    match t with
-    | Anything -> 0
-    | Definitely_pointer -> 1
-    | Definitely_immediate -> 2
-
-  let compare t1 t2 = (to_int t1) - (to_int t2)
-end
-
-module Generic_array_specialisation = struct
-  type t =
-    | No_specialisation
-    | Full_of_naked_floats
-    | Full_of_immediates
-    | Full_of_arbitrary_values_but_not_floats
-
-  let check () =
-    if not Config.flat_float_array then begin
-      Misc.fatal_errorf "Generic arrays cannot be used unless the \
-        float array optimisation has been enabled at compiler configuration \
-        time"
-    end
-
-  let no_specialisation () =
-    check ();
-    No_specialisation
-
-  let full_of_naked_floats () =
-    check ();
-    Full_of_naked_floats
-
-  let full_of_immediates () =
-    check ();
-    Full_of_immediates
-
-  let full_of_arbitrary_values_but_not_floats () =
-    check ();
-    Full_of_arbitrary_values_but_not_floats
-
-  let print ppf t =
-    match t with
-    | No_specialisation -> Format.pp_print_string ppf "not-specialised"
-    | Full_of_naked_floats -> Format.pp_print_string ppf "floats"
-    | Full_of_immediates -> Format.pp_print_string ppf "imms"
-    | Full_of_arbitrary_values_but_not_floats ->
-      Format.pp_print_string ppf "non-floats"
+    | Any_value -> Format.fprintf ppf "Any_value"
+    | Immediate -> Format.fprintf ppf "Immediate"
+    | Boxed_float -> Format.fprintf ppf "Boxed_float"
+    | Boxed_int32 -> Format.fprintf ppf "Boxed_int32"
+    | Boxed_int64 -> Format.fprintf ppf "Boxed_int64"
+    | Boxed_nativeint -> Format.fprintf ppf "Boxed_nativeint"
 
   let compare = Stdlib.compare
 end
 
-(* CR mshinwell: These types should probably go in their own modules with
-   a comparison function next to each. *)
-
-type make_block_kind =
-  | Full_of_values of Tag.Scannable.t * (Value_kind.t list)
-  | Full_of_naked_floats
-  | Generic_array of Generic_array_specialisation.t
-
-let print_make_block_kind ppf kind =
-  match kind with
-  | Full_of_values (tag, shape) ->
-    Format.fprintf ppf "@[<hov 1>(Full_of_values@ (tag %a)@ (%a))@]"
-      Tag.Scannable.print tag
-      (Format.pp_print_list ~pp_sep:Format.pp_print_space
-        Value_kind.print) shape
-  | Full_of_naked_floats -> Format.pp_print_string ppf "Full_of_naked_floats"
-  | Generic_array generic ->
-    Format.fprintf ppf "@[<hov 1>(Generic@ %a)@]"
-      Generic_array_specialisation.print generic
-
-let compare_make_block_kind kind1 kind2 =
-  match kind1, kind2 with
-  | Full_of_values (tag1, shape1), Full_of_values (tag2, shape2) ->
-    let c = Tag.Scannable.compare tag1 tag2 in
-    if c <> 0 then c
-    else Misc.Stdlib.List.compare Value_kind.compare shape1 shape2
-  | Full_of_values _, _ -> -1
-  | _, Full_of_values _ -> 1
-  | Full_of_naked_floats, Full_of_naked_floats -> 0
-  | Generic_array spec1, Generic_array spec2 ->
-    Generic_array_specialisation.compare spec1 spec2
-  | _, Generic_array _ -> -1
-  | Generic_array _, _ -> 1
-
-type duplicate_block_kind =
-  | Full_of_values_known_length of Tag.Scannable.t
-  | Full_of_values_unknown_length of Tag.Scannable.t
-  | Full_of_naked_floats of { length : Targetint.OCaml.t option; }
-  | Generic_array of Generic_array_specialisation.t
-
-let print_duplicate_block_kind ppf (kind : duplicate_block_kind) =
-  match kind with
-  | Full_of_values_known_length tag ->
-    Format.fprintf ppf "%a" Tag.Scannable.print tag
-  | Full_of_values_unknown_length tag ->
-    Format.fprintf ppf "%a" Tag.Scannable.print tag
-  | Full_of_naked_floats { length = None; } ->
-    Format.pp_print_string ppf "floats"
-  | Full_of_naked_floats { length = Some length; } ->
-    Format.fprintf ppf "%a floats"
-      Targetint.OCaml.print length
-  | Generic_array spec ->
-    Format.fprintf ppf "generic %a"
-      Generic_array_specialisation.print spec
-
-(* CR-someday mshinwell: We should have unboxed arrays of int32, int64 and
-   nativeint. *)
-
-module Block_access_kind = struct
-  type t0 =
-    | Value of Value_kind.t
-    | Naked_float
-
+module Block_kind = struct
   type t =
-    | Block of { elt_kind : t0; tag : Tag.t; size : Lambda.block_size; }
-    | Array of t0
-    | Generic_array of Generic_array_specialisation.t
+    | Values of Tag.Scannable.t * (Block_of_values_field.t list)
+    | Naked_floats
 
-  let element_kind t =
+   let print ppf t =
     match t with
-    | Block { elt_kind = Value _; _ } | Array (Value _) -> K.value
-    | Block { elt_kind = Naked_float; _ } | Array Naked_float -> K.naked_float
-    | Generic_array _ -> Misc.fatal_error "Not yet implemented"
-
-  let compare_t0 (t0_1 : t0) t0_2 = Stdlib.compare t0_1 t0_2
+    | Values (tag, shape) ->
+      Format.fprintf ppf
+        "@[<hov 1>(Values@ \
+          @[<hov 1>(tag %a)@]@ \
+          @[<hov 1>(shape@ @[<hov 1>(%a)@])@])@]"
+        Tag.Scannable.print tag
+        (Format.pp_print_list ~pp_sep:Format.pp_print_space
+          Block_of_values_field.print) shape
+    | Naked_floats ->
+      Format.pp_print_string ppf "Naked_floats"
 
   let compare t1 t2 =
     match t1, t2 with
-    | Block _, Array _ -> -1
-    | Block _, Generic_array _ -> -1
-    | Array _, Block _ -> 1
-    | Array _, Generic_array _ -> -1
-    | Generic_array _, Block _ -> 1
-    | Generic_array _, Array _ -> 1
-    | Block { elt_kind = ek_1; tag = tag1; size = size1; },
-      Block { elt_kind = ek_2; tag = tag2; size = size2; } ->
-      let c = compare_t0 ek_1 ek_2 in
-      if c <> 0 then c else
-      let c = Tag.compare tag1 tag2 in
-      if c <> 0 then c else
-      Stdlib.compare (size1: Lambda.block_size) size2
-    | Array t0_1, Array t0_2 -> compare_t0 t0_1 t0_2
-    | Generic_array spec1, Generic_array spec2 ->
-      Generic_array_specialisation.compare spec1 spec2
+    | Values (tag1, shape1), Values (tag2, shape2) ->
+      let c = Tag.Scannable.compare tag1 tag2 in
+      if c <> 0 then c
+      else Misc.Stdlib.List.compare Block_of_values_field.compare shape1 shape2
+    | Naked_floats, Naked_floats
+    | Values _, _ -> -1
+    | _, Values _ -> 1
 
-  let print_t0 ppf t0 =
-    match t0 with
-    | Value kind ->
-      Format.fprintf ppf "@[(Value %a)@]" Value_kind.print kind
-    | Naked_float -> Format.pp_print_string ppf "Naked_float"
+  let element_kind t =
+    match t with
+    | Values _ -> K.value
+    | Naked_floats -> K.naked_float
+end
 
-  let print_block_size ppf (size: Lambda.block_size) =
-    match size with
-    | Unknown -> Format.pp_print_string ppf "unknown"
-    | Known sz -> Format.pp_print_int ppf sz
+module Array_kind = struct
+  type t =
+    | Immediates
+    | Values
+    | Naked_floats
+    | Float_array_opt_dynamic
 
-  let print ppf kind =
-    match kind with
-    | Block { elt_kind; tag; size; } ->
-      Format.fprintf ppf "(Block %a tag %a size %a)"
-        print_t0 elt_kind
-        Tag.print tag
-        print_block_size size
-    | Array t0 -> Format.fprintf ppf "(Array %a)" print_t0 t0
-    | Generic_array spec ->
-      Format.fprintf ppf "(Generic %a)"
-        Generic_array_specialisation.print spec
+  let print ppf t =
+    match t with
+    | Immediates -> Format.pp_print_string ppf "Immediates"
+    | Naked_floats -> Format.pp_print_string ppf "Naked_floats"
+    | Values -> Format.pp_print_string ppf "Values"
+    | Float_array_opt_dynamic ->
+      Format.pp_print_string ppf "Float_array_opt_dynamic"
 
-  let to_lambda_array_kind kind =
-    match (kind : t) with
-    (* Full naked float arrays *)
-    | Block { elt_kind = Naked_float; _ }
-    | Array Naked_float
-    | Generic_array Full_of_naked_floats -> Lambda.Pfloatarray
-    (* Arrays (or accesses) to immediate integers *)
-    | Block { elt_kind = Value Definitely_immediate; _ }
-    | Array Value Definitely_immediate
-    | Generic_array Full_of_immediates -> Lambda.Pintarray
-    (* Arrays of caml values (i.e specifically not naked floats) *)
-    | Block { elt_kind = Value (Anything|Definitely_pointer); _ }
-    | Array Value Definitely_pointer
-    | Generic_array Full_of_arbitrary_values_but_not_floats -> Lambda.Paddrarray
-    (* General case: the array might contain naked floats *)
-    | _ -> Lambda.Pgenarray
+  let compare = Stdlib.compare
 
+  let element_kind_for_set t =
+    match t with
+    | Immediates | Values | Float_array_opt_dynamic -> K.value
+    | Naked_floats -> K.naked_float
+
+  let element_kind_for_creation = element_kind_for_set
+  let element_kind_for_load = element_kind_for_set
+
+  let to_lambda t : Lambda.array_kind =
+    match t with
+    | Immediates -> Pintarray
+    | Values -> Paddrarray
+    | Naked_floats -> Pfloatarray
+    | Float_array_opt_dynamic -> Pgenarray
+end
+
+module Duplicate_block_kind = struct
+  type t =
+    | Values of { tag : Tag.Scannable.t; length : Targetint.OCaml.t; }
+    | Naked_floats of { length : Targetint.OCaml.t; }
+
+  let print ppf t =
+    match t with
+    | Values { tag; length; } ->
+      Format.fprintf ppf
+        "@[<hov 1>(Block_of_values \
+          @[<hov 1>(tag@ %a)@]@ \
+          @[<hov 1>(length@ %a)@]\
+          )@]"
+        Tag.Scannable.print tag
+        Targetint.OCaml.print length
+    | Naked_floats { length; } ->
+      Format.fprintf ppf
+        "@[<hov 1>(Block_of_naked_floats@ \
+          @[<hov 1>(length@ %a)@]\
+          )@]"
+        Targetint.OCaml.print length
+
+  let compare t1 t2 =
+    match t1, t2 with
+    | Values { tag = tag1; length = length1; },
+        Values { tag = tag2; length = length2; } ->
+      let c = Tag.Scannable.compare tag1 tag2 in
+      if c <> 0 then c
+      else Targetint.OCaml.compare length1 length2
+    | Naked_floats { length = length1; }, Naked_floats { length = length2; } ->
+      Targetint.OCaml.compare length1 length2
+    | Values _, Naked_floats _ -> -1
+    | Naked_floats _, Values _ -> 1
+end
+
+module Duplicate_array_kind = struct
+  type t =
+    | Immediates
+    | Values
+    | Naked_floats of { length : Targetint.OCaml.t option; }
+    | Float_array_opt_dynamic
+
+  let print ppf t =
+    match t with
+    | Immediates -> Format.pp_print_string ppf "Immediates"
+    | Values -> Format.pp_print_string ppf "Values"
+    | Naked_floats { length; } ->
+      Format.fprintf ppf
+        "@[<hov 1>(Naked_floats@ \
+          @[<hov 1>(length@ %a)@]\
+          )@]"
+        (Misc.Stdlib.Option.print Targetint.OCaml.print) length
+    | Float_array_opt_dynamic ->
+      Format.pp_print_string ppf "Float_array_opt_dynamic"
+
+  let compare t1 t2 =
+    match t1, t2 with
+    | Immediates, Immediates
+    | Values, Values
+    | Float_array_opt_dynamic, Float_array_opt_dynamic -> 0
+    | Naked_floats { length = length1; }, Naked_floats { length = length2; } ->
+      Option.compare Targetint.OCaml.compare length1 length2
+    | Immediates, _ -> -1
+    | _, Immediates -> 1
+    | Values, _ -> -1
+    | _, Values -> 1
+    | Naked_floats _, _ -> -1
+    | _, Naked_floats _ -> 1
+end
+
+module Block_access_field_kind = struct
+  type t =
+    | Any_value
+    | Immediate
+
+  let print ppf t =
+    match t with
+    | Any_value -> Format.pp_print_string ppf "Any_value"
+    | Immediate -> Format.pp_print_string ppf "Immediate"
+
+  let compare = Stdlib.compare
+end
+
+module Block_access_kind = struct
+  type t =
+    | Values of {
+        tag : Tag.Scannable.t;
+        size : Targetint.OCaml.t Or_unknown.t;
+        field_kind : Block_access_field_kind.t;
+      }
+    | Naked_floats of { size : Targetint.OCaml.t Or_unknown.t; }
+
+  let print ppf t =
+    match t with
+    | Values { tag; size; field_kind; } ->
+      Format.fprintf ppf
+        "@[<hov 1>(Values@ \
+          @[<hov 1>(tag@ %a)@]@ \
+          @[<hov 1>(size@ %a)@]@ \
+          @[<hov 1>(field_kind@ %a)@]\
+          )@]"
+        Tag.Scannable.print tag
+        (Or_unknown.print Targetint.OCaml.print) size
+        Block_access_field_kind.print field_kind
+    | Naked_floats { size; } ->
+      Format.fprintf ppf
+        "@[<hov 1>(Naked_floats@ \
+          @[<hov 1>(size@ %a)@]@\
+          )@]"
+        (Or_unknown.print Targetint.OCaml.print) size
+
+  let element_kind_for_load t =
+    match t with
+    | Values _ -> K.value
+    | Naked_floats _ -> K.naked_float
+
+  let element_kind_for_set = element_kind_for_load
+
+  let compare t1 t2 =
+    match t1, t2 with
+    | Values { tag = tag1; size = size1; field_kind = field_kind1; },
+        Values { tag = tag2; size = size2; field_kind = field_kind2; } ->
+      let c = Tag.Scannable.compare tag1 tag2 in
+      if c <> 0 then c
+      else
+        let c = Or_unknown.compare Targetint.OCaml.compare size1 size2 in
+        if c <> 0 then c
+        else Block_access_field_kind.compare field_kind1 field_kind2
+    | Naked_floats { size = size1; }, Naked_floats { size = size2; } ->
+      Or_unknown.compare Targetint.OCaml.compare size1 size2
+    | Values _, Naked_floats _ -> -1
+    | Naked_floats _, Values _ -> 1
 end
 
 type string_or_bytes = String | Bytes
 
-type init_or_assign = Initialization | Assignment
+module Init_or_assign = struct
+  type t = Initialization | Assignment
 
-let print_init_or_assign ppf init_or_assign =
-  let fprintf = Format.fprintf in
-  match init_or_assign with
-  | Initialization -> fprintf ppf "Init"
-  | Assignment -> fprintf ppf "Assign"
+  let print ppf t =
+    let fprintf = Format.fprintf in
+    match t with
+    | Initialization -> fprintf ppf "Init"
+    | Assignment -> fprintf ppf "Assign"
+
+  let compare = Stdlib.compare
+
+  let to_lambda t : Lambda.initialization_or_assignment =
+    match t with
+    | Initialization -> Heap_initialization
+    | Assignment -> Assignment
+end
 
 type array_like_operation = Reading | Writing
 
@@ -243,27 +275,39 @@ let effects_of_operation operation =
   | Reading -> Effects.No_effects
   | Writing -> Effects.Arbitrary_effects
 
-let reading_from_an_array_like_thing mutable_or_immutable =
+let reading_from_a_block mutable_or_immutable =
   let effects = effects_of_operation Reading in
   let coeffects =
-    match (mutable_or_immutable : Effects.mutable_or_immutable) with
+    match (mutable_or_immutable : Mutable_or_immutable.t) with
     | Immutable -> Coeffects.No_coeffects
     | Mutable -> Coeffects.Has_coeffects
   in
   effects, coeffects
 
-let writing_to_an_array_like_thing =
+let reading_from_an_array mutable_or_immutable =
+  reading_from_a_block mutable_or_immutable
+
+let reading_from_a_string_or_bigstring mutable_or_immutable =
+  reading_from_a_block mutable_or_immutable
+
+let writing_to_a_block =
   let effects = effects_of_operation Writing in
   effects, Coeffects.No_coeffects
 
-let array_like_thing_index_kind = K.value
-
+let writing_to_an_array = writing_to_a_block
+let writing_to_bytes_or_bigstring = writing_to_a_block
 
 (* CR mshinwell: Improve naming *)
 let bigarray_kind = K.value
 let bigstring_kind = K.value
 let block_kind = K.value
+let array_kind = K.value
 let string_or_bytes_kind = K.value
+
+let block_index_kind = K.value
+let array_index_kind = K.value
+let string_or_bigstring_index_kind = K.value
+let bytes_or_bigstring_index_kind = K.value
 
 type comparison = Eq | Neq | Lt | Gt | Le | Ge
 
@@ -465,13 +509,18 @@ type result_kind =
 
 type unary_primitive =
   | Duplicate_block of {
-      kind : duplicate_block_kind;
-      source_mutability : Effects.mutable_or_immutable;
-      destination_mutability : Effects.mutable_or_immutable;
+      kind : Duplicate_block_kind.t;
+      source_mutability : Mutable_or_immutable.t;
+      destination_mutability : Mutable_or_immutable.t;
+    }
+  | Duplicate_array of {
+      kind : Duplicate_array_kind.t;
+      source_mutability : Mutable_or_immutable.t;
+      destination_mutability : Mutable_or_immutable.t;
     }
   | Is_int
   | Get_tag
-  | Array_length of Block_access_kind.t
+  | Array_length of Array_kind.t
   | Bigarray_length of { dimension : int; }
   | String_length of string_or_bytes
   | Int_as_pointer
@@ -498,12 +547,17 @@ type unary_primitive =
    eligible for CSE, since we deal with projections through types. *)
 let unary_primitive_eligible_for_cse p ~arg =
   match p with
-  | Duplicate_block {
+  | Duplicate_array {
+      kind = _;
       source_mutability = Immutable;
       destination_mutability = Immutable;
-      _
+    }
+  | Duplicate_block {
+      kind = _;
+      source_mutability = Immutable;
+      destination_mutability = Immutable;
     } -> true
-  | Duplicate_block _ -> false
+  | Duplicate_array _ | Duplicate_block _ -> false
   | Is_int
   | Get_tag -> true
   | Array_length _ -> true
@@ -528,9 +582,10 @@ let unary_primitive_eligible_for_cse p ~arg =
 let compare_unary_primitive p1 p2 =
   let unary_primitive_numbering p =
     match p with
-    | Duplicate_block _ -> 0
-    | Is_int -> 1
-    | Get_tag -> 2
+    | Duplicate_array _ -> 0
+    | Duplicate_block _ -> 1
+    | Is_int -> 2
+    | Get_tag -> 3
     | Array_length _ -> 4
     | Bigarray_length _ -> 5
     | String_length _ -> 6
@@ -546,6 +601,21 @@ let compare_unary_primitive p1 p2 =
     | Project_var _ -> 16
   in
   match p1, p2 with
+  | Duplicate_array { kind = kind1;
+        source_mutability = source_mutability1;
+        destination_mutability = destination_mutability1;
+      },
+    Duplicate_array { kind = kind2;
+        source_mutability = source_mutability2;
+        destination_mutability = destination_mutability2;
+      } ->
+    let c = Duplicate_array_kind.compare kind1 kind2 in
+    if c <> 0 then c
+    else
+      let c = Stdlib.compare source_mutability1 source_mutability2 in
+      if c <> 0 then c
+      else
+        Stdlib.compare destination_mutability1 destination_mutability2
   | Duplicate_block { kind = kind1;
         source_mutability = source_mutability1;
         destination_mutability = destination_mutability1;
@@ -554,7 +624,7 @@ let compare_unary_primitive p1 p2 =
         source_mutability = source_mutability2;
         destination_mutability = destination_mutability2;
       } ->
-    let c = Stdlib.compare kind1 kind2 in
+    let c = Duplicate_block_kind.compare kind1 kind2 in
     if c <> 0 then c
     else
       let c = Stdlib.compare source_mutability1 source_mutability2 in
@@ -599,7 +669,8 @@ let compare_unary_primitive p1 p2 =
       let c = Closure_id.compare closure_id1 closure_id2 in
       if c <> 0 then c
       else Var_within_closure.compare var_within_closure1 var_within_closure2
-  | (Duplicate_block _
+  | (Duplicate_array _
+    | Duplicate_block _
     | Is_int
     | Get_tag
     | String_length _
@@ -622,10 +693,15 @@ let print_unary_primitive ppf p =
   let fprintf = Format.fprintf in
   match p with
   | Duplicate_block { kind; source_mutability; destination_mutability; } ->
-    fprintf ppf "(Duplicate_array %a (source %a) (dest %a))"
-      print_duplicate_block_kind kind
-      Effects.print_mutable_or_immutable source_mutability
-      Effects.print_mutable_or_immutable destination_mutability
+    fprintf ppf "@[<hov 1>(Duplicate_block %a (source %a) (dest %a))@]"
+      Duplicate_block_kind.print kind
+      Mutable_or_immutable.print source_mutability
+      Mutable_or_immutable.print destination_mutability
+  | Duplicate_array { kind; source_mutability; destination_mutability; } ->
+    fprintf ppf "@[<hov 1>(Duplicate_array %a (source %a) (dest %a))@]"
+      Duplicate_array_kind.print kind
+      Mutable_or_immutable.print source_mutability
+      Mutable_or_immutable.print destination_mutability
   | Is_int -> fprintf ppf "Is_int"
   | Get_tag -> fprintf ppf "Get_tag"
   | String_length _ -> fprintf ppf "String_length"
@@ -638,7 +714,9 @@ let print_unary_primitive ppf p =
       Flambda_kind.Standard_int_or_float.print_lowercase dst
   | Boolean_not -> fprintf ppf "Boolean_not"
   | Float_arith o -> print_unary_float_arith_op ppf o
-  | Array_length _ -> fprintf ppf "Array_length"
+  | Array_length kind ->
+    fprintf ppf "@[<hov 1>(Array_length@ %a)@]"
+      Array_kind.print kind
   | Bigarray_length { dimension; } ->
     fprintf ppf "Bigarray_length %a" print_num_dimensions dimension
   | Unbox_number Untagged_immediate -> fprintf ppf "Untag_imm"
@@ -661,6 +739,7 @@ let print_unary_primitive ppf p =
 
 let arg_kind_of_unary_primitive p =
   match p with
+  | Duplicate_array _
   | Duplicate_block _ -> K.value
   | Is_int -> K.value
   | Get_tag -> K.value
@@ -680,6 +759,7 @@ let arg_kind_of_unary_primitive p =
 
 let result_kind_of_unary_primitive p : result_kind =
   match p with
+  | Duplicate_array _
   | Duplicate_block _ -> Singleton K.value
   | Is_int
   | Get_tag -> Singleton K.naked_immediate
@@ -704,14 +784,18 @@ let result_kind_of_unary_primitive p : result_kind =
 
 let effects_and_coeffects_of_unary_primitive p =
   match p with
+  | Duplicate_array { kind = _;
+      source_mutability; destination_mutability; _ }
   | Duplicate_block { kind = _;
       source_mutability; destination_mutability; _ } ->
     begin match source_mutability with
     | Immutable ->
       (* [Obj.truncate] has now been removed. *)
-      Effects.Only_generative_effects destination_mutability, Coeffects.No_coeffects
+      Effects.Only_generative_effects destination_mutability,
+        Coeffects.No_coeffects
     | Mutable ->
-      Effects.Only_generative_effects destination_mutability, Coeffects.Has_coeffects
+      Effects.Only_generative_effects destination_mutability,
+        Coeffects.Has_coeffects
     end
   | Is_int -> Effects.No_effects, Coeffects.No_coeffects
   | Get_tag ->
@@ -733,9 +817,9 @@ let effects_and_coeffects_of_unary_primitive p =
   | Bigarray_length { dimension = _; } ->
     (* This is pretty much a direct access to a field of the bigarray,
        different from reading one of the values actually stored inside
-       the array, hence the array_like_thing (i.e. this has the same
+       the array, hence [reading_from_a_block] (i.e. this has the same
        behaviour as a regular Block_load). *)
-    reading_from_an_array_like_thing Mutable
+    reading_from_a_block Mutable
   | Unbox_number _ ->
     Effects.No_effects, Coeffects.No_coeffects
   | Box_number _ ->
@@ -745,6 +829,7 @@ let effects_and_coeffects_of_unary_primitive p =
 
 let unary_classify_for_printing p =
   match p with
+  | Duplicate_array _
   | Duplicate_block _ -> Constructive
   | String_length _
   | Get_tag -> Destructive
@@ -797,7 +882,8 @@ let print_binary_float_arith_op ppf o =
   | Div -> fprintf ppf "/."
 
 type binary_primitive =
-  | Block_load of Block_access_kind.t * Effects.mutable_or_immutable
+  | Block_load of Block_access_kind.t * Mutable_or_immutable.t
+  | Array_load of Array_kind.t * Mutable_or_immutable.t
   | String_or_bigstring_load of string_like_value * string_accessor_width
   | Bigarray_load of num_dimensions * bigarray_kind * bigarray_layout
   | Phys_equal of Flambda_kind.t * equality_comparison
@@ -810,6 +896,7 @@ type binary_primitive =
 
 let binary_primitive_eligible_for_cse p =
   match p with
+  | Array_load _
   | Block_load _ -> false
   | String_or_bigstring_load _ -> false  (* CR mshinwell: review *)
   | Bigarray_load _ -> false
@@ -832,21 +919,26 @@ let binary_primitive_eligible_for_cse p =
 let compare_binary_primitive p1 p2 =
   let binary_primitive_numbering p =
     match p with
-    | Block_load _ -> 0
-    | String_or_bigstring_load _ -> 1
-    | Bigarray_load _ -> 2
-    | Phys_equal _ -> 3
-    | Int_arith _ -> 4
-    | Int_shift _ -> 5
-    | Int_comp _ -> 6
-    | Float_arith _ -> 7
-    | Float_comp _ -> 8
+    | Array_load _ -> 0
+    | Block_load _ -> 1
+    | String_or_bigstring_load _ -> 2
+    | Bigarray_load _ -> 3
+    | Phys_equal _ -> 4
+    | Int_arith _ -> 5
+    | Int_shift _ -> 6
+    | Int_comp _ -> 7
+    | Float_arith _ -> 8
+    | Float_comp _ -> 9
   in
   match p1, p2 with
   | Block_load (kind1, mut1), Block_load (kind2, mut2) ->
     let c = Block_access_kind.compare kind1 kind2 in
     if c <> 0 then c
-    else Effects.compare_mutable_or_immutable mut1 mut2
+    else Mutable_or_immutable.compare mut1 mut2
+  | Array_load (kind1, mut1), Array_load (kind2, mut2) ->
+    let c = Array_kind.compare kind1 kind2 in
+    if c <> 0 then c
+    else Mutable_or_immutable.compare mut1 mut2
   | String_or_bigstring_load (string_like1, width1),
       String_or_bigstring_load (string_like2, width2) ->
     let c = Stdlib.compare string_like1 string_like2 in
@@ -885,6 +977,7 @@ let compare_binary_primitive p1 p2 =
   | Float_comp comp1, Float_comp comp2 ->
     Stdlib.compare comp1 comp2
   | (Block_load _
+    | Array_load _
     | String_or_bigstring_load _
     | Bigarray_load _
     | Phys_equal _
@@ -900,9 +993,13 @@ let print_binary_primitive ppf p =
   let fprintf = Format.fprintf in
   match p with
   | Block_load (kind, mut) ->
-    fprintf ppf "@[(Block_load %a %a)@]"
+    fprintf ppf "@[(Block_load@ %a@ %a)@]"
       Block_access_kind.print kind
-      Effects.print_mutable_or_immutable mut
+      Mutable_or_immutable.print mut
+  | Array_load (kind, mut) ->
+    fprintf ppf "@[(Array_load@ %a@ %a)@]"
+      Array_kind.print kind
+      Mutable_or_immutable.print mut
   | String_or_bigstring_load (string_like, width) ->
     fprintf ppf "@[(String_load %a %a)@]"
       print_string_like_value string_like
@@ -928,12 +1025,12 @@ let print_binary_primitive ppf p =
 
 let args_kind_of_binary_primitive p =
   match p with
-  | Block_load _ ->
-    block_kind, array_like_thing_index_kind
+  | Block_load _ -> block_kind, block_index_kind
+  | Array_load _ -> array_kind, array_index_kind
   | String_or_bigstring_load ((String | Bytes), _) ->
-    string_or_bytes_kind, array_like_thing_index_kind
+    string_or_bytes_kind, string_or_bigstring_index_kind
   | String_or_bigstring_load (Bigstring, _) ->
-    bigstring_kind, array_like_thing_index_kind
+    bigstring_kind, string_or_bigstring_index_kind
   | Bigarray_load (_, _, _) ->
     bigarray_kind, bigarray_index_kind
   | Phys_equal (kind, _) -> kind, kind
@@ -951,7 +1048,9 @@ let args_kind_of_binary_primitive p =
 let result_kind_of_binary_primitive p : result_kind =
   match p with
   | Block_load (block_access_kind, _) ->
-    Singleton (Block_access_kind.element_kind block_access_kind)
+    Singleton (Block_access_kind.element_kind_for_load block_access_kind)
+  | Array_load (kind, _) ->
+    Singleton (Array_kind.element_kind_for_load kind)
   | String_or_bigstring_load (_, (Eight | Sixteen)) ->
     Singleton K.naked_immediate
   | String_or_bigstring_load (_, Thirty_two) ->
@@ -969,12 +1068,13 @@ let result_kind_of_binary_primitive p : result_kind =
 
 let effects_and_coeffects_of_binary_primitive p =
   match p with
-  | Block_load (_, mut) -> reading_from_an_array_like_thing mut
+  | Block_load (_, mut) -> reading_from_a_block mut
+  | Array_load (_, mut) -> reading_from_an_array mut
   | Bigarray_load (_, kind, _) -> reading_from_a_bigarray kind
   | String_or_bigstring_load (String, _) ->
-    reading_from_an_array_like_thing Immutable
+    reading_from_a_string_or_bigstring Immutable
   | String_or_bigstring_load ((Bytes | Bigstring), _) ->
-    reading_from_an_array_like_thing Mutable
+    reading_from_a_string_or_bigstring Mutable
   | Phys_equal _ -> Effects.No_effects, Coeffects.No_coeffects
   | Int_arith (_kind, (Add | Sub | Mul | Div | Mod | And | Or | Xor)) ->
     Effects.No_effects, Coeffects.No_coeffects
@@ -985,7 +1085,8 @@ let effects_and_coeffects_of_binary_primitive p =
 
 let binary_classify_for_printing p =
   match p with
-  | Block_load _ -> Destructive
+  | Block_load _
+  | Array_load _ -> Destructive
   | Phys_equal _
   | Int_arith _
   | Int_shift _
@@ -996,13 +1097,15 @@ let binary_classify_for_printing p =
   | String_or_bigstring_load _ -> Neither
 
 type ternary_primitive =
-  | Block_set of Block_access_kind.t * init_or_assign
+  | Block_set of Block_access_kind.t * Init_or_assign.t
+  | Array_set of Array_kind.t * Init_or_assign.t
   | Bytes_or_bigstring_set of bytes_like_value * string_accessor_width
   | Bigarray_set of num_dimensions * bigarray_kind * bigarray_layout
 
 let ternary_primitive_eligible_for_cse p =
   match p with
   | Block_set _
+  | Array_set _
   | Bytes_or_bigstring_set _
   | Bigarray_set _ -> false
 
@@ -1010,15 +1113,20 @@ let compare_ternary_primitive p1 p2 =
   let ternary_primitive_numbering p =
     match p with
     | Block_set _ -> 0
-    | Bytes_or_bigstring_set _ -> 1
-    | Bigarray_set _ -> 2
+    | Array_set _ -> 1
+    | Bytes_or_bigstring_set _ -> 2
+    | Bigarray_set _ -> 3
   in
   match p1, p2 with
   | Block_set (kind1, init_or_assign1),
       Block_set (kind2, init_or_assign2) ->
     let c = Block_access_kind.compare kind1 kind2 in
     if c <> 0 then c
-    else Stdlib.compare init_or_assign1 init_or_assign2
+    else Init_or_assign.compare init_or_assign1 init_or_assign2
+  | Array_set (kind1, init_or_assign1), Array_set (kind2, init_or_assign2) ->
+    let c = Array_kind.compare kind1 kind2 in
+    if c <> 0 then c
+    else Init_or_assign.compare init_or_assign1 init_or_assign2
   | Bytes_or_bigstring_set (kind1, width1),
       Bytes_or_bigstring_set (kind2, width2) ->
     let c = Stdlib.compare kind1 kind2 in
@@ -1033,6 +1141,7 @@ let compare_ternary_primitive p1 p2 =
       if c <> 0 then c
       else Stdlib.compare layout1 layout2
   | (Block_set _
+    | Array_set _
     | Bytes_or_bigstring_set _
     | Bigarray_set _ ), _ ->
     Stdlib.compare (ternary_primitive_numbering p1)
@@ -1044,7 +1153,11 @@ let print_ternary_primitive ppf p =
   | Block_set (kind, init) ->
     fprintf ppf "(Block_set %a %a)"
       Block_access_kind.print kind
-      print_init_or_assign init
+      Init_or_assign.print init
+  | Array_set (kind, init) ->
+    fprintf ppf "(Array_set %a %a)"
+      Array_kind.print kind
+      Init_or_assign.print init
   | Bytes_or_bigstring_set (kind, string_accessor_width) ->
     fprintf ppf "(Bytes_set %a %a)"
       print_bytes_like_value kind
@@ -1061,103 +1174,108 @@ let print_ternary_primitive ppf p =
 
 let args_kind_of_ternary_primitive p =
   match p with
-  | Block_set (block_access_kind, _) ->
-    block_kind, array_like_thing_index_kind,
-      Block_access_kind.element_kind block_access_kind
+  | Block_set (access_kind, _) ->
+    block_kind, block_index_kind,
+      Block_access_kind.element_kind_for_set access_kind
+  | Array_set (kind, _) ->
+    array_kind, array_index_kind, Array_kind.element_kind_for_set kind
   | Bytes_or_bigstring_set (Bytes, (Eight | Sixteen)) ->
-    string_or_bytes_kind, array_like_thing_index_kind,
-      K.naked_immediate
+    string_or_bytes_kind, bytes_or_bigstring_index_kind, K.naked_immediate
   | Bytes_or_bigstring_set (Bytes, Thirty_two) ->
-    string_or_bytes_kind, array_like_thing_index_kind,
-      K.naked_int32
+    string_or_bytes_kind, bytes_or_bigstring_index_kind, K.naked_int32
   | Bytes_or_bigstring_set (Bytes, Sixty_four) ->
-    string_or_bytes_kind, array_like_thing_index_kind,
-      K.naked_int64
+    string_or_bytes_kind, bytes_or_bigstring_index_kind, K.naked_int64
   | Bytes_or_bigstring_set (Bigstring, (Eight | Sixteen)) ->
-    bigstring_kind, array_like_thing_index_kind,
-      K.naked_immediate
+    bigstring_kind, bytes_or_bigstring_index_kind, K.naked_immediate
   | Bytes_or_bigstring_set (Bigstring, Thirty_two) ->
-    bigstring_kind, array_like_thing_index_kind,
-      K.naked_int32
+    bigstring_kind, bytes_or_bigstring_index_kind, K.naked_int32
   | Bytes_or_bigstring_set (Bigstring, Sixty_four) ->
-    bigstring_kind, array_like_thing_index_kind,
-      K.naked_int64
+    bigstring_kind, bytes_or_bigstring_index_kind, K.naked_int64
   | Bigarray_set (_, kind, _) ->
-    let new_value = element_kind_of_bigarray_kind kind in
-    bigarray_kind, bigarray_index_kind, new_value
+    bigarray_kind, bigarray_index_kind, element_kind_of_bigarray_kind kind
 
 let result_kind_of_ternary_primitive p : result_kind =
   match p with
   | Block_set _
+  | Array_set _
   | Bytes_or_bigstring_set _
   | Bigarray_set _ -> Unit
 
 let effects_and_coeffects_of_ternary_primitive p =
   match p with
-  | Block_set _
-  | Bytes_or_bigstring_set _ -> writing_to_an_array_like_thing
+  | Block_set _ -> writing_to_a_block
+  | Array_set _ -> writing_to_an_array
+  | Bytes_or_bigstring_set _ -> writing_to_bytes_or_bigstring
   | Bigarray_set (_, kind, _) -> writing_to_a_bigarray kind
 
 let ternary_classify_for_printing p =
   match p with
   | Block_set _
+  | Array_set _
   | Bytes_or_bigstring_set _
   | Bigarray_set _ -> Neither
 
 type variadic_primitive =
-  | Make_block of make_block_kind * Effects.mutable_or_immutable
+  | Make_block of Block_kind.t * Mutable_or_immutable.t
+  | Make_array of Array_kind.t * Mutable_or_immutable.t
 
 let variadic_primitive_eligible_for_cse p ~args =
   match p with
-  | Make_block (_, Immutable) ->
+  | Make_block (_, Immutable) | Make_array (_, Immutable) ->
     (* See comment in [unary_primitive_eligible_for_cse], above, on
        [Box_number] case. *)
     List.exists (fun arg -> Simple.is_var arg) args
-  | Make_block (_, Mutable) -> false
+  | Make_block (_, Mutable) | Make_array (_, Mutable) -> false
 
 let compare_variadic_primitive p1 p2 =
   match p1, p2 with
   | Make_block (kind1, mut1), Make_block (kind2, mut2) ->
-    let c = compare_make_block_kind kind1 kind2 in
+    let c = Block_kind.compare kind1 kind2 in
     if c <> 0 then c
     else Stdlib.compare mut1 mut2
+  | Make_array (kind1, mut1), Make_array (kind2, mut2) ->
+    let c = Array_kind.compare kind1 kind2 in
+    if c <> 0 then c
+    else Stdlib.compare mut1 mut2
+  | Make_block _, Make_array _ -> -1
+  | Make_array _, Make_block _ -> 1
 
 let print_variadic_primitive ppf p =
   let fprintf = Format.fprintf in
   match p with
   | Make_block (kind, mut) ->
     fprintf ppf "@[<hov 1>(Make_block@ %a@ %a)@]"
-      print_make_block_kind kind
-      Effects.print_mutable_or_immutable mut
+      Block_kind.print kind
+      Mutable_or_immutable.print mut
+  | Make_array (kind, mut) ->
+    fprintf ppf "@[<hov 1>(Make_array@ %a@ %a)@]"
+      Array_kind.print kind
+      Mutable_or_immutable.print mut
 
 let args_kind_of_variadic_primitive p : arg_kinds =
   match p with
-  | Make_block (Full_of_values (_tag, _shape), _) ->
-    Variadic_all_of_kind K.value
-  | Make_block (Full_of_naked_floats, _) ->
-    Variadic_all_of_kind K.naked_float
-  | Make_block (Generic_array No_specialisation, _) ->
-    Variadic_all_of_kind K.value
-  | Make_block (Generic_array Full_of_naked_floats, _) ->
-    Variadic_all_of_kind K.naked_float
-  | Make_block (Generic_array Full_of_immediates, _) ->
-    Variadic_all_of_kind K.value
-  | Make_block (Generic_array Full_of_arbitrary_values_but_not_floats, _) ->
-    Variadic_all_of_kind K.value
+  | Make_block (kind, _) ->
+    Variadic_all_of_kind (Block_kind.element_kind kind)
+  | Make_array (kind, _) ->
+    Variadic_all_of_kind (Array_kind.element_kind_for_creation kind)
 
 let result_kind_of_variadic_primitive p : result_kind =
   match p with
-  | Make_block _ -> Singleton K.value
+  | Make_block _
+  | Make_array _ -> Singleton K.value
 
-let effects_and_coeffects_of_variadic_primitive p =
+let effects_and_coeffects_of_variadic_primitive p ~args =
   match p with
-  (* CR mshinwell: Arrays of size zero? *)
-  | Make_block (_, mut) ->
-    Effects.Only_generative_effects mut, Coeffects.No_coeffects
+  | Make_block (_, mut) | Make_array (_, mut) ->
+    if List.length args >= 1 then
+      Effects.Only_generative_effects mut, Coeffects.No_coeffects
+    else  (* zero-sized blocks and arrays are preallocated ("atoms"). *)
+      Effects.No_effects, Coeffects.No_coeffects
 
 let variadic_classify_for_printing p =
   match p with
-  | Make_block _ -> Constructive
+  | Make_block _
+  | Make_array _ -> Constructive
 
 type t =
   | Unary of unary_primitive * Simple.t
@@ -1182,6 +1300,7 @@ let invariant env t =
       E.add_use_of_closure_id env project_from;
       E.add_use_of_var_within_closure env var;
       E.check_simple_is_bound_and_of_kind env closure K.value
+    | Duplicate_array _, _
     | Duplicate_block _, _
     | Is_int, _
     | Get_tag, _
@@ -1205,6 +1324,7 @@ let invariant env t =
     (* None of these currently contain names: this is here so that we
        are reminded to check upon adding a new primitive. *)
     | Block_load _
+    | Array_load _
     | String_or_bigstring_load _
     | Bigarray_load _
     | Phys_equal _
@@ -1221,6 +1341,7 @@ let invariant env t =
     E.check_simple_is_bound_and_of_kind env x2 kind2;
     begin match prim with
     | Block_set _
+    | Array_set _
     | Bytes_or_bigstring_set _
     | Bigarray_set _ -> ()
     end
@@ -1235,7 +1356,8 @@ let invariant env t =
         E.check_simple_is_bound_and_of_kind env var kind)
       xs kinds;
     begin match prim with
-    | Make_block _ -> ()
+    | Make_block _
+     | Make_array _ -> ()
     end
 
 let classify_for_printing t =
@@ -1411,7 +1533,8 @@ let effects_and_coeffects (t : t) =
   | Unary (prim, _) -> effects_and_coeffects_of_unary_primitive prim
   | Binary (prim, _, _) -> effects_and_coeffects_of_binary_primitive prim
   | Ternary (prim, _, _, _) -> effects_and_coeffects_of_ternary_primitive prim
-  | Variadic (prim, _) -> effects_and_coeffects_of_variadic_primitive prim
+  | Variadic (prim, args) ->
+    effects_and_coeffects_of_variadic_primitive prim ~args
 
 let no_effects_or_coeffects t =
   match effects_and_coeffects t with

--- a/middle_end/flambda2.0/terms/static_const.rec.mli
+++ b/middle_end/flambda2.0/terms/static_const.rec.mli
@@ -79,6 +79,7 @@ type t =
   | Boxed_int32 of Int32.t Or_variable.t
   | Boxed_int64 of Int64.t Or_variable.t
   | Boxed_nativeint of Targetint.t Or_variable.t
+  | Immutable_float_block of Numbers.Float_by_bit_pattern.t Or_variable.t list
   | Immutable_float_array of Numbers.Float_by_bit_pattern.t Or_variable.t list
   | Mutable_string of { initial_value : string; }
   | Immutable_string of string

--- a/middle_end/flambda2.0/to_cmm/un_cps_helper.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps_helper.ml
@@ -15,6 +15,7 @@
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
 open Cmm_helpers
+module P = Flambda_primitive
 
 (* Are we compiling on/for a 32-bit architecture ? *)
 let arch32 = Arch.size_int = 4
@@ -223,18 +224,15 @@ let make_alloc_safe ?(dbg=Debuginfo.none) tag = function
   | [] -> static_atom ~dbg tag
   | args -> make_alloc dbg tag args
 
-let make_block ?(dbg=Debuginfo.none) kind args =
-  match (kind : Flambda_primitive.make_block_kind) with
-  | Full_of_values (tag, _) ->
-      make_alloc_safe ~dbg (Tag.Scannable.to_int tag) args
-  | Full_of_naked_floats
-  | Generic_array Full_of_naked_floats ->
+let make_array ?(dbg=Debuginfo.none) kind args =
+  match (kind : Flambda_primitive.Array_kind.t) with
+  | Naked_floats ->
       begin match args with
       | [] -> static_atom ~dbg 0 (* 0-size arrays, even float arrays, should have
                                     tag 0, see runtime/array.c:caml_make_vec *)
       | _ -> make_float_alloc dbg (Tag.to_int Tag.double_array_tag) args
       end
-  | Generic_array No_specialisation ->
+  | Float_array_opt_dynamic ->
       begin match args with
       | [] -> static_atom ~dbg 0
       | _ ->
@@ -242,8 +240,13 @@ let make_block ?(dbg=Debuginfo.none) kind args =
             "caml_make_array" Cmm.typ_val
             [make_alloc dbg 0 args]
       end
-  | _ ->
+  | Immediates | Values ->
       make_alloc_safe ~dbg 0 args
+
+let make_block ?(dbg=Debuginfo.none) kind args =
+  match (kind : Flambda_primitive.Block_kind.t) with
+  | Values (tag, _) -> make_alloc_safe ~dbg (Tag.Scannable.to_int tag) args
+  | Naked_floats -> make_array ~dbg Naked_floats args
 
 let make_closure_block ?(dbg=Debuginfo.none) l =
   assert (List.compare_length_with l 0 > 0);
@@ -252,42 +255,68 @@ let make_closure_block ?(dbg=Debuginfo.none) l =
 
 (* Block access *)
 
-let array_kind_of_block_access =
-  Flambda_primitive.Block_access_kind.to_lambda_array_kind
+let block_length ?(dbg=Debuginfo.none) block = get_size block dbg
 
-let block_length ?(dbg=Debuginfo.none) block_access_kind block =
-  arraylength (array_kind_of_block_access block_access_kind) block dbg
+let block_load ?(dbg=Debuginfo.none) (kind : P.Block_access_kind.t)
+      (mutability : Mutable_or_immutable.t) block index =
+  let mutability = Mutable_or_immutable.to_lambda mutability in
+  match kind with
+  | Values { field_kind = Any_value; _ } ->
+    get_field_computed Pointer mutability ~block ~index dbg
+  | Values { field_kind = Immediate; _ } ->
+    get_field_computed Immediate mutability ~block ~index dbg
+  | Naked_floats _ -> unboxed_float_array_ref block index dbg
 
-let block_load ?(dbg=Debuginfo.none) kind block index =
-  match array_kind_of_block_access kind with
-  | Lambda.Pintarray -> int_array_ref block index dbg
-  | Lambda.Paddrarray -> addr_array_ref block index dbg
-  | Lambda.Pfloatarray -> unboxed_float_array_ref block index dbg
-  | Lambda.Pgenarray ->
-      ite ~dbg (is_addr_array_ptr block dbg)
-        ~then_:(addr_array_ref block index dbg) ~then_dbg:dbg
-        ~else_:(float_array_ref block index dbg) ~else_dbg:dbg
+let block_set ?(dbg=Debuginfo.none) (kind : P.Block_access_kind.t)
+      (init : P.Init_or_assign.t) block index new_value =
+  let init_or_assign = P.Init_or_assign.to_lambda init in
+  match kind with
+  | Values { field_kind = Any_value; _ } ->
+    setfield_computed Pointer init_or_assign block index new_value dbg
+    |> return_unit dbg
+  | Values { field_kind = Immediate; _ } ->
+    setfield_computed Immediate init_or_assign block index new_value dbg
+    |> return_unit dbg
+  | Naked_floats _ ->
+    float_array_set block index new_value dbg
+    |> return_unit dbg
 
-let addr_array_store init block index value dbg =
-  match (init : Flambda_primitive.init_or_assign) with
-  | Assignment -> addr_array_set block index value dbg
-  | Initialization -> addr_array_initialize block index value dbg
+(* Array access *)
 
-let block_set ?(dbg=Debuginfo.none) kind init block index value =
-  match (array_kind_of_block_access kind : Lambda.array_kind) with
-  | Pintarray ->
-      return_unit dbg (int_array_set block index value dbg)
-  | Pfloatarray ->
-      return_unit dbg (float_array_set block index value dbg)
-  | Paddrarray ->
-      return_unit dbg (addr_array_store init block index value dbg)
-  | Pgenarray ->
-      return_unit dbg (
-        ite ~dbg (is_addr_array_ptr block dbg)
-          ~then_:(addr_array_store init block index value dbg) ~then_dbg:dbg
-          ~else_:(float_array_set block index (unbox_float dbg value) dbg) ~else_dbg:dbg
-      )
+let array_length ?(dbg=Debuginfo.none) kind arr =
+  arraylength (P.Array_kind.to_lambda kind) arr dbg
 
+let array_load ?(dbg=Debuginfo.none) (kind : P.Array_kind.t) arr index =
+  match kind with
+  | Immediates -> int_array_ref arr index dbg
+  | Values -> addr_array_ref arr index dbg
+  | Naked_floats -> unboxed_float_array_ref arr index dbg
+  | Float_array_opt_dynamic ->
+    ite ~dbg (is_addr_array_ptr arr dbg)
+      ~then_:(addr_array_ref arr index dbg) ~then_dbg:dbg
+      ~else_:(float_array_ref arr index dbg) ~else_dbg:dbg
+
+let addr_array_store init arr index value dbg =
+  match (init : P.Init_or_assign.t) with
+  | Assignment -> addr_array_set arr index value dbg
+  | Initialization -> addr_array_initialize arr index value dbg
+
+let array_set ?(dbg=Debuginfo.none) (kind : P.Array_kind.t)
+      (init : P.Init_or_assign.t) arr index value =
+  match kind with
+  | Immediates -> return_unit dbg (int_array_set arr index value dbg)
+  | Values -> return_unit dbg (addr_array_store init arr index value dbg)
+  | Naked_floats -> return_unit dbg (float_array_set arr index value dbg)
+  | Float_array_opt_dynamic ->
+    ite ~dbg
+      (is_addr_array_ptr arr dbg)
+      ~then_:(addr_array_store init arr index value dbg)
+      ~then_dbg:dbg
+      ~else_:(float_array_set arr index (unbox_float dbg value) dbg)
+      ~else_dbg:dbg
+    |> return_unit dbg
+
+(* String and bytes access *)
 
 (* here, block and ptr are different only for bigstrings, because the
    extcall must apply to the whole bigstring block (variable [block]),

--- a/middle_end/flambda2.0/to_cmm/un_cps_helper.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps_helper.ml
@@ -246,7 +246,12 @@ let make_array ?(dbg=Debuginfo.none) kind args =
 let make_block ?(dbg=Debuginfo.none) kind args =
   match (kind : Flambda_primitive.Block_kind.t) with
   | Values (tag, _) -> make_alloc_safe ~dbg (Tag.Scannable.to_int tag) args
-  | Naked_floats -> make_array ~dbg Naked_floats args
+  | Naked_floats ->
+    if List.length args < 1 then begin
+      Misc.fatal_error "Don't know what tag to put on zero-sized blocks \
+        of naked floats"
+    end;
+    make_array ~dbg Naked_floats args
 
 let make_closure_block ?(dbg=Debuginfo.none) l =
   assert (List.compare_length_with l 0 > 0);

--- a/middle_end/flambda2.0/to_cmm/un_cps_helper.mli
+++ b/middle_end/flambda2.0/to_cmm/un_cps_helper.mli
@@ -76,14 +76,21 @@ val targetint : ?dbg:Debuginfo.t -> Targetint.t -> Cmm.expression
 
 (** {2 Block creation} *)
 
+val make_array :
+  ?dbg:Debuginfo.t -> Flambda_primitive.Array_kind.t ->
+  Cmm.expression list -> Cmm.expression
+(** Create an array using the given fields. *)
+
 val make_block :
-  ?dbg:Debuginfo.t -> Flambda_primitive.make_block_kind ->
+  ?dbg:Debuginfo.t -> Flambda_primitive.Block_kind.t ->
   Cmm.expression list -> Cmm.expression
 (** Create a block using the given fields. *)
 
 val make_closure_block :
   ?dbg:Debuginfo.t -> Cmm.expression list -> Cmm.expression
 (** Create a closure block. *)
+
+(** {2 Boxed numbers} *)
 
 val box_number :
   ?dbg:Debuginfo.t ->
@@ -94,6 +101,11 @@ val box_number :
 val box_int64 : ?dbg:Debuginfo.t -> Cmm.expression -> Cmm.expression
 (** Shortcut for [box_number Flambda_kind.Boxable_number.Naked_int64] *)
 
+val unbox_number :
+  ?dbg:Debuginfo.t ->
+  Flambda_kind.Boxable_number.t ->
+  Cmm.expression -> Cmm.expression
+(** Unbox a boxed number. *)
 
 (** {2 Block access} *)
 
@@ -105,17 +117,58 @@ val infix_field_address :
     header, so that the returned address is in fact a correct ocaml value. *)
 
 val block_length :
-  ?dbg:Debuginfo.t -> Flambda_primitive.Block_access_kind.t ->
-  Cmm.expression -> Cmm.expression
+  ?dbg:Debuginfo.t -> Cmm.expression -> Cmm.expression
 (** Return an expression that computes the length of the given block. *)
 
 val block_load :
   ?dbg:Debuginfo.t -> Flambda_primitive.Block_access_kind.t ->
+  Mutable_or_immutable.t ->
   Cmm.expression -> Cmm.expression -> Cmm.expression
-(** Load a field from a block. Cmm arguments order:
+(** Load a field from a block. Cmm argument order:
     - block
     - field number as a tagged integer
 *)
+
+val block_set :
+  ?dbg:Debuginfo.t ->
+  Flambda_primitive.Block_access_kind.t ->
+  Flambda_primitive.Init_or_assign.t ->
+  Cmm.expression -> Cmm.expression -> Cmm.expression -> Cmm.expression
+(* CR mshinwell: These functions should have labelled arguments so we don't
+   need comments *)
+(** Set a field in a block. Cmm argument order:
+    - block
+    - field number as a tagged integer
+    - new value for the field.
+*)
+
+(** {2 Array access} *)
+
+val array_length :
+  ?dbg:Debuginfo.t -> Flambda_primitive.Array_kind.t ->
+  Cmm.expression -> Cmm.expression
+(** Return an expression that computes the length of the given array. *)
+
+val array_load :
+  ?dbg:Debuginfo.t -> Flambda_primitive.Array_kind.t ->
+  Cmm.expression -> Cmm.expression -> Cmm.expression
+(** Load a field from an array. Cmm argument order:
+    - array
+    - field number as a tagged integer
+*)
+
+val array_set :
+  ?dbg:Debuginfo.t ->
+  Flambda_primitive.Array_kind.t ->
+  Flambda_primitive.Init_or_assign.t ->
+  Cmm.expression -> Cmm.expression -> Cmm.expression -> Cmm.expression
+(** Set a field in an array. Cmm argument order:
+    - array
+    - field number as a tagged integer
+    - new value for the field.
+*)
+
+(** {2 String and Bytes access} *)
 
 val string_like_load :
   ?dbg:Debuginfo.t ->
@@ -126,17 +179,6 @@ val string_like_load :
     bigstring). Cmm arguments order:
     - string-like value
     - index within the string as a tagged integer
-*)
-
-val block_set :
-  ?dbg:Debuginfo.t ->
-  Flambda_primitive.Block_access_kind.t ->
-  Flambda_primitive.init_or_assign ->
-  Cmm.expression -> Cmm.expression -> Cmm.expression -> Cmm.expression
-(** Set a field from a block. Cmm arguments order:
-    - block
-    - field number as a tagged integer
-    - new value for the field.
 *)
 
 val bytes_like_set :
@@ -150,13 +192,6 @@ val bytes_like_set :
     - index within the string as a tagged integer
     - new value for the bits set
 *)
-
-val unbox_number :
-  ?dbg:Debuginfo.t ->
-  Flambda_kind.Boxable_number.t ->
-  Cmm.expression -> Cmm.expression
-(** Unbox a boxed number. *)
-
 
 (** {2 Bigarrays} *)
 

--- a/middle_end/flambda2.0/to_cmm/un_cps_static.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps_static.ml
@@ -353,7 +353,8 @@ let static_const0 env r ~params_and_body (bound_symbols : Bound_symbols.t)
           Cmm.Word_int env s default C.emit_nativeint_constant transl v r
       in
       env, r, updates
-  | Singleton s, Immutable_float_array fields ->
+  | Singleton s,
+    (Immutable_float_block fields | Immutable_float_array fields) ->
       let name = symbol s in
       let aux =
         Or_variable.value_map ~default:0.
@@ -376,8 +377,8 @@ let static_const0 env r ~params_and_body (bound_symbols : Bound_symbols.t)
         SC.print static_const
   | Sets_of_closures _,
     (Block _ | Boxed_float _ | Boxed_int32 _ | Boxed_int64 _
-      | Boxed_nativeint _ | Immutable_float_array _ | Mutable_string _
-      | Immutable_string _) ->
+      | Boxed_nativeint _ | Immutable_float_block _
+      | Immutable_float_array _ | Mutable_string _ | Immutable_string _) ->
       Misc.fatal_errorf "Only [Code_and_set_of_closures] can be bound by a \
           [Code_and_set_of_closures] binding:@ %a"
         SC.print static_const

--- a/middle_end/internal_variable_names.ml
+++ b/middle_end/internal_variable_names.ml
@@ -135,6 +135,7 @@ let plsrbint = "Plsrbint"
 let plsrint = "Plsrint"
 let pmakearray = "Pmakearray"
 let pmakeblock = "Pmakeblock"
+let pmakefloatblock = "Pmakefloatblock"
 let pmodbint = "Pmodbint"
 let pmodint = "Pmodint"
 let pmulbint = "Pmulbint"
@@ -236,6 +237,7 @@ let plsrbint_arg = "Plsrbint_arg"
 let plsrint_arg = "Plsrint_arg"
 let pmakearray_arg = "Pmakearray_arg"
 let pmakeblock_arg = "Pmakeblock_arg"
+let pmakefloatblock_arg = "Pmakefloatblock_arg"
 let pmodbint_arg = "Pmodbint_arg"
 let pmodint_arg = "Pmodint_arg"
 let pmulbint_arg = "Pmulbint_arg"
@@ -316,6 +318,7 @@ let of_primitive : Lambda.primitive -> string = function
   | Pgetglobal _ -> pgetglobal
   | Psetglobal _ -> psetglobal
   | Pmakeblock _ -> pmakeblock
+  | Pmakefloatblock _ -> pmakefloatblock
   | Pfield _ -> pfield
   | Pfield_computed _ -> pfield_computed
   | Psetfield _ -> psetfield
@@ -421,6 +424,7 @@ let of_primitive_arg : Lambda.primitive -> string = function
   | Pgetglobal _ -> pgetglobal_arg
   | Psetglobal _ -> psetglobal_arg
   | Pmakeblock _ -> pmakeblock_arg
+  | Pmakefloatblock _ -> pmakefloatblock_arg
   | Pfield _ -> pfield_arg
   | Pfield_computed _ -> pfield_computed_arg
   | Psetfield _ -> psetfield_arg

--- a/testsuite/tests/translprim/ref_spec.compilers.reference
+++ b/testsuite/tests/translprim/ref_spec.compilers.reference
@@ -17,7 +17,7 @@
          cst_rec = (makemutable 0 0a 0a)
          gen_rec = (makemutable 0 0a 0a)
          flt_rec = (makemutable 0 (*,float) 0a 0.)
-         flt_rec' = (makearray[float] 0. 0.))
+         flt_rec' = (makefloatblock Mutable 0. 0.))
         (seq (setfield_imm 1 int_rec 2) (setfield_imm 1 var_rec 66a)
           (setfield_ptr 1 vargen_rec [0: 66 0])
           (setfield_ptr 1 vargen_rec 67a) (setfield_imm 1 cst_rec 1a)

--- a/tools/dumpobj.ml
+++ b/tools/dumpobj.ml
@@ -104,6 +104,10 @@ let rec print_struct_const = function
           List.iter (fun a -> printf ", "; print_struct_const a) al;
           printf ")"
       end
+  | Const_float_block a ->
+      printf "[|b ";
+      List.iter (fun f -> print_float f; printf "; ") a;
+      printf "|]"
   | Const_float_array a ->
       printf "[|";
       List.iter (fun f -> print_float f; printf "; ") a;


### PR DESCRIPTION
This follows on from a discovery that integer array modification was calling caml_modify. We now handle arrays and blocks separately for the various primitives (load, store, etc.) as we should have done all along.