### PR TITLE
Use extcalls for bound errors

### DIFF
--- a/asmcomp/afl_instrument.ml
+++ b/asmcomp/afl_instrument.ml
@@ -105,7 +105,7 @@ let instrument_initialiser c dbg =
     (Csequence
        (Cop (Cextcall { func = "caml_setup_afl";
                         ty = typ_int; alloc = false;
-                        label_after = None; },
+                        label_after = None; returns = true; },
              [Cconst_int (0, dbg ())],
              dbg ()),
         c))

--- a/asmcomp/afl_instrument.ml
+++ b/asmcomp/afl_instrument.ml
@@ -103,7 +103,9 @@ let instrument_initialiser c dbg =
      calls *)
   with_afl_logging
     (Csequence
-       (Cop (Cextcall ("caml_setup_afl", typ_int, false, None),
+       (Cop (Cextcall { func = "caml_setup_afl";
+                        ty = typ_int; alloc = false;
+                        label_after = None; },
              [Cconst_int (0, dbg ())],
              dbg ()),
         c))

--- a/asmcomp/amd64/selection.ml
+++ b/asmcomp/amd64/selection.ml
@@ -135,7 +135,7 @@ method is_immediate_natint n = n <= 0x7FFFFFFFn && n >= -0x80000000n
 
 method! is_simple_expr e =
   match e with
-  | Cop(Cextcall (fn, _, _, _), args, _)
+  | Cop(Cextcall { func = fn; ty = _; alloc = _; label_after = _; }, args, _)
     when List.mem fn inline_ops ->
       (* inlined ops are simple if their arguments are *)
       List.for_all self#is_simple_expr args
@@ -144,7 +144,7 @@ method! is_simple_expr e =
 
 method! effects_of e =
   match e with
-  | Cop(Cextcall(fn, _, _, _), args, _)
+  | Cop(Cextcall { func = fn; ty = _; alloc = _; label_after = _; }, args, _)
     when List.mem fn inline_ops ->
       Selectgen.Effect_and_coeffect.join_list_map args self#effects_of
   | _ ->
@@ -201,7 +201,7 @@ method! select_operation op args dbg =
       self#select_floatarith true Imulf Ifloatmul args
   | Cdivf ->
       self#select_floatarith false Idivf Ifloatdiv args
-  | Cextcall("sqrt", _, false, _) ->
+  | Cextcall { func = "sqrt"; ty = _; alloc = false; label_after = _; } ->
      begin match args with
        [Cop(Cload ((Double|Double_u as chunk), _), [loc], _dbg)] ->
          let (addr, arg) = self#select_addressing chunk loc in
@@ -221,12 +221,16 @@ method! select_operation op args dbg =
       | _ ->
           super#select_operation op args dbg
       end
-  | Cextcall("caml_bswap16_direct", _, _, _) ->
+  | Cextcall { func = "caml_bswap16_direct"; ty = _;
+               alloc = _; label_after = _; } ->
       (Ispecific (Ibswap 16), args)
-  | Cextcall("caml_int32_direct_bswap", _, _, _) ->
+  | Cextcall { func = "caml_int32_direct_bswap"; ty = _;
+               alloc = _; label_after = _; } ->
       (Ispecific (Ibswap 32), args)
-  | Cextcall("caml_int64_direct_bswap", _, _, _)
-  | Cextcall("caml_nativeint_direct_bswap", _, _, _) ->
+  | Cextcall { func = "caml_int64_direct_bswap"; ty = _;
+               alloc = _; label_after = _; }
+  | Cextcall { func = "caml_nativeint_direct_bswap"; ty =  _;
+               alloc = _; label_after = _; } ->
       (Ispecific (Ibswap 64), args)
   (* AMD64 does not support immediate operands for multiply high signed *)
   | Cmulhi ->

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -161,7 +161,8 @@ and operation =
     Capply of machtype
   | Cextcall of
       { func : string; ty : machtype;
-        alloc : bool ; label_after : label option; }
+        alloc : bool ; label_after : label option;
+        returns : bool; }
     (** If specified, the given label will be placed immediately after the
         call (at the same place as any frame descriptor would reference). *)
   | Cload of memory_chunk * Asttypes.mutable_flag

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -159,7 +159,9 @@ type memory_chunk =
 
 and operation =
     Capply of machtype
-  | Cextcall of string * machtype * bool * label option
+  | Cextcall of
+      { func : string; ty : machtype;
+        alloc : bool ; label_after : label option; }
     (** If specified, the given label will be placed immediately after the
         call (at the same place as any frame descriptor would reference). *)
   | Cload of memory_chunk * Asttypes.mutable_flag

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -163,7 +163,9 @@ type memory_chunk =
 
 and operation =
     Capply of machtype
-  | Cextcall of string * machtype * bool * label option
+  | Cextcall of
+      { func : string; ty : machtype;
+        alloc : bool ; label_after : label option; }
   | Cload of memory_chunk * Asttypes.mutable_flag
   | Calloc
   | Cstore of memory_chunk * Lambda.initialization_or_assignment

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -165,7 +165,8 @@ and operation =
     Capply of machtype
   | Cextcall of
       { func : string; ty : machtype;
-        alloc : bool ; label_after : label option; }
+        alloc : bool ; label_after : label option;
+        returns : bool; }
   | Cload of memory_chunk * Asttypes.mutable_flag
   | Calloc
   | Cstore of memory_chunk * Lambda.initialization_or_assignment

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -568,8 +568,8 @@ let rec remove_unit = function
       Clet(id, c1, remove_unit c2)
   | Cop(Capply _mty, args, dbg) ->
       Cop(Capply typ_void, args, dbg)
-  | Cop(Cextcall(proc, _mty, alloc, label_after), args, dbg) ->
-      Cop(Cextcall(proc, typ_void, alloc, label_after), args, dbg)
+  | Cop(Cextcall { func; ty = _; alloc; label_after; }, args, dbg) ->
+    Cop(Cextcall { func; ty = typ_void; alloc; label_after; }, args, dbg)
   | Cexit (_,_,_) as c -> c
   | Ctuple [] as c -> c
   | c -> Csequence(c, Ctuple [])
