### PR TITLE
Rework simplification of Get_tag

### DIFF
--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -468,6 +468,9 @@ let read_one_param ppf position name v =
   | "flambda2-expert-fallback-inlining-heuristic" ->
     set "flambda2-expert-fallback-inlining-heuristic"
       [ Flambda_2.Expert.fallback_inlining_heuristic ] v
+  | "flambda2-debug-strict-get-tag-check" ->
+    set "flambda2-debug-strict-get-tag-check"
+      [ Flambda_2.Debug.strict_get_tag_check ] v
 
   | _ ->
     if not (List.mem name !can_discard) then begin

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -957,6 +957,12 @@ let mk_no_flambda2_expert_fallback_inlining_heuristic f =
     " Allow inlining of functions whose bodies contain closures (default)"
 ;;
 
+let mk_flambda2_debug_strict_get_tag_check f =
+  "-flambda2-debug-strict-get-tag-check", Arg.Unit f,
+    " Raise a fatal error when a Get_tag primitive's argument cannot be proved \
+      to be a block"
+;;
+
 let mk_flambda2_backend_cse_at_toplevel f =
   "-flambda2-backend-cse-at-toplevel", Arg.Unit f,
     " Apply the backend CSE pass to module initializers"
@@ -1185,6 +1191,7 @@ module type Optcommon_options = sig
   val _no_flambda2_expert_code_id_and_symbol_scoping_checks : unit -> unit
   val _flambda2_expert_fallback_inlining_heuristic : unit -> unit
   val _no_flambda2_expert_fallback_inlining_heuristic : unit -> unit
+  val _flambda2_debug_strict_get_tag_check : unit -> unit
 
   val _dprepared_lambda : unit -> unit
   val _dilambda : unit -> unit
@@ -1536,6 +1543,8 @@ struct
       F._flambda2_expert_fallback_inlining_heuristic;
     mk_no_flambda2_expert_fallback_inlining_heuristic
       F._no_flambda2_expert_fallback_inlining_heuristic;
+    mk_flambda2_debug_strict_get_tag_check
+      F._flambda2_debug_strict_get_tag_check;
 
     mk_match_context_rows F._match_context_rows;
     mk_dno_unique_ids F._dno_unique_ids;
@@ -1679,6 +1688,8 @@ module Make_opttop_options (F : Opttop_options) = struct
       F._flambda2_expert_fallback_inlining_heuristic;
     mk_no_flambda2_expert_fallback_inlining_heuristic
       F._no_flambda2_expert_fallback_inlining_heuristic;
+    mk_flambda2_debug_strict_get_tag_check
+      F._flambda2_debug_strict_get_tag_check;
 
     mk_dsource F._dsource;
     mk_dparsetree F._dparsetree;
@@ -1988,6 +1999,8 @@ module Default = struct
       set Flambda_2.Expert.fallback_inlining_heuristic
     let _no_flambda2_expert_fallback_inlining_heuristic =
       clear Flambda_2.Expert.fallback_inlining_heuristic
+    let _flambda2_debug_strict_get_tag_check =
+      set Flambda_2.Debug.strict_get_tag_check
 
     let _dprepared_lambda = set dump_prepared_lambda
     let _dilambda = set dump_ilambda

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -235,6 +235,7 @@ module type Optcommon_options = sig
   val _no_flambda2_expert_code_id_and_symbol_scoping_checks : unit -> unit
   val _flambda2_expert_fallback_inlining_heuristic : unit -> unit
   val _no_flambda2_expert_fallback_inlining_heuristic : unit -> unit
+  val _flambda2_debug_strict_get_tag_check : unit -> unit
 
   (** Flambda 2 debugging flags *)
   val _dprepared_lambda : unit -> unit

--- a/middle_end/flambda2.0/compilenv_deps/flambda_features.ml
+++ b/middle_end/flambda2.0/compilenv_deps/flambda_features.ml
@@ -28,3 +28,7 @@ module Expert = struct
   let fallback_inlining_heuristic () =
     !Clflags.Flambda_2.Expert.fallback_inlining_heuristic
 end
