### PR TITLE
Do not emit code for functions using deleted closures

### DIFF
--- a/middle_end/flambda2.0/to_cmm/un_cps.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps.ml
@@ -428,17 +428,21 @@ let unary_primitive env dbg f arg =
   | Box_number kind ->
       C.box_number ~dbg kind arg
   | Select_closure { move_from = c1; move_to = c2} ->
-      begin match Env.closure_offset env c1, Env.closure_offset env c2 with
-      | Some c1_offset, Some c2_offset ->
-        let diff = c2_offset - c1_offset in
-        C.infix_field_address ~dbg arg diff
-      | Some _, None | None, Some _ | None, None -> C.unreachable
-      end
+    begin match Env.closure_offset env c1, Env.closure_offset env c2 with
+    | Some c1_offset, Some c2_offset ->
+      let diff = c2_offset - c1_offset in
+      C.infix_field_address ~dbg arg diff
+    | Some _, None | None, Some _ | None, None ->
+      raise Un_cps_static.Unreachable_code
+    end
   | Project_var { project_from; var; } ->
-      match Env.env_var_offset env var, Env.closure_offset env project_from with
-      | Some offset, Some base ->
-        C.get_field_gen Asttypes.Immutable arg (offset - base) dbg
-      | Some _, None | None, Some _ | None, None -> C.unreachable
+    begin match Env.env_var_offset env var,
+                Env.closure_offset env project_from with
+    | Some offset, Some base ->
+      C.get_field_gen Asttypes.Immutable arg (offset - base) dbg
+    | Some _, None | None, Some _ | None, None ->
+      raise Un_cps_static.Unreachable_code
+    end
 
 let binary_primitive env dbg f x y =
   match (f : Flambda_primitive.binary_primitive) with

--- a/middle_end/flambda2.0/to_cmm/un_cps_static.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps_static.ml
@@ -31,6 +31,16 @@ module R = Un_cps_result
 module BSCSC = Bound_symbols.Code_and_set_of_closures
 module SCCSC = Static_const.Code_and_set_of_closures
 
+exception Unreachable_code
+(* This exception is raise when code is encountered that is unused
+    but hasn't been removed by flambda2. This typically happens for
+    code of functions for which newer version have been generated and
+    used instead, but that flambda2 didn't have the needed precision to
+    remove in its one pass. Un_cps can detect such unused code when it
+    finds closure ids with no associated offset.
+    If it occurs in a function's body, the the function declaration
+    is ignored, i.e. no cmm is generated for that function. *)
+
 (* CR mshinwell: Share these next functions with Un_cps.  Unfortunately
    there's a name clash with at least one of them ("symbol") with functions
    already in Un_cps_helper. *)
@@ -269,8 +279,9 @@ let add_function env r ~params_and_body code_id p =
   let fun_name =
     Linkage_name.to_string (Symbol.linkage_name fun_symbol)
   in
-  let fundecl = params_and_body env fun_name p in
-  R.add_function r fundecl
+  match params_and_body env fun_name p with
+  | fundecl -> R.add_function r fundecl
+  | exception Unreachable_code -> r
 
 let add_functions
     env ~params_and_body r { SCCSC.code; set_of_closures = _; }  =

--- a/middle_end/flambda2.0/to_cmm/un_cps_static.mli
+++ b/middle_end/flambda2.0/to_cmm/un_cps_static.mli
@@ -18,6 +18,16 @@
 
 open! Flambda.Import
 
+exception Unreachable_code
+(* This exception is raise when code is encountered that is unused
+    but hasn't been removed by flambda2. This typically happens for
+    code of functions for which newer version have been generated and
+    used instead, but that flambda2 didn't have the needed precision to
+    remove in its one pass. Un_cps can detect such unused code when it
+    finds closure ids with no associated offset.
+    If it occurs in a function's body, the the function declaration
+    is ignored, i.e. no cmm is generated for that function. *)
+
 val static_const
   : Un_cps_env.t
   -> Un_cps_result.t
@@ -29,3 +39,12 @@ val static_const
   -> Let_symbol.Bound_symbols.t
   -> Static_const.t
   -> Un_cps_env.t * Un_cps_result.t * Cmm.expression option
+(** Translate a static constant bound by a let_symbol, and return a
+    new rsult containing the translation. Takes a [~params_and_body]
+    function as argument to translate a function's body, and thus
+    avoid a cyclic dependency between {Un_cps} and this module.
+    If the [~params_and_body] function raises [Unreachable_code], then the
+    function whose body's translation raise the exception will be ignored
+    (i.e. no cmm code will be mitted for the function body). If such a
+    function (or rather the function's code symbol) is used in the code,
+    this should trigger a linking error because of a symbol not found. *)


### PR DESCRIPTION
This PR changes the translation of `Select_closure` and `Project_var` when the used closure ids have no associated offset. Instead of generating unreachable code (i.e. code that segfaults), this PR makes its so that we skip the whole function which contains the primitive, i.e. the function's code will not be emitted.
This comes from the assertion that a function's body which make use of a closure id that is not declared (and thus has no offset), makes the whole function invalid (rather than only making the local code branch invalid), but it might need to be confirmed by @mshinwell  and @lthls .