### PR TITLE
Restrict lifting to variables with normal name mode

### DIFF
--- a/middle_end/flambda2.0/simplify/simplify_named.rec.ml
+++ b/middle_end/flambda2.0/simplify/simplify_named.rec.ml
@@ -73,7 +73,9 @@ let simplify_named0 dacc ~(bound_vars : Bindable_let_bound.t)
       if T.is_bottom (DA.typing_env dacc) ty then Reachable.invalid ()
       else defining_expr
     in
-    if DE.at_unit_toplevel (DA.denv dacc) then begin
+    if DE.at_unit_toplevel (DA.denv dacc)
+      && Name_mode.is_normal (Var_in_binding_pos.name_mode bound_var)
+    then begin
       match
         Lift_inconstants.reify_primitive_at_toplevel dacc bound_var ty
       with

--- a/middle_end/flambda2.0/types/env/typing_env.rec.ml
+++ b/middle_end/flambda2.0/types/env/typing_env.rec.ml
@@ -697,6 +697,15 @@ let mem_simple t simple =
     ~name:(fun name -> mem t name)
     ~const:(fun _ -> true)
 
+let mem_normal_mode t name =
+  Name.pattern_match name
+    ~var:(fun _var ->
+      match Name.Map.find name (names_to_types t) with
+      | exception Not_found -> false
+      | (_ty, _binding_time, name_mode) ->
+        Name_mode.is_normal name_mode)
+    ~symbol:(fun sym -> Symbol.Set.mem sym t.defined_symbols)
+
 let with_current_level t ~current_level =
   let t = { t with current_level; } in
   invariant t;

--- a/middle_end/flambda2.0/types/env/typing_env.rec.ml
+++ b/middle_end/flambda2.0/types/env/typing_env.rec.ml
@@ -686,25 +686,34 @@ let binding_time_and_mode_of_simple t simple =
         Binding_time.consts_and_discriminants Name_mode.normal)
     ~name:(fun name -> binding_time_and_mode t name)
 
-let mem t name =
+let mem ?min_name_mode t name =
   Name.pattern_match name
-    ~var:(fun _var -> Name.Map.mem name (names_to_types t)
-                      || Name.Set.mem name (t.get_imported_names ()))
+    ~var:(fun _var ->
+      let name_mode =
+        match Name.Map.find name (names_to_types t) with
+        | exception Not_found ->
+          if Name.Set.mem name (t.get_imported_names ())
+          then Some Name_mode.in_types
+          else None
+        | _ty, _binding_time, name_mode ->
+          Some name_mode
+      in
+      match name_mode, min_name_mode with
+      | None, _ -> false
+      | Some _, None -> true
+      | Some name_mode, Some min_name_mode ->
+        begin match
+          Name_mode.compare_partial_order min_name_mode name_mode
+        with
+        | None -> false
+        | Some c -> c <= 0
+        end)
     ~symbol:(fun sym -> Symbol.Set.mem sym t.defined_symbols)
 
 let mem_simple t simple =
   Simple.pattern_match simple
     ~name:(fun name -> mem t name)
     ~const:(fun _ -> true)
-
-let mem_normal_mode t name =
-  Name.pattern_match name
-    ~var:(fun _var ->
-      match Name.Map.find name (names_to_types t) with
-      | exception Not_found -> false
-      | (_ty, _binding_time, name_mode) ->
-        Name_mode.is_normal name_mode)
-    ~symbol:(fun sym -> Symbol.Set.mem sym t.defined_symbols)
 
 let with_current_level t ~current_level =
   let t = { t with current_level; } in

--- a/middle_end/flambda2.0/types/env/typing_env.rec.mli
+++ b/middle_end/flambda2.0/types/env/typing_env.rec.mli
@@ -71,6 +71,8 @@ val mem : t -> Name.t -> bool
 
 val mem_simple : t -> Simple.t -> bool
 
+val mem_normal_mode : t -> Name.t -> bool
+
 val add_cse
    : t
   -> Flambda_primitive.Eligible_for_cse.t

--- a/middle_end/flambda2.0/types/env/typing_env.rec.mli
+++ b/middle_end/flambda2.0/types/env/typing_env.rec.mli
@@ -67,11 +67,9 @@ val find_params : t -> Kinded_parameter.t list -> Type_grammar.t list
 
 val variable_is_from_missing_cmx_file : t -> Name.t -> bool
 
-val mem : t -> Name.t -> bool
+val mem : ?min_name_mode:Name_mode.t -> t -> Name.t -> bool
 
 val mem_simple : t -> Simple.t -> bool
-
-val mem_normal_mode : t -> Name.t -> bool
 
 val add_cse
    : t

--- a/middle_end/flambda2.0/types/flambda_type.mli
+++ b/middle_end/flambda2.0/types/flambda_type.mli
@@ -106,7 +106,7 @@ module Typing_env : sig
     -> bound_to:Simple.t
     -> t
 
-  val mem : t -> Name.t -> bool
+  val mem : ?min_name_mode:Name_mode.t -> t -> Name.t -> bool
 
   val find : t -> Name.t -> Flambda_kind.t option -> flambda_type
 

--- a/middle_end/flambda2.0/types/template/flambda_type.templ.ml
+++ b/middle_end/flambda2.0/types/template/flambda_type.templ.ml
@@ -709,9 +709,7 @@ let reify ?allowed_if_free_vars_defined_in ?disallowed_free_vars
     match allowed_if_free_vars_defined_in with
     | None -> false
     | Some allowed_if_free_vars_defined_in ->
-      (* Only allow variables in normal mode, otherwise they will not be
-         allowed as static const fields *)
-      Typing_env.mem_normal_mode allowed_if_free_vars_defined_in (Name.var var)
+      Typing_env.mem ~min_name_mode allowed_if_free_vars_defined_in (Name.var var)
         && match disallowed_free_vars with
            | None -> true
            | Some disallowed_free_vars ->

--- a/middle_end/flambda2.0/types/template/flambda_type.templ.ml
+++ b/middle_end/flambda2.0/types/template/flambda_type.templ.ml
@@ -709,7 +709,9 @@ let reify ?allowed_if_free_vars_defined_in ?disallowed_free_vars
     match allowed_if_free_vars_defined_in with
     | None -> false
     | Some allowed_if_free_vars_defined_in ->
-      Typing_env.mem allowed_if_free_vars_defined_in (Name.var var)
+      (* Only allow variables in normal mode, otherwise they will not be
+         allowed as static const fields *)
+      Typing_env.mem_normal_mode allowed_if_free_vars_defined_in (Name.var var)
         && match disallowed_free_vars with
            | None -> true
            | Some disallowed_free_vars ->


### PR DESCRIPTION
Two orthogonal issues:
- Lifting of phantom variables is not a good idea
- Lifting of inconstant blocks should be restricted to those where all the fields are defined with normal mode