### PR TITLE
Only add equations on canonical names

### DIFF
--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -468,7 +468,9 @@ let read_one_param ppf position name v =
   | "flambda2-expert-fallback-inlining-heuristic" ->
     set "flambda2-expert-fallback-inlining-heuristic"
       [ Flambda_2.Expert.fallback_inlining_heuristic ] v
-
+  | "flambda2-debug-concrete-types-only-on-canonicals" ->
+    set "flambda2-debug-concrete-types-only-on-canonicals"
+      [ Flambda_2.Debug.concrete_types_only_on_canonicals ] v
   | _ ->
     if not (List.mem name !can_discard) then begin
       can_discard := name :: !can_discard;

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -961,6 +961,16 @@ let mk_no_flambda2_expert_fallback_inlining_heuristic f =
     " Allow inlining of functions whose bodies contain closures (default)"
 ;;
 
+let mk_flambda2_debug_concrete_types_only_on_canonicals f =
+  "-flambda2-debug-concrete-types-only-on-canonicals", Arg.Unit f,
+    " Check that concrete types are only assigned to canonical names"
+;;
+
+let mk_no_flambda2_debug_concrete_types_only_on_canonicals f =
+  "-no-flambda2-debug-concrete-types-only-on-canonicals", Arg.Unit f,
+    " Do not check that concrete types are only assigned to canonical names"
+;;
+
 let mk_flambda2_backend_cse_at_toplevel f =
   "-flambda2-backend-cse-at-toplevel", Arg.Unit f,
     " Apply the backend CSE pass to module initializers"
@@ -1190,6 +1200,8 @@ module type Optcommon_options = sig
   val _no_flambda2_expert_code_id_and_symbol_scoping_checks : unit -> unit
   val _flambda2_expert_fallback_inlining_heuristic : unit -> unit
   val _no_flambda2_expert_fallback_inlining_heuristic : unit -> unit
+  val _flambda2_debug_concrete_types_only_on_canonicals : unit -> unit
+  val _no_flambda2_debug_concrete_types_only_on_canonicals : unit -> unit
 
   val _dprepared_lambda : unit -> unit
   val _dilambda : unit -> unit
@@ -1542,6 +1554,10 @@ struct
       F._flambda2_expert_fallback_inlining_heuristic;
     mk_no_flambda2_expert_fallback_inlining_heuristic
       F._no_flambda2_expert_fallback_inlining_heuristic;
+    mk_flambda2_debug_concrete_types_only_on_canonicals
+      F._flambda2_debug_concrete_types_only_on_canonicals;
+    mk_no_flambda2_debug_concrete_types_only_on_canonicals
+      F._no_flambda2_debug_concrete_types_only_on_canonicals;
 
     mk_match_context_rows F._match_context_rows;
     mk_dno_unique_ids F._dno_unique_ids;
@@ -1686,6 +1702,10 @@ module Make_opttop_options (F : Opttop_options) = struct
       F._flambda2_expert_fallback_inlining_heuristic;
     mk_no_flambda2_expert_fallback_inlining_heuristic
       F._no_flambda2_expert_fallback_inlining_heuristic;
+    mk_flambda2_debug_concrete_types_only_on_canonicals
+      F._flambda2_debug_concrete_types_only_on_canonicals;
+    mk_no_flambda2_debug_concrete_types_only_on_canonicals
+      F._no_flambda2_debug_concrete_types_only_on_canonicals;
 
     mk_dsource F._dsource;
     mk_dparsetree F._dparsetree;
@@ -1996,6 +2016,10 @@ module Default = struct
       set Flambda_2.Expert.fallback_inlining_heuristic
     let _no_flambda2_expert_fallback_inlining_heuristic =
       clear Flambda_2.Expert.fallback_inlining_heuristic
+    let _flambda2_debug_concrete_types_only_on_canonicals =
+      set Flambda_2.Debug.concrete_types_only_on_canonicals
+    let _no_flambda2_debug_concrete_types_only_on_canonicals =
+      clear Flambda_2.Debug.concrete_types_only_on_canonicals
 
     let _dprepared_lambda = set dump_prepared_lambda
     let _dilambda = set dump_ilambda

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -236,6 +236,8 @@ module type Optcommon_options = sig
   val _no_flambda2_expert_code_id_and_symbol_scoping_checks : unit -> unit
   val _flambda2_expert_fallback_inlining_heuristic : unit -> unit
   val _no_flambda2_expert_fallback_inlining_heuristic : unit -> unit
+  val _flambda2_debug_concrete_types_only_on_canonicals : unit -> unit
+  val _no_flambda2_debug_concrete_types_only_on_canonicals : unit -> unit
 
   (** Flambda 2 debugging flags *)
   val _dprepared_lambda : unit -> unit

--- a/middle_end/flambda2.0/types/env/aliases.ml
+++ b/middle_end/flambda2.0/types/env/aliases.ml
@@ -473,3 +473,9 @@ let get_aliases t element =
       assert (Simple.Set.mem element aliases)
     end;
     Simple.Set.add canonical_element aliases
+
+let get_canonical_ignoring_name_mode t name =
+  let simple = Simple.name name in
+  match canonical t simple with
+  | Is_canonical _ -> simple
+  | Alias_of_canonical { canonical_element; _ } -> canonical_element

--- a/middle_end/flambda2.0/types/env/aliases.mli
+++ b/middle_end/flambda2.0/types/env/aliases.mli
@@ -51,3 +51,5 @@ val get_canonical_element_exn
 
 (** [get_aliases] always returns the supplied element in the result set. *)
 val get_aliases : t -> Simple.t -> Simple.Set.t
+
+val get_canonical_ignoring_name_mode : t -> Name.t -> Simple.t

--- a/middle_end/flambda2.0/types/type_descr.rec.ml
+++ b/middle_end/flambda2.0/types/type_descr.rec.ml
@@ -129,7 +129,7 @@ module Make (Head : Type_head_intf.S
       match descr t with
       | Equals alias -> alias
       | No_alias _ | Type _ -> assert false
- 
+
   let apply_rec_info t rec_info : _ Or_bottom.t =
     match descr t with
     | Equals simple ->
@@ -427,6 +427,9 @@ module Make (Head : Type_head_intf.S
                wrong way", for example "y : =x" when [y] is the canonical
                element. This doesn't matter, however, because [Typing_env] sorts
                this out when adding equations into an environment. *)
+            (* CR mshinwell: May be able to improve efficiency by not
+               doing [meet] again (via [TE.add_env_extension]) if we tried
+               here to emit the equations the correct way around *)
             match meet_head_or_unknown_or_bottom env head1 head2 with
             | Left_head_unchanged ->
               let env_extension =

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -435,6 +435,10 @@ module Flambda_2 = struct
     let code_id_and_symbol_scoping_checks = ref false
     let fallback_inlining_heuristic = ref false
   end
+
+  module Debug = struct
+    let concrete_types_only_on_canonicals = ref false
+  end
 end
 
 (* This is used by the -stop-after option. *)

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -255,6 +255,10 @@ module Flambda_2 : sig
     val code_id_and_symbol_scoping_checks : bool ref
     val fallback_inlining_heuristic : bool ref
   end
+
+  module Debug : sig
+    val concrete_types_only_on_canonicals : bool ref
+  end
 end
 
 module Compiler_pass : sig


### PR DESCRIPTION
As per the discussion on Slack today.  There is also a check that can be enabled to validate this property.