### PR TITLE
Unused closure var removal when not under a lambda

### DIFF
--- a/middle_end/flambda2.0/simplify/env/simplify_env_and_result_intf.ml
+++ b/middle_end/flambda2.0/simplify/env/simplify_env_and_result_intf.ml
@@ -287,6 +287,10 @@ module type Result = sig
   val imported_symbols : t -> Flambda_kind.t Symbol.Map.t
 
   val clear_lifted_constants : t -> t
+
+  val add_use_of_closure_var : t -> Var_within_closure.t -> t
+
+  val used_closure_vars : t -> Var_within_closure.Set.t
 end
 
 module type Lifted_constant = sig

--- a/middle_end/flambda2.0/simplify/simplify_common.mli
+++ b/middle_end/flambda2.0/simplify/simplify_common.mli
@@ -70,8 +70,16 @@ val bind_let_bound
   -> body:Flambda.Expr.t
   -> Flambda.Expr.t
 
+(** Create a [Let_symbol] expression around a given body.  Two optimisations
+    are performed:
+    1. Best efforts are made not to create the [Let_symbol] if it would be
+       redundant.
+    2. Closure variables are removed if they are not used according to the
+       given [r].  Such [r] must have seen all uses in the whole
+       compilation unit. *)
 val create_let_symbol
-   : Flambda.Let_symbol_expr.Scoping_rule.t
+   : Simplify_env_and_result.Result.t
+  -> Flambda.Let_symbol_expr.Scoping_rule.t
   -> Code_age_relation.t
   -> Flambda.Let_symbol_expr.Bound_symbols.t
   -> Flambda.Static_const.t

--- a/middle_end/flambda2.0/simplify/simplify_expr.rec.ml
+++ b/middle_end/flambda2.0/simplify/simplify_expr.rec.ml
@@ -160,7 +160,7 @@ Format.eprintf "All bindings:@ %a\n%!"
   in
   let expr =
     List.fold_left (fun body (bound_symbols, defining_expr) ->
-        Simplify_common.create_let_symbol scoping_rule
+        Simplify_common.create_let_symbol (UA.r uacc) scoping_rule
           (UA.code_age_relation uacc) bound_symbols defining_expr body)
       body
       sorted_lifted_constants.bindings_outermost_last
@@ -175,11 +175,11 @@ and simplify_one_continuation_handler :
   -> params:KP.t list
   -> handler:Expr.t
   -> extra_params_and_args:Continuation_extra_params_and_args.t
-  -> 'a k 
+  -> 'a k
   -> Continuation_handler.t * 'a * UA.t
 = fun dacc cont (recursive : Recursive.t) (cont_handler : CH.t) ~params
       ~(handler : Expr.t) ~(extra_params_and_args : EPA.t) k ->
-  (* 
+  (*
 Format.eprintf "handler:@.%a@."
   Expr.print cont_handler.handler;
   *)
@@ -1544,7 +1544,7 @@ and simplify_switch
                     else if
                       (Target_imm.equal arm Target_imm.bool_true
                         && Target_imm.equal arg Target_imm.bool_false)
-                      || 
+                      ||
                         (Target_imm.equal arm Target_imm.bool_false
                           && Target_imm.equal arg Target_imm.bool_true)
                     then


### PR DESCRIPTION
I realised yesterday that there is a problem with removal of unused closure vars during Simplify in some cases.  The problem stems from the fact that we need to rebuild the right-hand side of `Let` expressions binding sets of closures on the _downwards_ (typing) traversal before moving onto the subsequent expression.  We cannot do the downwards traversal of a set of closures in such a situation, suspend, continue with the downwards traversal of the rest of the code and then resume to rebuild the set of closures.  The reason is that we need the rebuilt function bodies in the set of closures so we can construct the type of the set of closures which may subsequently be needed (in particular for inlining) on the rest of the downwards traversal.

This means that the property that all of the rest of the compilation unit has been seen before rebuilding an expression only applies when the expression is not under any lambda.  (It also means that the existing traversal order in Simplify is in fact correct.)  As such, we can only do the closure var removal in these situations, which means the removal will not be performed for non-lifted sets of closures under lambdas.  I think this will in practice be sufficient to catch the majority of cases, but it means we should still keep the existing code in `Un_cps` as-is.  Luckily, sets of closures that get lifted will have their variables removed -- these are not placed in the code until a `Let_symbol` binding point, which can never be under a lambda.

This means that the small patch in this PR should suffice to help us with the code size.  The much more difficult patch, which I am still working on and will lower the priority of slightly, will now just have the effect of making Simplify tail-recursive (in addition to tidying up the code by splitting up various large functions).  This will still be beneficial, for debugging and performance profile collection, in addition to making the code be in the correct CPS form for potential defunctionalisation in the future.