### PR TITLE
Fix typo

### DIFF
--- a/middle_end/flambda2.0/to_cmm/un_cps_static.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps_static.ml
@@ -318,7 +318,7 @@ let static_const0 env r ~params_and_body (bound_symbols : Bound_symbols.t)
         List.fold_left update_env_for_set_of_closure env definitions
       in
       let r =
-        List.fold_left (add_functions env ~params_and_body) r definitions
+        List.fold_left (add_functions updated_env ~params_and_body) r definitions
       in
       let r, updates, env =
         List.fold_left2 preallocate_set_of_closures


### PR DESCRIPTION
This typo meant that recursive calls did not have access to the
function_info, and thus un_cps did not elide the closure argument even
when it was possible