### PR TITLE
Tagged switch

### DIFF
--- a/middle_end/flambda2.0/to_cmm/un_cps.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps.ml
@@ -56,6 +56,16 @@ let nativeint_of_targetint t =
   | Int32 i -> Nativeint.of_int32 i
   | Int64 i -> Int64.to_nativeint i
 
+(* CR gbury: {Targetint.to_int} should raise an error when converting
+              an out-of-range integer. *)
+let int_of_targetint t =
+  let i = Targetint.to_int t in
+  let t' = Targetint.of_int i in
+  if not (Targetint.equal t t') then
+    Misc.fatal_errorf "Cannot translate targetint to caml int";
+  i
+
+
 (* Name expressions *)
 
 let symbol s =
@@ -158,58 +168,58 @@ let arithmetic_conversion dbg src dst arg =
   match src, dst with
   (* 64-bit on 32-bit host specific cases *)
   | Naked_int64, Tagged_immediate when C.arch32 ->
-      C.extcall ~alloc:false "caml_int64_to_int" typ_int [arg]
+      None, C.extcall ~alloc:false "caml_int64_to_int" typ_int [arg]
   | Naked_int64, Naked_int32 when C.arch32 ->
-      C.extcall ~alloc:false "caml_int64_to_int32" typ_int [arg]
+      None, C.extcall ~alloc:false "caml_int64_to_int32" typ_int [arg]
   | Naked_int64, (Naked_nativeint | Naked_immediate) when C.arch32 ->
-      C.extcall ~alloc:false "caml_int64_to_nativeint" typ_int [arg]
+      None, C.extcall ~alloc:false "caml_int64_to_nativeint" typ_int [arg]
   | Naked_int64, Naked_float when C.arch32 ->
-      C.extcall ~alloc:false "caml_int64_to_float_unboxed" typ_float [arg]
+      None, C.extcall ~alloc:false "caml_int64_to_float_unboxed" typ_float [arg]
   | Tagged_immediate, Naked_int64 when C.arch32 ->
-      C.extcall ~alloc:true "caml_int64_of_int" typ_val [arg]
-      |> C.unbox_number ~dbg Flambda_kind.Boxable_number.Naked_int64
+      None, C.extcall ~alloc:true "caml_int64_of_int" typ_val [arg]
+            |> C.unbox_number ~dbg Flambda_kind.Boxable_number.Naked_int64
   | Naked_int32, Naked_int64 when C.arch32 ->
-      C.extcall ~alloc:true "caml_int64_of_int32" typ_val [arg]
-      |> C.unbox_number ~dbg Flambda_kind.Boxable_number.Naked_int64
+      None, C.extcall ~alloc:true "caml_int64_of_int32" typ_val [arg]
+            |> C.unbox_number ~dbg Flambda_kind.Boxable_number.Naked_int64
   | (Naked_nativeint | Naked_immediate), Naked_int64 when C.arch32 ->
-      C.extcall ~alloc:true "caml_int64_of_nativeint" typ_val [arg]
-      |> C.unbox_number ~dbg Flambda_kind.Boxable_number.Naked_int64
+      None, C.extcall ~alloc:true "caml_int64_of_nativeint" typ_val [arg]
+            |> C.unbox_number ~dbg Flambda_kind.Boxable_number.Naked_int64
   | Naked_float, Naked_int64 when C.arch32 ->
-      C.extcall ~alloc:true "caml_int64_of_float_unboxed" typ_val [arg]
-      |> C.unbox_number ~dbg Flambda_kind.Boxable_number.Naked_int64
+      None, C.extcall ~alloc:true "caml_int64_of_float_unboxed" typ_val [arg]
+            |> C.unbox_number ~dbg Flambda_kind.Boxable_number.Naked_int64
   (* Identity on floats *)
-  | Naked_float, Naked_float -> arg
+  | Naked_float, Naked_float -> None, arg
   (* Conversions to and from tagged ints  *)
   | (Naked_int32 | Naked_int64 | Naked_nativeint | Naked_immediate),
     Tagged_immediate ->
-      C.tag_int arg dbg
+    None, C.tag_int arg dbg
   | Tagged_immediate, (Naked_int64 | Naked_nativeint | Naked_immediate) ->
-    C.untag_int arg dbg
+    Some (Env.Untag arg), C.untag_int arg dbg
   (* Operations resulting in int32s must take care to sign_extend the res *)
   | Tagged_immediate, Naked_int32 ->
-    C.sign_extend_32 dbg (C.untag_int arg dbg)
+    None, C.sign_extend_32 dbg (C.untag_int arg dbg)
   | (Naked_int32 | Naked_int64 | Naked_nativeint | Naked_immediate),
     Naked_int32 ->
-    C.sign_extend_32 dbg arg
+    None, C.sign_extend_32 dbg arg
   (* No-op conversions *)
   | Tagged_immediate, Tagged_immediate
   | Naked_int32, (Naked_int64 | Naked_nativeint | Naked_immediate)
   | Naked_int64, (Naked_int64 | Naked_nativeint | Naked_immediate)
   | Naked_nativeint, (Naked_int64 | Naked_nativeint | Naked_immediate)
   | Naked_immediate, (Naked_int64 | Naked_nativeint | Naked_immediate) ->
-      arg
+    None, arg
   (* Int-Float conversions *)
   | Tagged_immediate, Naked_float ->
-      C.float_of_int ~dbg (C.untag_int arg dbg)
+    None, C.float_of_int ~dbg (C.untag_int arg dbg)
   | (Naked_immediate | Naked_int32 | Naked_int64 | Naked_nativeint),
     Naked_float ->
-      C.float_of_int ~dbg arg
+    None, C.float_of_int ~dbg arg
   | Naked_float, Tagged_immediate ->
-      C.tag_int (C.int_of_float ~dbg arg) dbg
+    None, C.tag_int (C.int_of_float ~dbg arg) dbg
   | Naked_float, (Naked_immediate | Naked_int64 | Naked_nativeint) ->
-    C.int_of_float ~dbg arg
+    None, C.int_of_float ~dbg arg
   | Naked_float, Naked_int32 ->
-    C.sign_extend_32 dbg (C.int_of_float ~dbg arg)
+    None, C.sign_extend_32 dbg (C.int_of_float ~dbg arg)
 
 let binary_phys_comparison _env dbg kind op x y =
   match (kind : Flambda_kind.t),
@@ -397,48 +407,55 @@ let binary_float_comp_primitive _env dbg op x y =
 let unary_primitive env dbg f arg =
   match (f : Flambda_primitive.unary_primitive) with
   | Duplicate_array _ ->
-      C.extcall ~alloc:true "caml_obj_dup" typ_val [arg]
+      None, C.extcall ~alloc:true "caml_obj_dup" typ_val [arg]
   | Duplicate_block _ ->
-      C.extcall ~alloc:true "caml_obj_dup" typ_val [arg]
+      None, C.extcall ~alloc:true "caml_obj_dup" typ_val [arg]
   | Is_int ->
-      C.and_ ~dbg arg (C.int ~dbg 1)
+      None, C.and_ ~dbg arg (C.int ~dbg 1)
   | Get_tag ->
-      C.get_tag arg dbg
+    None, C.get_tag arg dbg
   | Array_length array_kind ->
-      C.array_length ~dbg array_kind arg
+    None, C.array_length ~dbg array_kind arg
   | Bigarray_length { dimension } ->
-      C.load ~dbg Cmm.Word_int Asttypes.Mutable
-        (C.field_address arg (4 + dimension) dbg)
+      None, C.load ~dbg Cmm.Word_int Asttypes.Mutable
+              (C.field_address arg (4 + dimension) dbg)
   | String_length _ ->
-      C.string_length arg dbg
+      None, C.string_length arg dbg
   | Int_as_pointer ->
-      C.int_as_pointer arg dbg
+      None, C.int_as_pointer arg dbg
   | Opaque_identity ->
-      arg
+      None, arg
   | Int_arith (kind, op) ->
-      unary_int_arith_primitive env dbg kind op arg
+      None, unary_int_arith_primitive env dbg kind op arg
   | Float_arith op ->
-      unary_float_arith_primitive env dbg op arg
+      None, unary_float_arith_primitive env dbg op arg
   | Num_conv { src; dst; } ->
       arithmetic_conversion dbg src dst arg
   | Boolean_not ->
-      C.mk_not dbg arg
+    None, C.mk_not dbg arg
   | Unbox_number kind ->
-      C.unbox_number ~dbg kind arg
+    let extra =
+      match kind with
+      | Untagged_immediate -> Some (Env.Untag arg)
+      | _ -> None
+    in
+    extra, C.unbox_number ~dbg kind arg
   | Box_number kind ->
-      C.box_number ~dbg kind arg
+      None, C.box_number ~dbg kind arg
   | Select_closure { move_from = c1; move_to = c2} ->
       begin match Env.closure_offset env c1, Env.closure_offset env c2 with
       | Some c1_offset, Some c2_offset ->
         let diff = c2_offset - c1_offset in
-        C.infix_field_address ~dbg arg diff
-      | Some _, None | None, Some _ | None, None -> C.unreachable
+        None, C.infix_field_address ~dbg arg diff
+      | Some _, None | None, Some _ | None, None ->
+        None, C.unreachable
       end
   | Project_var { project_from; var; } ->
       match Env.env_var_offset env var, Env.closure_offset env project_from with
       | Some offset, Some base ->
-        C.get_field_gen Asttypes.Immutable arg (offset - base) dbg
-      | Some _, None | None, Some _ | None, None -> C.unreachable
+        None, C.get_field_gen Asttypes.Immutable arg (offset - base) dbg
+      | Some _, None | None, Some _ | None, None ->
+        None, C.unreachable
 
 let binary_primitive env dbg f x y =
   match (f : Flambda_primitive.binary_primitive) with
@@ -495,21 +512,25 @@ let prim env dbg p =
   match (p : Flambda_primitive.t) with
   | Unary (f, x) ->
       let x, env, eff = simple env x in
-      unary_primitive env dbg f x, env, eff
+      let extra, res = unary_primitive env dbg f x in
+      res, extra, env, eff
   | Binary (f, x, y) ->
       let x, env, effx = simple env x in
       let y, env, effy = simple env y in
       let effs = Ece.join effx effy in
-      binary_primitive env dbg f x y, env, effs
+      let res = binary_primitive env dbg f x y in
+      res, None, env, effs
   | Ternary (f, x, y, z) ->
       let x, env, effx = simple env x in
       let y, env, effy = simple env y in
       let z, env, effz = simple env z in
       let effs = Ece.join (Ece.join effx effy) effz in
-      ternary_primitive env dbg f x y z, env, effs
+      let res = ternary_primitive env dbg f x y z in
+      res, None, env, effs
   | Variadic (f, l) ->
       let args, env, effs = arg_list env l in
-      variadic_primitive env dbg f args, env, effs
+      let res = variadic_primitive env dbg f args in
+      res, None, env, effs
 
 (* Kinds and types *)
 
@@ -633,12 +654,16 @@ let rec expr env e =
 
 and named env n =
   match (n : Named.t) with
-  | Simple s -> simple env s
-  | Set_of_closures s -> set_of_closures env s
+  | Simple s ->
+    let t, env, effs = simple env s in
+    t, None, env, effs
+  | Set_of_closures s ->
+    let t, env, effs = set_of_closures env s in
+    t, None, env, effs
   | Prim (p, dbg) ->
-      let prim_eff = Flambda_primitive.effects_and_coeffects p in
-      let t, env, effs = prim env dbg p in
-      t, env, Ece.join effs prim_eff
+    let prim_eff = Flambda_primitive.effects_and_coeffects p in
+    let t, extra, env, effs = prim env dbg p in
+    t, extra, env, Ece.join effs prim_eff
 
 and let_expr env t =
   Let.pattern_match t ~f:(fun ~bound_vars ~body ->
@@ -714,18 +739,15 @@ and let_set_of_closures env body closure_vars soc =
      are correctly set in the env, go on translating the body. *)
   expr env body
 
-and let_expr_bind body env v cmm_expr effs =
+and let_expr_bind ?extra body env v cmm_expr effs =
   match decide_inline_let effs v body with
   | Skip -> env
-  | Inline -> Env.bind_variable env v effs true cmm_expr
-  | Regular -> Env.bind_variable env v effs false cmm_expr
+  | Inline -> Env.bind_variable env v ?extra effs true cmm_expr
+  | Regular -> Env.bind_variable env v ?extra effs false cmm_expr
 
 and let_expr_env body env v e =
-  let cmm_expr, env, effs = named env e in
-  match decide_inline_let effs v body with
-  | Skip -> env
-  | Inline -> Env.bind_variable env v effs true cmm_expr
-  | Regular -> Env.bind_variable env v effs false cmm_expr
+  let cmm_expr, extra, env, effs = named env e in
+  let_expr_bind ?extra body env v cmm_expr effs
 
 and let_expr_aux env v e body =
   let env = let_expr_env body env v e in
@@ -1087,44 +1109,118 @@ and apply_cont_trap_actions env e =
       [Cmm.Push cont]
 
 and switch env s =
-  let e, env, _ = simple env (Switch.scrutinee s) in
-  let wrap, env = Env.flush_delayed_lets env in
-  let ints, exprs =
-    Target_imm.Map.fold (fun d action (ints, exprs) ->
-      let i = Targetint.OCaml.to_int (Target_imm.to_targetint d) in
-      let e = apply_cont env action in
-      (i :: ints, e :: exprs)
-      ) (Switch.arms s) ([], [])
-  in
-  let ints = Array.of_list (List.rev ints) in
-  let exprs = Array.of_list (List.rev exprs) in
-  assert (Array.length ints = Array.length exprs);
-  match ints, exprs with
-  | [| 0; 1 |], [| else_; then_ |] ->
-      (* This switch is actually an if-then-else.
-         On such switches, transl_switch_clambda will actually generate
-         code that compare the scrutinee with 0 (or 1), whereas directly
-         generating an if-then-else on the scrutinee is better
-         (avoid a comparison, and even let selectgen/emit optimize away
-         the move from the condition register to a regular register). *)
-      wrap (C.ite e ~then_ ~else_)
-  | _ ->
-      (* CR mshinwell: Don't use polymorphic comparison! *)
-      if Misc.Stdlib.Array.for_alli (=) ints then
-        wrap (C.transl_switch_clambda Location.none e ints exprs)
-      else begin
-        (* Add an unreachable case to the cases array *)
-        let c = Array.length exprs in
-        let cases = Array.append exprs [| C.unreachable |] in
-        (* The transl_switch_clambda expects an index array such that
-           index.(i) is the index in [cases] of the expression to
-           execute when [e] matches [i]. *)
-        let d, _ = Target_imm.Map.max_binding (Switch.arms s) in
-        let n = Targetint.OCaml.to_int (Target_imm.to_targetint d) in
-        let index = Array.make (n + 2) c in
-        Array.iteri (fun i j -> index.(j) <- i) ints;
-        wrap (C.transl_switch_clambda Location.none e index cases)
+  (* Regular preparation of switches:
+     - translate the scrutinee
+     - generate the sequence of the arms *)
+  let scrutinee = Switch.scrutinee s in
+  let e, env, _ = simple env scrutinee in
+  let arms = Switch.arms s in
+  (* For binary switches, which can be translated to if-then-elses,
+     it can be interesting to *not* untag the scrutinee (particularly
+     for those coming from source if-then-elses on booleans) as that way
+     the translation can use 2 instructions instead of 3.
+     However, this is only useful to do if the tagged expression is
+     smaller then the untagged one (which is not always true due to
+     arithmetic simplifications performed by cmm_helpers).
+     Additionally for switches with more than 2 arms, not untagging
+     and lifting the switch to perform on tagged integer might be worse
+     (because the discrimant of the arms may not be successive anymore,
+     thus preventing the use of a table), or simply not worth it
+     given the already high number of isntructions needed for big
+     switches (but that might be up-to-debate on small switches with
+     3-5 arms). *)
+  let scrutinee, tag_discriminant =
+    match Target_imm.Map.cardinal arms with
+    | 2 ->
+      begin match match_var_with_extra_info env scrutinee with
+      | None -> e, false
+      | Some Untag e' ->
+        let size_e = cmm_arith_size e in
+        let size_e' = cmm_arith_size e' in
+        if size_e' < size_e then e', true else e, false
       end
+    | _ -> e, false
+  in
+  make_switch ~tag_discriminant env scrutinee arms
+
+and match_var_with_extra_info env simple : Env.extra_info option =
+  Simple.pattern_match simple
+    ~const:(fun _ -> None)
+    ~name:(fun n ->
+      Name.pattern_match n
+        ~symbol:(fun _ -> None)
+        ~var:(Env.extra_info env)
+    )
+
+(* Small function to estimate the number of arithmetic instructions
+   in a cmm expression. This is currently used to determine whether
+   untagging an expression resulted in a smaller expresison or not
+   (as can happen because of some arithmetic simplifications performed
+   by cmm_helpers.ml) *)
+and cmm_arith_size e =
+  match (e : Cmm.expression) with
+  | Cop (
+    ( Caddi | Csubi | Cmuli | Cmulhi | Cdivi | Cmodi
+    | Cand | Cor | Cxor | Clsl | Clsr | Casr ), l, _) ->
+    List.fold_left (+) 1 @@
+    List.map cmm_arith_size l
+  | _ -> 0
+
+and prepare_discriminant ~tag d =
+  let targetint_d = Target_imm.to_targetint' d in
+  let prepared_d =
+    if tag then tag_targetint targetint_d else targetint_d
+  in
+  int_of_targetint prepared_d
+
+and make_arm ~tag_discriminant env (d, action) =
+  let d = prepare_discriminant ~tag:tag_discriminant d in
+  let cmm_action = apply_cont env action in
+  d, cmm_action
+
+(* Create a switch given the env, the scrutinee and its arms. *)
+and make_switch ~tag_discriminant env e arms =
+  let wrap, env = Env.flush_delayed_lets env in
+  match Target_imm.Map.cardinal arms with
+
+  (* Binary case: if-then-else *)
+  | 2 ->
+    let aux = make_arm ~tag_discriminant env in
+    let first_arm = aux @@ Target_imm.Map.min_binding arms in
+    let second_arm = aux @@ Target_imm.Map.max_binding arms in
+    begin match first_arm, second_arm with
+    (* These switchs are actually if-then-elses.
+       On such switches, transl_switch_clambda will introduce a let-binding
+       to the scrutinee before creating an if-then-else, introducing an
+       indirection that might prevent some optimizations. performed by
+       selectgen/emit when the condition is inlined in the if-then-else. *)
+    | (0, else_), (_, then_)
+    | (_, then_), (0, else_)
+      -> wrap (C.ite e ~then_ ~else_)
+    (* Similar case to the if/then/else but none of the arms match 0,
+       so we have to generate an equality test, and make sure it is inside
+       the condition to ensure selectgen and emit can take advantage of it. *)
+    | (x, if_x), (_, if_not)
+      -> wrap (C.ite (C.eq (C.int x) e) ~then_:if_x ~else_:if_not)
+    end
+
+  (* General case *)
+  | n ->
+    (* The transl_switch_clambda expects an index array such that
+       index.(d) is the index in [cases] of the expression to
+       execute when [e] matches [d]. *)
+    let (max_d, _) = Target_imm.Map.max_binding arms in
+    let m = prepare_discriminant ~tag:tag_discriminant max_d in
+    let cases = Array.make (n + 1) C.unreachable in
+    let index = Array.make (m + 2) n in
+    let i = ref 0 in
+    Target_imm.Map.iter (fun discriminant action ->
+      let d, cmm_action = make_arm ~tag_discriminant env (discriminant, action) in
+      cases.(!i) <- cmm_action;
+      index.(d) <- !i;
+      incr i
+    ) arms;
+    wrap (C.transl_switch_clambda Location.none e index cases)
 
 and invalid _env _e =
   C.unreachable

--- a/middle_end/flambda2.0/to_cmm/un_cps_env.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps_env.ml
@@ -24,7 +24,7 @@ type cont =
                 handler_body: Flambda.Expr.t; }
 
 (* Extra information about bound variables. These extra information
-   help keep trakc of some extra semantics that are useful to
+   help keep track of some extra semantics that are useful to
    implement some optimization in the translation to cmm. *)
 
 type extra_info =
@@ -117,7 +117,7 @@ type t = {
 
   (* Local information.
 
-     Thses are relative to the flambda2 expression being currently
+     These are relative to the flambda2 expression being currently
      translated, i.e. either the unit initialization code, or the
      body of a function.
      Thus they are reset when entering a new function. *)
@@ -320,7 +320,7 @@ let print_binding_list fmt l =
 *)
 
 
-(* Variable binding (for potential inlinging) *)
+(* Variable binding (for potential inlining) *)
 
 let next_order =
   let r = ref 0 in

--- a/middle_end/flambda2.0/to_cmm/un_cps_env.mli
+++ b/middle_end/flambda2.0/to_cmm/un_cps_env.mli
@@ -44,6 +44,7 @@ val return_cont : t -> Continuation.t
 val exn_cont : t -> Continuation.t
 (** Returns the exception continuation of the environment. *)
 
+
 (** {2 Function info *)
 
 type function_info = {
@@ -57,7 +58,15 @@ val add_function_info : t -> Code_id.t -> function_info -> t
 val get_function_info : t -> Code_id.t -> function_info option
 (** Retrieve known information on the given function *)
 
+
 (** {2 Variable bindings} *)
+
+type extra_info =
+  | Untag of Cmm.expression
+  (** The variable is bound to the result of untagging the cmm expression.
+      This alows to have access to the cmm expression before untagging. *)
+(** Extra information abount bound variables. These are not necessary
+    for the translatio, but useful to enable certain optimization. *)
 
 val create_variable : t -> Variable.t -> t * Backend_var.With_provenance.t
 (** Create (and bind) a cmm variable for the given flambda2 variable, and return
@@ -67,12 +76,19 @@ val create_variable : t -> Variable.t -> t * Backend_var.With_provenance.t
 val create_variables : t -> Variable.t list -> t * Backend_var.With_provenance.t list
 (** Same as {!create_variable} but for a list of variables. *)
 
-val bind_variable : t -> Variable.t -> Effects_and_coeffects.t -> bool -> Cmm.expression -> t
+val bind_variable :
+  t -> Variable.t ->
+  ?extra:extra_info ->
+  Effects_and_coeffects.t ->
+  bool -> Cmm.expression -> t
 (** Bind a variable to the given cmm expression, to allow for delaying the let-binding. *)
 
 val get_variable : t -> Variable.t -> Cmm.expression
 (** Get the cmm variable bound to a flambda2 variable.
-    Will fail (i.e. assertion failure) if the variable is not bound. *)
+    Will fail (i.e. assertion failure) if the variable is not bound.
+    Be careful: in general you do *NOT* want to use this function but
+    instead the {inline_variable} function, as it will correctly
+    perform the inlining of used exactly once variables. *)
 
 val inline_variable : t -> Variable.t -> Cmm.expression * t * Effects_and_coeffects.t
 (** Try and inline an flambda2 variable using the delayed let-bindings. *)
@@ -80,6 +96,9 @@ val inline_variable : t -> Variable.t -> Cmm.expression * t * Effects_and_coeffe
 val flush_delayed_lets : t -> (Cmm.expression -> Cmm.expression) * t
 (** Wrap the given cmm expression with all the delayed let bindings accumulated
     in the environment. *)
+
+val extra_info : t -> Variable.t -> extra_info option
+(** Fetch the extra info for a flambda variable (if any). *)
 
 
 (** {2 Continuation bindings} *)

--- a/middle_end/flambda2.0/to_cmm/un_cps_env.mli
+++ b/middle_end/flambda2.0/to_cmm/un_cps_env.mli
@@ -64,9 +64,9 @@ val get_function_info : t -> Code_id.t -> function_info option
 type extra_info =
   | Untag of Cmm.expression
   (** The variable is bound to the result of untagging the cmm expression.
-      This alows to have access to the cmm expression before untagging. *)
-(** Extra information abount bound variables. These are not necessary
-    for the translatio, but useful to enable certain optimization. *)
+      This allows to have access to the cmm expression before untagging. *)
+(** Extra information about bound variables. These are not necessary
+    for the translation, but useful to enable certain optimization. *)
 
 val create_variable : t -> Variable.t -> t * Backend_var.With_provenance.t
 (** Create (and bind) a cmm variable for the given flambda2 variable, and return


### PR DESCRIPTION
This PR adds the ability for `un_cps` to simplify a switch on untagged integers into a switch on tagged integers, when it is an improvement.

More precisely, currently, switches in flambda2 always operate on untagged integers. This means that when a switch on a caml value needs to be done, the flambda2 code will first untag the caml value into an untagged integer, and then perform the switch, even if the switch could be done on the tagged value by tagging the constants discriminants of the switch's arms.

There exists a few cases where that approach makes the generated code longer and less performant that needs to be. Let's consider the example of a simple source code if-then-else:
```ocaml
let foobar b =
  if b then 42 else 113
```
which ends up generating asm code such as:
```asm
camlSwitch__foobar_0_1_code:
	.cfi_startproc
.L101:
	sarq	$1, %rax
	testq	%rax, %rax
	je	.L100
	movl	$85, %eax
	ret
	.align	4
.L100:
	movl	$227, %eax
	ret
	.cfi_endproc
```

However, we could instead not untag the boolean and perform the switch on the tagged version of the boolean directly, allowing the generated code to skip the shift instruction (used for the untagging), resulting in the following assembly code:

```asm
camlSwitch__foobar_0_1_code:
	.cfi_startproc
.L101:
	cmpq	$1, %rax
	jne	.L100
	movl	$227, %eax
	ret
	.align	4
.L100:
	movl	$85, %eax
	ret
	.cfi_endproc
```

However, note that performing the switch on the tagged version would not necessarily always be better, since the following cases can occur:
- not untagging might not result in a smaller expression: indeed due to arithmetic optimization performed by `cmm_helpers`, it can be the case that an expression and its untagged version have the same size w.r.t. the generated cmm
- the switch translation for cmm can sometimes make use of jump tables, in particular when the discriminants of the switch are consecutive; however if the discriminants were tagged they would not be consecutive anymore and the current implementation of switch compilation would not use a switch table, potentially resulting in worse code
- the switch translation can also detect and transform switchs that actually represent affine function (as can be the case for conversion functions between an enumerated type and integers); and it's not always the case that a switch that is inf act an affine function on an untagged integer would also be an affine function on the tagged version.

For all these reasons, there are currently very strict cases where a regular untagged switch is "simplified" into a switch on tagged integers:
- if the cmm expression before untagging is strictly smaller than the cmm expression after untaggin
- if the switch has 2 branches, in which case `un_cps` translates it directly into a cmm if-then-else, guaranteeing that the transformation results in smaller and better generated code

There might be other cases of interest that could be found after more research, but it's not yet obvious to me, and the code in this PR should make it fairly easy to add new cases as we discover them. To enable the transformation, the translation environment for `un_cps` now keeps track of a bit of semantic information about the variables, called "extra information".

Lastly, the first commit re-organizes `un_cps_end`  a bit to document the environment a little better, so it might be easier to review each commit separately.