### PR TITLE
Ensure no empty cmm data lists are emitted

### DIFF
--- a/middle_end/flambda2.0/to_cmm/un_cps_result.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps_result.ml
@@ -33,10 +33,21 @@ let empty = {
   current_data = [];
 }
 
+let defines_a_symbol data =
+  match (data : Cmm.data_item) with
+  | Cdefine_symbol _
+  | Cglobal_symbol _ -> true
+  | _ -> false
+
 let add_to_data_list x l =
   match x with
   | [] -> l
-  | _ :: _ -> C.cdata x :: l
+  | _ :: _ ->
+    if not (List.exists defines_a_symbol x) then
+      Misc.fatal_errorf "data list does not define any symbol, \
+                         its elements will be unusable: %a"
+        Printcmm.data x;
+    C.cdata x :: l
 
 let archive_data r =
   { r with current_data = [];

--- a/middle_end/flambda2.0/to_cmm/un_cps_static.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps_static.ml
@@ -420,7 +420,7 @@ let static_const
        print the ound symbols and static const. *)
     let dummy_body = Expr.create_invalid () in
     let tmp_let_symbol =
-      Let_symbol.create bound_symbols static_const dummy_body
+      Let_symbol.create Syntactic bound_symbols static_const dummy_body
     in
     Format.eprintf
       "\n@[<v 0>%sContext is:%s translating let_symbol to Cmm:@ %a@."

--- a/middle_end/flambda2.0/to_cmm/un_cps_static.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps_static.ml
@@ -169,12 +169,21 @@ let rec static_set_of_closures env symbs set prev_update =
   let env, l, updates, length =
     fill_static_layout clos_symb symbs decls elts env [] prev_update 0 layout
   in
-  let header = C.cint (C.black_closure_header length) in
-  let sdef = match !clos_symb with
-    | None -> []
-    | Some s -> C.define_symbol ~global:false (symbol s)
+  let block =
+    match l with
+    (* Closures can be deleted by flambda2 but still appear in let_symbols,
+       hence we may end up with empty sets of closures. *)
+    | [] -> []
+    (* Regular case. *)
+    | _ ->
+      let header = C.cint (C.black_closure_header length) in
+      let sdef = match !clos_symb with
+        | None -> []
+        | Some s -> C.define_symbol ~global:false (symbol s)
+      in
+      header :: sdef @ l
   in
-  env, header :: sdef @ l, updates
+  env, block, updates
 
 and fill_static_layout s symbs decls elts env acc updates i = function
   | [] -> env, List.rev acc, updates, i
@@ -387,23 +396,36 @@ let static_const
     env r ~params_and_body
     (bound_symbols : Bound_symbols.t)
     (static_const : Static_const.t) =
-  (* Gc roots: statically allocated blocks themselves do not need to be scanned,
-     however if statically allocated blocks contain dynamically allocated
-     contents, then that block has to be registered as Gc roots for the Gc to
-     correctly patch it if/when it moves some of the dynamically allocated
-     blocks. As a safe over-approximation, we thus register as gc_roots all
-     symbols who have an associated computation (and thus are not
-     fully_static). *)
-  let roots =
-    if Static_const.is_fully_static static_const then []
-    else Symbol.Set.elements (Bound_symbols.being_defined bound_symbols)
-  in
-  let r = R.add_gc_roots r roots in
-  let env, r, update_opt =
-    static_const0 env r ~params_and_body bound_symbols static_const
-  in
-  (* [R.archive_data] helps keep definitions of separate symbols in different
-     [data_item] lists and this increases readability of the generated Cmm. *)
-  env, R.archive_data r, update_opt
-
+  try
+    (* Gc roots: statically allocated blocks themselves do not need to be scanned,
+       however if statically allocated blocks contain dynamically allocated
+       contents, then that block has to be registered as Gc roots for the Gc to
+       correctly patch it if/when it moves some of the dynamically allocated
+       blocks. As a safe over-approximation, we thus register as gc_roots all
+       symbols who have an associated computation (and thus are not
+       fully_static). *)
+    let roots =
+      if Static_const.is_fully_static static_const then []
+      else Symbol.Set.elements (Bound_symbols.being_defined bound_symbols)
+    in
+    let r = R.add_gc_roots r roots in
+    let env, r, update_opt =
+      static_const0 env r ~params_and_body bound_symbols static_const
+    in
+    (* [R.archive_data] helps keep definitions of separate symbols in different
+       [data_item] lists and this increases readability of the generated Cmm. *)
+    env, R.archive_data r, update_opt
+  with Misc.Fatal_error as e ->
+    (* Create a new let_symbol with a dummy body to better
+       print the ound symbols and static const. *)
+    let dummy_body = Expr.create_invalid () in
+    let tmp_let_symbol =
+      Let_symbol.create bound_symbols static_const dummy_body
+    in
+    Format.eprintf
+      "\n@[<v 0>%sContext is:%s translating let_symbol to Cmm:@ %a@."
+      (Flambda_colours.error ())
+      (Flambda_colours.normal ())
+      Let_symbol.print tmp_let_symbol;
+    raise e
 

--- a/middle_end/flambda2.0/to_cmm/un_cps_static.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps_static.ml
@@ -416,16 +416,18 @@ let static_const
        [data_item] lists and this increases readability of the generated Cmm. *)
     env, R.archive_data r, update_opt
   with Misc.Fatal_error as e ->
-    (* Create a new let_symbol with a dummy body to better
-       print the ound symbols and static const. *)
-    let dummy_body = Expr.create_invalid () in
-    let tmp_let_symbol =
-      Let_symbol.create Syntactic bound_symbols static_const dummy_body
-    in
-    Format.eprintf
-      "\n@[<v 0>%sContext is:%s translating let_symbol to Cmm:@ %a@."
-      (Flambda_colours.error ())
-      (Flambda_colours.normal ())
-      Let_symbol.print tmp_let_symbol;
+    if !Clflags.flambda2_context_on_error then begin
+      (* Create a new let_symbol with a dummy body to better
+         print the ound symbols and static const. *)
+      let dummy_body = Expr.create_invalid () in
+      let tmp_let_symbol =
+        Let_symbol.create Syntactic bound_symbols static_const dummy_body
+      in
+      Format.eprintf
+        "\n@[<v 0>%sContext is:%s translating let_symbol to Cmm:@ %a@."
+        (Flambda_colours.error ())
+        (Flambda_colours.normal ())
+        Let_symbol.print tmp_let_symbol
+    end;
     raise e
 


### PR DESCRIPTION
Flambda2 can delete code when it generates new versions of closures/code. In this case, the closure_id of the deleted code still exists in the let_symbol of the unit generated by flambda2, which until now, could make it so that cmm generates data lists that only contain a header for an empty set of closures. While it is not a soundness issue, it is still less than optimal to generate such useless data lists (which also clobber up the cmm output).

This PR thus makes it so that when allocating a static block for a set of closures, if the set of closures has no actual fields (as happens when all the closures code have been deleted), no block is emitted.
Additionally, `un_cps_result` has an added check that all generated statically allocated constants contain in their data list at least one symbol definition. Indeed, if no symbol is present in the data list, the contents of the data list are unreachable (and thus useless). If this happens (i.e. no symbol in a data list), compilation will fail since it is most likely an indication that something is wrong.