@@ -691,10 +691,12 @@ let float_array_ref arr ofs dbg =
   box_float dbg (unboxed_float_array_ref arr ofs dbg)
 
 let addr_array_set arr ofs newval dbg =
-  Cop(Cextcall("caml_modify", typ_void, false, None),
+  Cop(Cextcall { func = "caml_modify"; ty = typ_void;
+                 alloc = false; label_after = None; },
       [array_indexing log2_size_addr arr ofs dbg; newval], dbg)
 let addr_array_initialize arr ofs newval dbg =
-  Cop(Cextcall("caml_initialize", typ_void, false, None),
+  Cop(Cextcall { func = "caml_initialize"; ty = typ_void;
+                 alloc =false; label_after = None },
       [array_indexing log2_size_addr arr ofs dbg; newval], dbg)
 let int_array_set arr ofs newval dbg =
   Cop(Cstore (Word_int, Lambda.Assignment),
@@ -741,7 +743,8 @@ let bigstring_length ba dbg =
 
 let lookup_tag obj tag dbg =
   bind "tag" tag (fun tag ->
-    Cop(Cextcall("caml_get_public_method", typ_val, false, None),
+    Cop(Cextcall { func = "caml_get_public_method"; ty = typ_val;
+                   alloc = false; label_after = None },
         [obj; tag],
         dbg))
 
@@ -773,14 +776,16 @@ let make_alloc_generic set_fn dbg tag wordsize args =
     | e1::el -> Csequence(set_fn (Cvar id) (Cconst_int (idx, dbg)) e1 dbg,
                           fill_fields (idx + 2) el) in
     Clet(VP.create id,
-         Cop(Cextcall("caml_alloc", typ_val, true, None),
+         Cop(Cextcall { func = "caml_alloc"; ty = typ_val;
+                        alloc = true; label_after = None },
                  [Cconst_int (wordsize, dbg); Cconst_int (tag, dbg)], dbg),
          fill_fields 1 args)
   end
 
 let make_alloc dbg tag args =
   let addr_array_init arr ofs newval dbg =
-    Cop(Cextcall("caml_initialize", typ_void, false, None),
+    Cop(Cextcall { func = "caml_initialize"; ty = typ_void;
+                   alloc = false; label_after = None },
         [array_indexing log2_size_addr arr ofs dbg; newval], dbg)
   in
   make_alloc_generic addr_array_init dbg tag (List.length args) args
@@ -2117,13 +2122,15 @@ let bbswap bi arg dbg =
     | Pint32 -> "int32"
     | Pint64 -> "int64"
   in
-  Cop(Cextcall(Printf.sprintf "caml_%s_direct_bswap" prim,
-               typ_int, false, None),
+  Cop(Cextcall {
+    func = Printf.sprintf "caml_%s_direct_bswap" prim;
+    ty = typ_int; alloc = false; label_after = None },
       [arg],
       dbg)
 
 let bswap16 arg dbg =
-  (Cop(Cextcall("caml_bswap16_direct", typ_int, false, None),
+  (Cop(Cextcall { func = "caml_bswap16_direct"; ty = typ_int;
+                  alloc = false; label_after = None },
        [arg],
        dbg))
 
@@ -2148,12 +2155,14 @@ let assignment_kind
 let setfield n ptr init arg1 arg2 dbg =
   match assignment_kind ptr init with
   | Caml_modify ->
-      return_unit dbg (Cop(Cextcall("caml_modify", typ_void, false, None),
+    return_unit dbg (Cop(Cextcall { func ="caml_modify"; ty = typ_void;
+                                    alloc = false; label_after = None; },
                       [field_address arg1 n dbg;
                        arg2],
                       dbg))
   | Caml_initialize ->
-      return_unit dbg (Cop(Cextcall("caml_initialize", typ_void, false, None),
+    return_unit dbg (Cop(Cextcall { func = "caml_initialize"; ty = typ_void;
+                                    alloc = false; label_after = None; },
                       [field_address arg1 n dbg;
                        arg2],
                       dbg))

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -762,7 +762,7 @@ and transl_make_array dbg env kind args =
   match kind with
   | Pgenarray ->
     Cop(Cextcall { func = "caml_make_array"; ty = typ_val;
-                   alloc = true; label_after =  None; },
+                   alloc = true; label_after =  None; returns = true; },
           [make_alloc dbg 0 (List.map (transl env) args)], dbg)
   | Paddrarray | Pintarray ->
       make_alloc dbg 0 (List.map (transl env) args)
@@ -800,7 +800,8 @@ and transl_ccall env prim args dbg =
   let args = transl_args prim.prim_native_repr_args args in
   wrap_result
     (Cop(Cextcall { func = Primitive.native_name prim; ty = typ_res;
-                    alloc = prim.prim_alloc; label_after = None; }, args, dbg))
+                    alloc = prim.prim_alloc; label_after = None;
+                    returns = true; }, args, dbg))
 
 and transl_prim_1 env p arg dbg =
   match p with
@@ -1329,7 +1330,8 @@ and transl_letrec env bindings cont =
   in
   let op_alloc prim args =
     Cop(Cextcall { func = prim; ty = typ_val;
-                   alloc = true; label_after = None; }, args, dbg) in
+                   alloc = true; label_after = None;
+                   returns = true; }, args, dbg) in
   let rec init_blocks = function
     | [] -> fill_nonrec bsz
     | (id, _exp, RHS_block sz) :: rem ->
@@ -1356,7 +1358,7 @@ and transl_letrec env bindings cont =
     | (id, exp, (RHS_block _ | RHS_infix _ | RHS_floatblock _)) :: rem ->
         let op =
           Cop(Cextcall { func = "caml_update_dummy"; ty = typ_void;
-                         alloc = false; label_after = None; },
+                         alloc = false; label_after = None; returns = true; },
               [Cvar (VP.var id); transl env exp], dbg) in
         Csequence(op, fill_blocks rem)
     | (_id, _exp, RHS_nonrec) :: rem ->

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -761,7 +761,8 @@ and transl_catch env nfail ids body handler dbg =
 and transl_make_array dbg env kind args =
   match kind with
   | Pgenarray ->
-      Cop(Cextcall("caml_make_array", typ_val, true, None),
+    Cop(Cextcall { func = "caml_make_array"; ty = typ_val;
+                   alloc = true; label_after =  None; },
           [make_alloc dbg 0 (List.map (transl env) args)], dbg)
   | Paddrarray | Pintarray ->
       make_alloc dbg 0 (List.map (transl env) args)
@@ -798,8 +799,8 @@ and transl_ccall env prim args dbg =
   in
   let args = transl_args prim.prim_native_repr_args args in
   wrap_result
-    (Cop(Cextcall(Primitive.native_name prim,
-                  typ_res, prim.prim_alloc, None), args, dbg))
+    (Cop(Cextcall { func = Primitive.native_name prim; ty = typ_res;
+                    alloc = prim.prim_alloc; label_after = None; }, args, dbg))
 
 and transl_prim_1 env p arg dbg =
   match p with
@@ -1327,7 +1328,8 @@ and transl_letrec env bindings cont =
       bindings
   in
   let op_alloc prim args =
-    Cop(Cextcall(prim, typ_val, true, None), args, dbg) in
+    Cop(Cextcall { func = prim; ty = typ_val;
+                   alloc = true; label_after = None; }, args, dbg) in
   let rec init_blocks = function
     | [] -> fill_nonrec bsz
     | (id, _exp, RHS_block sz) :: rem ->
@@ -1353,7 +1355,8 @@ and transl_letrec env bindings cont =
     | [] -> cont
     | (id, exp, (RHS_block _ | RHS_infix _ | RHS_floatblock _)) :: rem ->
         let op =
-          Cop(Cextcall("caml_update_dummy", typ_void, false, None),
+          Cop(Cextcall { func = "caml_update_dummy"; ty = typ_void;
+                         alloc = false; label_after = None; },
               [Cvar (VP.var id); transl env exp], dbg) in
         Csequence(op, fill_blocks rem)
     | (_id, _exp, RHS_nonrec) :: rem ->

--- a/asmcomp/linearize.ml
+++ b/asmcomp/linearize.ml
@@ -164,8 +164,6 @@ let linear i n contains_calls =
           copy_instr (Lop op) i (discard_dead_code n)
         else
           copy_instr (Lop op) i (linear env i.Mach.next n)
-    | Iop(Iextcall { func = "caml_ml_array_bound_error"; _ } as op) ->
-        copy_instr (Lop op) i (discard_dead_code n)
     | Iop(Imove | Ireload | Ispill)
       when i.Mach.arg.(0).loc = i.Mach.res.(0).loc ->
         linear env i.Mach.next n

--- a/asmcomp/liveness.ml
+++ b/asmcomp/liveness.ml
@@ -119,6 +119,9 @@ let rec live env i finally =
         let across_after = Reg.diff_set_array after i.res in
         let across =
           match op with
+          | Iextcall { returns = false; _ } ->
+              (* extcalls that never return can raise an exception *)
+              env.at_raise
           | Icall_ind _ | Icall_imm _ | Iextcall _ | Ialloc _
           | Iintop (Icheckbound _) | Iintop_imm(Icheckbound _, _) ->
               (* The function call may raise an exception, branching to the

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -55,7 +55,8 @@ type operation =
   | Icall_imm of { func : string; label_after : label; }
   | Itailcall_ind of { label_after : label; }
   | Itailcall_imm of { func : string; label_after : label; }
-  | Iextcall of { func : string; alloc : bool; label_after : label; }
+  | Iextcall of { func : string; alloc : bool;
+                  label_after : label; returns: bool; }
   | Istackoffset of int
   | Iload of Cmm.memory_chunk * Arch.addressing_mode
   | Istore of Cmm.memory_chunk * Arch.addressing_mode * bool

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -65,7 +65,8 @@ type operation =
   | Icall_imm of { func : string; label_after : label; }
   | Itailcall_ind of { label_after : label; }
   | Itailcall_imm of { func : string; label_after : label; }
-  | Iextcall of { func : string; alloc : bool; label_after : label; }
+  | Iextcall of { func : string; alloc : bool;
+                  label_after : label; returns : bool; }
   | Istackoffset of int
   | Iload of Cmm.memory_chunk * Arch.addressing_mode
   | Istore of Cmm.memory_chunk * Arch.addressing_mode * bool

--- a/asmcomp/printcmm.ml
+++ b/asmcomp/printcmm.ml
@@ -119,7 +119,7 @@ let trywith_kind ppf kind =
 
 let operation d = function
   | Capply _ty -> "app" ^ Debuginfo.to_string d
-  | Cextcall { func = lbl; ty = _; alloc = _; label_after = _; } ->
+  | Cextcall { func = lbl; ty = _; alloc = _; label_after = _; returns = _; } ->
       Printf.sprintf "extcall \"%s\"%s" lbl (Debuginfo.to_string d)
   | Cload (c, Asttypes.Immutable) -> Printf.sprintf "load %s" (chunk c)
   | Cload (c, Asttypes.Mutable) -> Printf.sprintf "load_mut %s" (chunk c)
@@ -227,7 +227,7 @@ let rec expr ppf = function
       List.iter (fun e -> fprintf ppf "@ %a" expr e) el;
       begin match op with
       | Capply mty -> fprintf ppf "@ %a" machtype mty
-      | Cextcall { func = _; ty = mty; alloc = _; label_after = _; } ->
+      | Cextcall { func = _; ty = mty; alloc = _; label_after = _; returns = _; } ->
         fprintf ppf "@ %a" machtype mty
       | _ -> ()
       end;

--- a/asmcomp/printcmm.ml
+++ b/asmcomp/printcmm.ml
@@ -119,7 +119,7 @@ let trywith_kind ppf kind =
 
 let operation d = function
   | Capply _ty -> "app" ^ Debuginfo.to_string d
-  | Cextcall(lbl, _ty, _alloc, _) ->
+  | Cextcall { func = lbl; ty = _; alloc = _; label_after = _; } ->
       Printf.sprintf "extcall \"%s\"%s" lbl (Debuginfo.to_string d)
   | Cload (c, Asttypes.Immutable) -> Printf.sprintf "load %s" (chunk c)
   | Cload (c, Asttypes.Mutable) -> Printf.sprintf "load_mut %s" (chunk c)
@@ -227,7 +227,8 @@ let rec expr ppf = function
       List.iter (fun e -> fprintf ppf "@ %a" expr e) el;
       begin match op with
       | Capply mty -> fprintf ppf "@ %a" machtype mty
-      | Cextcall(_, mty, _, _) -> fprintf ppf "@ %a" machtype mty
+      | Cextcall { func = _; ty = mty; alloc = _; label_after = _; } ->
+        fprintf ppf "@ %a" machtype mty
       | _ -> ()
       end;
       fprintf ppf ")@]"

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -140,7 +140,7 @@ let env_empty = {
 
 let oper_result_type = function
     Capply ty -> ty
-  | Cextcall { func = _; ty; alloc = _; label_after = _; } -> ty
+  | Cextcall { func = _; ty; alloc = _; label_after = _; returns = _; } -> ty
   | Cload (c, _) ->
       begin match c with
       | Word_val -> typ_val
@@ -521,13 +521,13 @@ method select_operation op args _dbg =
   | (Capply _, _) ->
     let label_after = Cmm.new_label () in
     (Icall_ind { label_after; }, args)
-  | (Cextcall { func; ty = _; alloc;label_after; }, _) ->
+  | (Cextcall { func; ty = _; alloc;label_after; returns; }, _) ->
     let label_after =
       match label_after with
       | None -> Cmm.new_label ()
       | Some label_after -> label_after
     in
-    Iextcall { func; alloc; label_after; }, args
+    Iextcall { func; alloc; label_after; returns; }, args
   | (Cload (chunk, _mut), [arg]) ->
       let (addr, eloc) = self#select_addressing chunk arg in
       (Iload(chunk, addr), [eloc])
@@ -797,7 +797,7 @@ method emit_expr (env:environment) exp =
           self#insert_debug env  (Iraise k) dbg rd [||];
           set_traps_for_raise env;
           None
-      end
+    end
   | Cop(Ccmpf _, _, dbg) ->
       self#emit_expr env
         (Cifthenelse (exp,
@@ -841,7 +841,7 @@ method emit_expr (env:environment) exp =
               self#insert_move_results env loc_res rd stack_ofs;
               set_traps_for_raise env;
               Some rd
-          | Iextcall _ ->
+          | Iextcall { returns; _ } ->
               let spacetime_reg =
                 self#about_to_emit_call env (Iop new_op) [| |] dbg
               in
@@ -851,9 +851,9 @@ method emit_expr (env:environment) exp =
               let loc_res =
                 self#insert_op_debug env new_op dbg
                   loc_arg (Proc.loc_external_results rd) in
-              self#insert_move_results env loc_res rd stack_ofs;
+              if returns then self#insert_move_results env loc_res rd stack_ofs;
               set_traps_for_raise env;
-              Some rd
+              if returns then Some rd else None
           | Ialloc { bytes = _; spacetime_index; label_after_call_gc; } ->
               let rd = self#regs_for typ_val in
               let bytes = size_expr env (Ctuple new_args) in

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -140,7 +140,7 @@ let env_empty = {
 
 let oper_result_type = function
     Capply ty -> ty
-  | Cextcall(_s, ty, _alloc, _) -> ty
+  | Cextcall { func = _; ty; alloc = _; label_after = _; } -> ty
   | Cload (c, _) ->
       begin match c with
       | Word_val -> typ_val
@@ -521,7 +521,7 @@ method select_operation op args _dbg =
   | (Capply _, _) ->
     let label_after = Cmm.new_label () in
     (Icall_ind { label_after; }, args)
-  | (Cextcall(func, _ty, alloc, label_after), _) ->
+  | (Cextcall { func; ty = _; alloc;label_after; }, _) ->
     let label_after =
       match label_after with
       | None -> Cmm.new_label ()

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -797,7 +797,7 @@ method emit_expr (env:environment) exp =
           self#insert_debug env  (Iraise k) dbg rd [||];
           set_traps_for_raise env;
           None
-    end
+      end
   | Cop(Ccmpf _, _, dbg) ->
       self#emit_expr env
         (Cifthenelse (exp,
@@ -851,7 +851,7 @@ method emit_expr (env:environment) exp =
               let loc_res =
                 self#insert_op_debug env new_op dbg
                   loc_arg (Proc.loc_external_results rd) in
-              if returns then self#insert_move_results env loc_res rd stack_ofs;
+              self#insert_move_results env loc_res rd stack_ofs;
               set_traps_for_raise env;
               if returns then Some rd else None
           | Ialloc { bytes = _; spacetime_index; label_after_call_gc; } ->

--- a/asmcomp/spacetime_profiling.ml
+++ b/asmcomp/spacetime_profiling.ml
@@ -110,8 +110,9 @@ let code_for_function_prologue ~function_name ~fun_dbg:dbg ~node_hole =
           dbg,
           Clet (VP.create is_new_node,
             Clet (VP.create pc, cconst_symbol function_name,
-              Cop (Cextcall ("caml_spacetime_allocate_node",
-                  [| Int |], false, None),
+                  Cop (Cextcall  { func = "caml_spacetime_allocate_node";
+                                   ty = [| Int |]; alloc = false;
+                                   label_after = None; },
                 [cconst_int (1 (* header *) + !index_within_node);
                 Cvar pc;
                 Cvar node_hole;
@@ -151,8 +152,8 @@ let code_for_blockheader ~value's_header ~node ~dbg =
        the latter table to be used for resolving a program counter at such
        a point to a location.
     *)
-    Cop (Cextcall ("caml_spacetime_generate_profinfo", [| Int |],
-        false, Some label),
+    Cop (Cextcall { func = "caml_spacetime_generate_profinfo";
+                    ty = [| Int |]; alloc= false; label_after = Some label; },
       [Cvar address_of_profinfo;
        cconst_int (index_within_node + 1)],
       dbg)
@@ -271,8 +272,8 @@ let code_for_call ~node ~callee ~is_tail ~label dbg =
         if is_tail then node
         else cconst_int 1  (* [Val_unit] *)
       in
-      Cop (Cextcall ("caml_spacetime_indirect_node_hole_ptr",
-          [| Int |], false, None),
+      Cop (Cextcall { func = "caml_spacetime_indirect_node_hole_ptr";
+                      ty = [| Int |]; alloc = false; label_after = None; },
         [callee; Cvar place_within_node; caller_node],
         dbg))
 

--- a/middle_end/flambda/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion.ml
@@ -125,7 +125,7 @@ let tupled_function_call_stub
     in
     let apply =
       Flambda.Apply.create ~callee:(Simple.var unboxed_version_var)
-        ~continuation:return_continuation
+        ~continuation:(Return return_continuation)
         exn_continuation
         ~args:(Simple.vars params)
         ~call_kind
@@ -353,7 +353,7 @@ let close_c_call t ~let_bound_var (prim : Primitive.description)
   let call args =
     let apply =
       Flambda.Apply.create ~callee:(Simple.symbol call_symbol)
-        ~continuation:return_continuation
+        ~continuation:(Return return_continuation)
         exn_continuation
         ~args
         ~call_kind
@@ -636,7 +636,7 @@ let rec close t env (ilam : Ilambda.t) : Expr.t * _ =
     let exn_continuation = close_exn_continuation t env exn_continuation in
     let apply =
       Flambda.Apply.create ~callee:(find_simple_from_id t env func)
-        ~continuation
+        ~continuation:(Return continuation)
         exn_continuation
         ~args:(find_simples t env args)
         ~call_kind
@@ -1063,12 +1063,15 @@ let ilambda_to_flambda ~backend ~module_ident ~module_block_size_in_words
       ~filename (ilam : Ilambda.program) =
   let module Backend = (val backend : Flambda_backend_intf.S) in
   let compilation_unit = Compilation_unit.get_current_exn () in
+  let bound_error_symbol =
+    Lambda_to_flambda_primitives_helpers.caml_ml_array_bound_error
+  in
   let t =
     { backend;
       current_unit_id = Compilation_unit.get_persistent_ident compilation_unit;
       symbol_for_global' = Backend.symbol_for_global';
       filename;
-      imported_symbols = Symbol.Set.empty;
+      imported_symbols = Symbol.Set.singleton bound_error_symbol;
       declared_symbols = [];
       shareable_constants = Static_const.Map.empty;
       code = [];

--- a/middle_end/flambda/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion.ml
@@ -1071,6 +1071,8 @@ let ilambda_to_flambda ~backend ~module_ident ~module_block_size_in_words
       current_unit_id = Compilation_unit.get_persistent_ident compilation_unit;
       symbol_for_global' = Backend.symbol_for_global';
       filename;
+      (* CR: externals such as bound_error_symbol should ideally not be par of
+         the imported symbols, and not be required to be in the typing env. *)
       imported_symbols = Symbol.Set.singleton bound_error_symbol;
       declared_symbols = [];
       shareable_constants = Static_const.Map.empty;

--- a/middle_end/flambda/from_lambda/lambda_to_flambda_primitives_helpers.mli
+++ b/middle_end/flambda/from_lambda/lambda_to_flambda_primitives_helpers.mli
@@ -41,6 +41,8 @@ and simple_or_prim =
   | Simple of Simple.t
   | Prim of expr_primitive
 
+val caml_ml_array_bound_error : Symbol.t
+
 val print_expr_primitive : Format.formatter -> expr_primitive -> unit
 
 val print_simple_or_prim

--- a/middle_end/flambda/inlining/inlining_transforms.mli
+++ b/middle_end/flambda/inlining/inlining_transforms.mli
@@ -23,7 +23,7 @@ val inline
   -> callee:Simple.t
   -> args:Simple.t list
   -> Flambda_type.Function_declaration_type.Inlinable.t
-  -> apply_return_continuation:Continuation.t
+  -> apply_return_continuation:Apply.Result_continuation.t
   -> apply_exn_continuation:Exn_continuation.t
   -> apply_inlining_depth:int
   -> unroll_to:int option

--- a/middle_end/flambda/simplify/simplify_expr.rec.ml
+++ b/middle_end/flambda/simplify/simplify_expr.rec.ml
@@ -1210,7 +1210,7 @@ and simplify_method_call
   let apply_cont =
     match Apply.continuation apply with
     | Never_returns ->
-      Misc.fatal_error "cannot simplify a mathod call that never returns"
+      Misc.fatal_error "cannot simplify a method call that never returns"
     | Return continuation -> continuation
   in
   let denv = DA.denv dacc in

--- a/middle_end/flambda/simplify/simplify_expr.rec.ml
+++ b/middle_end/flambda/simplify/simplify_expr.rec.ml
@@ -693,21 +693,8 @@ Format.eprintf "Simplifying inlined body with DE depth delta = %d\n%!"
   | None ->
     begin match Apply.continuation apply with
     | Never_returns ->
-      let dacc, exn_cont_use_id =
-        DA.record_continuation_use dacc
-          (Exn_continuation.exn_handler (Apply.exn_continuation apply))
-          Non_inlinable
-          ~typing_env_at_use:(DA.typing_env dacc)
-          ~arg_types:(T.unknown_types_from_arity (
-            Exn_continuation.arity (Apply.exn_continuation apply)))
-      in
-      let user_data, uacc = k dacc in
-      let apply =
-        Simplify_common.update_exn_continuation_extra_args uacc ~exn_cont_use_id
-          apply
-      in
-      let expr = Expr.create_apply apply in
-      expr, user_data, uacc
+      Misc.fatal_errorf "Never returning direct calls are \
+                         not handled at the moment (but could be)"
     | Return apply_return_continuation ->
       let dacc, use_id =
         DA.record_continuation_use dacc apply_return_continuation Non_inlinable

--- a/middle_end/flambda/terms/apply_expr.ml
+++ b/middle_end/flambda/terms/apply_expr.ml
@@ -139,7 +139,6 @@ let invariant env
       end
     end;
     begin match continuation with
-    (* CR gbury: check arity of the call in this case ? *)
     | Never_returns ->
       begin match Call_kind.return_arity call_kind with
       | [] -> ()

--- a/middle_end/flambda/terms/apply_expr.ml
+++ b/middle_end/flambda/terms/apply_expr.ml
@@ -18,9 +18,50 @@
 
 module K = Flambda_kind
 
+module Result_continuation = struct
+
+  type t =
+    | Return of Continuation.t
+    | Never_returns
+
+  include Identifiable.Make(struct
+      type nonrec t = t
+
+      let compare h1 h2 =
+        match h1, h2 with
+        | Return k1, Return k2 -> Continuation.compare k1 k2
+        | Never_returns, Never_returns -> 0
+        | Return _, Never_returns -> 1
+        | Never_returns, Return _ -> -1
+
+      let equal h1 h2 = compare h1 h2 = 0
+
+      let hash = function
+        | Return k -> Continuation.hash k
+        | Never_returns as h -> Hashtbl.hash h
+
+      let print fmt = function
+        | Return k -> Continuation.print fmt k
+        | Never_returns -> Format.fprintf fmt "∅"
+
+      let output ch h =
+        print (Format.formatter_of_out_channel ch) h
+    end)
+
+  let free_names = function
+    | Return k -> Name_occurrences.singleton_continuation k
+    | Never_returns -> Name_occurrences.empty
+
+  let apply_name_permutation t perm =
+    match t with
+    | Return k -> Return (Name_permutation.apply_continuation perm k)
+    | Never_returns -> Never_returns
+
+end
+
 type t = {
   callee : Simple.t;
-  continuation : Continuation.t;
+  continuation : Result_continuation.t;
   exn_continuation : Exn_continuation.t;
   args : Simple.t list;
   call_kind : Call_kind.t;
@@ -39,7 +80,7 @@ let print ppf { callee; continuation; exn_continuation; args; call_kind;
       @[<hov 1>(inlining_depth@ %d)@]\
       )@]"
     Simple.print callee
-    Continuation.print continuation
+    Result_continuation.print continuation
     Exn_continuation.print exn_continuation
     Simple.List.print args
     Call_kind.print call_kind
@@ -97,60 +138,74 @@ let invariant env
           print t
       end
     end;
-    begin match E.find_continuation_opt env continuation with
-    | None ->
-      unbound_continuation continuation "[Apply] term"
-    | Some (arity, kind (*, cont_stack *)) ->
-      begin match kind with
-      | Normal -> ()
-      | Exn_handler ->
-        Misc.fatal_errorf "Continuation %a is an exception handler \
-            but is used in this [Apply] term as a return continuation:@ %a"
-          Continuation.print continuation
-          print t
+    begin match continuation with
+    (* CR gbury: check arity of the call in this case ? *)
+    | Never_returns ->
+      begin match Call_kind.return_arity call_kind with
+      | [] -> ()
+      | a ->
+        Misc.fatal_errorf "This [Apply] never returns and so expects an empty \
+                           arity, but has a call kind arity of %a:@ %a"
+          Flambda_arity.print a print t
+      end
+    (* general case *)
+    | Return continuation ->
+      begin match E.find_continuation_opt env continuation with
+      | None ->
+        unbound_continuation continuation "[Apply] term"
+      | Some (arity, kind (*, cont_stack *)) ->
+        begin match kind with
+        | Normal -> ()
+        | Exn_handler ->
+          Misc.fatal_errorf "Continuation %a is an exception handler \
+                             but is used in this [Apply] term as a \
+                             return continuation:@ %a"
+            Continuation.print continuation
+            print t
+        end;
+        let expected_arity = Call_kind.return_arity call_kind in
+        if not (Flambda_arity.equal arity expected_arity)
+        then begin
+          Misc.fatal_errorf "Continuation %a called with wrong arity in \
+                             this [Apply] term: expected %a but used at %a:@ %a"
+            Continuation.print continuation
+            Flambda_arity.print expected_arity
+            Flambda_arity.print arity
+            print t
+        end (*;
+              E.Continuation_stack.unify continuation stack cont_stack *)
       end;
-      let expected_arity = Call_kind.return_arity call_kind in
-      if not (Flambda_arity.equal arity expected_arity)
-      then begin
-        Misc.fatal_errorf "Continuation %a called with wrong arity in \
-            this [Apply] term: expected %a but used at %a:@ %a"
-          Continuation.print continuation
-          Flambda_arity.print expected_arity
-          Flambda_arity.print arity
-          print t
-      end (*;
-      E.Continuation_stack.unify continuation stack cont_stack *)
-    end;
-    begin match
-      E.find_continuation_opt env
-        (Exn_continuation.exn_handler exn_continuation)
-    with
-    | None ->
-      unbound_continuation continuation
-        "[Apply] term exception continuation"
-    | Some (arity, kind (*, cont_stack *)) ->
-      begin match kind with
-      | Normal ->
-        Misc.fatal_errorf "Continuation %a is a normal continuation \
-            but is used in this [Apply] term as an exception handler:@ %a"
-          Continuation.print continuation
-          print t
-      | Exn_handler -> ()
+      begin match
+        E.find_continuation_opt env
+          (Exn_continuation.exn_handler exn_continuation)
+      with
+      | None ->
+        unbound_continuation continuation
+          "[Apply] term exception continuation"
+      | Some (arity, kind (*, cont_stack *)) ->
+        begin match kind with
+        | Normal ->
+          Misc.fatal_errorf "Continuation %a is a normal continuation \
+                             but is used in this [Apply] term as an exception handler:@ %a"
+            Continuation.print continuation
+            print t
+        | Exn_handler -> ()
+        end;
+        let expected_arity = [Flambda_kind.value] in
+        if not (Flambda_arity.equal arity expected_arity) then begin
+          Misc.fatal_errorf "Exception continuation %a named in this \
+                             [Apply] term has the wrong arity: expected %a but have %a:@ %a"
+            Continuation.print continuation
+            Flambda_arity.print expected_arity
+            Flambda_arity.print arity
+            print t
+        end (*;
+              E.Continuation_stack.unify exn_continuation stack cont_stack *)
       end;
-      let expected_arity = [Flambda_kind.value] in
-      if not (Flambda_arity.equal arity expected_arity) then begin
-        Misc.fatal_errorf "Exception continuation %a named in this \
-            [Apply] term has the wrong arity: expected %a but have %a:@ %a"
-          Continuation.print continuation
-          Flambda_arity.print expected_arity
-          Flambda_arity.print arity
-          print t
-      end (*;
-      E.Continuation_stack.unify exn_continuation stack cont_stack *)
-    end;
-    ignore (dbg : Debuginfo.t);
-    ignore (inline : Inline_attribute.t);
-    assert (inlining_depth >= 0)
+      ignore (dbg : Debuginfo.t);
+      ignore (inline : Inline_attribute.t);
+      assert (inlining_depth >= 0)
+    end
 
 let create ~callee ~continuation exn_continuation ~args ~call_kind dbg ~inline
       ~inlining_depth =
@@ -188,7 +243,7 @@ let free_names
       } =
   Name_occurrences.union_list [
     Simple.free_names callee;
-    Name_occurrences.singleton_continuation continuation;
+    Result_continuation.free_names continuation;
     Exn_continuation.free_names exn_continuation;
     Simple.List.free_names args;
     Call_kind.free_names call_kind;
@@ -206,7 +261,7 @@ let apply_name_permutation
       } as t)
       perm =
   let continuation' =
-    Name_permutation.apply_continuation perm continuation
+    Result_continuation.apply_name_permutation continuation perm
   in
   let exn_continuation' =
     Exn_continuation.apply_name_permutation exn_continuation perm

--- a/middle_end/flambda/terms/apply_expr.mli
+++ b/middle_end/flambda/terms/apply_expr.mli
@@ -26,10 +26,22 @@ include Expr_std.S with type t := t
 
 include Contains_ids.S with type t := t
 
+module Result_continuation : sig
+
+  type t =
+    | Return of Continuation.t
+    | Never_returns
+
+  include Identifiable.S with type t := t
+
+  include Contains_names.S with type t := t
+
+end
+
 (** Create an application expression. *)
 val create
    : callee:Simple.t
-  -> continuation:Continuation.t
+  -> continuation:Result_continuation.t
   -> Exn_continuation.t
   -> args:Simple.t list
   -> call_kind:Call_kind.t
@@ -49,7 +61,7 @@ val args : t -> Simple.t list
 val call_kind : t -> Call_kind.t
 
 (** Where to send the result of the application. *)
-val continuation : t -> Continuation.t
+val continuation : t -> Result_continuation.t
 
 (** Where to jump to upon the application raising an exception. *)
 val exn_continuation : t -> Exn_continuation.t
@@ -62,9 +74,9 @@ val dbg : t -> Debuginfo.t
 val inline : t -> Inline_attribute.t
 
 (** Change the return continuation of an application. *)
-val with_continuation : t -> Continuation.t -> t
+val with_continuation : t -> Result_continuation.t -> t
 
-val with_continuations : t -> Continuation.t -> Exn_continuation.t -> t
+val with_continuations : t -> Result_continuation.t -> Exn_continuation.t -> t
 
 val with_exn_continuation : t -> Exn_continuation.t -> t
 
@@ -74,7 +86,7 @@ val with_call_kind : t -> Call_kind.t -> t
 (** Change the continuation, callee and arguments of an application. *)
 val with_continuation_callee_and_args
    : t
-  -> Continuation.t
+  -> Result_continuation.t
   -> callee:Simple.t
   -> args:Simple.t list
   -> t

--- a/middle_end/flambda/terms/call_kind.ml
+++ b/middle_end/flambda/terms/call_kind.ml
@@ -139,7 +139,7 @@ let method_call kind ~obj = Method { kind; obj; }
 
 let c_call ~alloc ~param_arity ~return_arity =
   let t = C_call { alloc; param_arity; return_arity; } in
-     invariant0 t;
+  invariant0 t;
   t
 
 let return_arity t : Flambda_arity.t =

--- a/middle_end/flambda/terms/call_kind.ml
+++ b/middle_end/flambda/terms/call_kind.ml
@@ -113,9 +113,13 @@ let invariant0 t =
   match t with
   | Function call -> Function_call.invariant call
   | Method { kind = _; obj = _; } -> ()
-  | C_call { alloc = _; param_arity; return_arity; } ->
+  | C_call { alloc = _; param_arity = _; return_arity = _; } ->
+    (* CR gbury: these were removed because there didn't seem to be any problem
+       with 0-arity c-calls
     check_arity param_arity;
-    check_arity return_arity
+    check_arity return_arity;
+    *)
+    ()
 
 let invariant _env t = invariant0 t
 
@@ -135,7 +139,7 @@ let method_call kind ~obj = Method { kind; obj; }
 
 let c_call ~alloc ~param_arity ~return_arity =
   let t = C_call { alloc; param_arity; return_arity; } in
-  invariant0 t;
+     invariant0 t;
   t
 
 let return_arity t : Flambda_arity.t =

--- a/middle_end/flambda/to_cmm/un_cps_helper.ml
+++ b/middle_end/flambda/to_cmm/un_cps_helper.ml
@@ -189,9 +189,10 @@ let load ?(dbg=Debuginfo.none) kind mut addr =
 let store ?(dbg=Debuginfo.none) kind init addr value =
   Cmm.Cop (Cmm.Cstore (kind, init), [addr; value], dbg)
 
-let extcall ?(dbg=Debuginfo.none) ?label ~alloc name typ_res args =
+let extcall ?(dbg=Debuginfo.none) ?label ~returns ~alloc name typ_res args =
+  if not returns then assert (typ_res = Cmm.typ_void);
   Cmm.Cop (Cextcall  { func = name; ty = typ_res;
-                       alloc; label_after = label; }, args, dbg)
+                       alloc; label_after = label; returns; }, args, dbg)
 
 
 (* Arithmetic helpers *)
@@ -237,7 +238,7 @@ let make_array ?(dbg=Debuginfo.none) kind args =
       begin match args with
       | [] -> static_atom ~dbg 0
       | _ ->
-          extcall ~dbg ~alloc:true
+          extcall ~dbg ~alloc:true ~returns:true
             "caml_make_array" Cmm.typ_val
             [make_alloc dbg 0 args]
       end
@@ -343,13 +344,13 @@ let string_like_load_aux ~dbg kind width block ptr idx =
       if arch32 then
         begin match (kind : Flambda_primitive.string_like_value) with
         | String ->
-            extcall ~alloc:false
+            extcall ~alloc:false ~returns:true
               "caml_string_get_64" typ_int64 [block; idx]
         | Bytes ->
-            extcall ~alloc:false
+            extcall ~alloc:false ~returns:true
               "caml_bytes_get_64" typ_int64 [block; idx]
         | Bigstring ->
-            extcall ~alloc:false
+            extcall ~alloc:false ~returns:true
               "caml_ba_uint8_get64" typ_int64 [block; idx]
         end
       else begin
@@ -383,10 +384,10 @@ let bytes_like_set_aux ~dbg kind width block ptr idx value =
       if arch32 then
         begin match (kind : Flambda_primitive.bytes_like_value) with
         | Bytes ->
-            extcall ~alloc:false
+            extcall ~alloc:false ~returns:true
               "caml_bytes_set_64" typ_int64 [block; idx; value]
         | Bigstring ->
-            extcall ~alloc:false
+            extcall ~alloc:false ~returns:true
               "caml_ba_uint8_set64" typ_int64 [block; idx; value]
         end
       else begin

--- a/middle_end/flambda/to_cmm/un_cps_helper.ml
+++ b/middle_end/flambda/to_cmm/un_cps_helper.ml
@@ -190,7 +190,8 @@ let store ?(dbg=Debuginfo.none) kind init addr value =
   Cmm.Cop (Cmm.Cstore (kind, init), [addr; value], dbg)
 
 let extcall ?(dbg=Debuginfo.none) ?label ~alloc name typ_res args =
-  Cmm.Cop (Cextcall (name, typ_res, alloc, label), args, dbg)
+  Cmm.Cop (Cextcall  { func = name; ty = typ_res;
+                       alloc; label_after = label; }, args, dbg)
 
 
 (* Arithmetic helpers *)

--- a/middle_end/flambda/to_cmm/un_cps_helper.mli
+++ b/middle_end/flambda/to_cmm/un_cps_helper.mli
@@ -389,7 +389,8 @@ val indirect_call :
 (** Same as {!direct_call} but for an indirect call. *)
 
 val extcall :
-  ?dbg:Debuginfo.t -> ?label:int -> alloc:bool ->
+  ?dbg:Debuginfo.t -> ?label:int ->
+  returns:bool -> alloc:bool ->
   string -> Cmm.machtype -> Cmm.expression list -> Cmm.expression
 (** Create a C function call. *)
 

--- a/testsuite/tools/parsecmm.mly
+++ b/testsuite/tools/parsecmm.mly
@@ -223,7 +223,10 @@ expr:
   | LPAREN APPLY location expr exprlist machtype RPAREN
                 { Cop(Capply $6, $4 :: List.rev $5, debuginfo ?loc:$3 ()) }
   | LPAREN EXTCALL STRING exprlist machtype RPAREN
-               {Cop(Cextcall($3, $5, false, None), List.rev $4, debuginfo ())}
+               {Cop(Cextcall {
+                 func = $3; ty = $5;
+                 alloc = false; label_after = None;
+                }, List.rev $4, debuginfo ()) }
   | LPAREN ALLOC machtype exprlist RPAREN { Cop(Calloc, List.rev $4, debuginfo ()) }
   | LPAREN SUBF expr RPAREN { Cop(Cnegf, [$3], debuginfo ()) }
   | LPAREN SUBF expr expr RPAREN { Cop(Csubf, [$3; $4], debuginfo ()) }

--- a/testsuite/tools/parsecmm.mly
+++ b/testsuite/tools/parsecmm.mly
@@ -226,6 +226,7 @@ expr:
                {Cop(Cextcall {
                  func = $3; ty = $5;
                  alloc = false; label_after = None;
+                 returns = true;
                 }, List.rev $4, debuginfo ()) }
   | LPAREN ALLOC machtype exprlist RPAREN { Cop(Calloc, List.rev $4, debuginfo ()) }
   | LPAREN SUBF expr RPAREN { Cop(Cnegf, [$3], debuginfo ()) }


### PR DESCRIPTION
This replaces the code for out of bounds error: previously it raise manually an exception (and had to create the exn). Now it can call the dedicated c function to raise the exception. This change could probably be dependant on a compiler option ?

Additionally to the primitive translation part of the changes, 2 additional changes are present:
- in flambda2, function call continuation can now never return, which implied a log of code changes. The current PR works, but duplicates code sometimes unecesarily, so it is expected that some modifications to these changes will be needed (but this PR can help converge on what these should look like)
- some code was added to linearize.ml to eliminate the deadcode present after a call to `caml_ml_array_bound_error` in the same way as tailcalls.