+
+module Debug = struct
+  let strict_get_tag_check () = !Clflags.Flambda_2.Debug.strict_get_tag_check
+end

--- a/middle_end/flambda2.0/compilenv_deps/flambda_features.mli
+++ b/middle_end/flambda2.0/compilenv_deps/flambda_features.mli
@@ -25,3 +25,7 @@ module Expert : sig
   val code_id_and_symbol_scoping_checks : unit -> bool
   val fallback_inlining_heuristic : unit -> bool
 end
+
+module Debug : sig
+  val strict_get_tag_check : unit -> bool
+end

--- a/middle_end/flambda2.0/types/template/flambda_type.templ.ml
+++ b/middle_end/flambda2.0/types/template/flambda_type.templ.ml
@@ -303,7 +303,17 @@ let prove_tags_must_be_a_block env t : Tag.Set.t proof =
     | Unknown -> Unknown
     | Known imms ->
       if not (is_bottom env imms) then
-        Invalid
+        (* This used to be Invalid. For consistency with the case above,
+           this is now Unknown.
+           However, if we reach this case it likely means that we lost
+           precision at some point where we could have avoided it, so
+           an extra check can be enabled to detect this.
+        *)
+        if Flambda_features.Debug.strict_get_tag_check () then
+          Misc.fatal_errorf
+            "Type %a is expected to be a block, but contains known immediates"
+            print t
+        else Unknown
       else
         match blocks_imms.blocks with
         | Unknown -> Unknown

--- a/middle_end/flambda2.0/types/template/flambda_type.templ.ml
+++ b/middle_end/flambda2.0/types/template/flambda_type.templ.ml
@@ -900,29 +900,10 @@ let reify ?allowed_if_free_vars_defined_in ?disallowed_free_vars env
       end
     (* CR mshinwell: share code with [prove_equals_tagged_immediates],
        above *)
-    | Naked_immediate (Ok (Is_int scrutinee_ty)) ->
-      begin match prove_is_int env scrutinee_ty with
-      | Proved true -> Simple Simple.untagged_const_true
-      | Proved false -> Simple Simple.untagged_const_false
-      | Unknown -> try_canonical_simple ()
-      | Invalid -> Invalid
-      end
-    | Naked_immediate (Ok (Get_tag block_ty)) ->
-      begin match prove_tags_must_be_a_block env block_ty with
-      | Proved tags ->
-        let is =
-          Tag.Set.fold (fun tag is ->
-              Target_imm.Set.add (Target_imm.tag tag) is)
-            tags
-            Target_imm.Set.empty
-        in
-        begin match Target_imm.Set.get_singleton is with
-        | None -> try_canonical_simple ()
-        | Some i -> Simple (Simple.const (Reg_width_const.naked_immediate i))
-        end
-      | Unknown -> try_canonical_simple ()
-      | Invalid -> Invalid
-      end
+    | Naked_immediate (Ok (Is_int _scrutinee_ty)) ->
+      try_canonical_simple ()
+    | Naked_immediate (Ok (Get_tag _block_ty)) ->
+      try_canonical_simple ()
     | Naked_float (Ok fs) ->
       begin match Float.Set.get_singleton fs with
       | None -> try_canonical_simple ()

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -435,6 +435,10 @@ module Flambda_2 = struct
     let code_id_and_symbol_scoping_checks = ref false
     let fallback_inlining_heuristic = ref false
   end
+
+  module Debug = struct
+    let strict_get_tag_check = ref false
+  end
 end
 
 (* This is used by the -stop-after option. *)

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -255,6 +255,10 @@ module Flambda_2 : sig
     val code_id_and_symbol_scoping_checks : bool ref
     val fallback_inlining_heuristic : bool ref
   end
+
+  module Debug : sig
+    val strict_get_tag_check : bool ref
+  end
 end
 
 module Compiler_pass : sig


### PR DESCRIPTION
- Replace Invalid by Unknown in the case were the type of the argument
contains known immediates
- Add a flag to throw a fatal error in the above case instead, as it is
likely caused by a loss of precision during simplification