### PR TITLE
Add Exported_code module to deal with calling conventions

### DIFF
--- a/.depend
+++ b/.depend
@@ -2065,7 +2065,6 @@ asmcomp/asmlibrarian.cmo : \
     middle_end/compilenv.cmi \
     file_formats/cmx_format.cmi \
     utils/clflags.cmi \
-    middle_end/clambda.cmi \
     utils/ccomp.cmi \
     asmcomp/asmlink.cmi \
     asmcomp/asmlibrarian.cmi
@@ -2077,7 +2076,6 @@ asmcomp/asmlibrarian.cmx : \
     middle_end/compilenv.cmx \
     file_formats/cmx_format.cmi \
     utils/clflags.cmx \
-    middle_end/clambda.cmx \
     utils/ccomp.cmx \
     asmcomp/asmlink.cmx \
     asmcomp/asmlibrarian.cmi
@@ -2131,8 +2129,8 @@ asmcomp/asmpackager.cmo : \
     utils/load_path.cmi \
     lambda/lambda.cmi \
     typing/ident.cmi \
-    middle_end/flambda/cmx/flambda_cmx_format.cmi \
     middle_end/flambda/flambda_middle_end.cmi \
+    middle_end/flambda/cmx/flambda_cmx_format.cmi \
     middle_end/flambda/flambda_backend_intf.cmi \
     typing/env.cmi \
     utils/config.cmi \
@@ -2155,8 +2153,8 @@ asmcomp/asmpackager.cmx : \
     utils/load_path.cmx \
     lambda/lambda.cmx \
     typing/ident.cmx \
-    middle_end/flambda/cmx/flambda_cmx_format.cmx \
     middle_end/flambda/flambda_middle_end.cmx \
+    middle_end/flambda/cmx/flambda_cmx_format.cmx \
     middle_end/flambda/flambda_backend_intf.cmi \
     typing/env.cmx \
     utils/config.cmx \
@@ -3662,1477 +3660,50 @@ middle_end/closure/closure_middle_end.cmi : \
     lambda/lambda.cmi \
     middle_end/clambda.cmi \
     middle_end/backend_intf.cmi
-middle_end/flambda/alias_analysis.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/basic/var_within_closure.cmi \
-    lambda/tag.cmi \
+middle_end/flambda/flambda_backend_intf.cmi : \
     middle_end/flambda/compilenv_deps/symbol.cmi \
-    utils/misc.cmi \
-    lambda/lambda.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    parsing/asttypes.cmi \
-    middle_end/flambda/alias_analysis.cmi
-middle_end/flambda/alias_analysis.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/basic/var_within_closure.cmx \
-    lambda/tag.cmx \
-    middle_end/flambda/compilenv_deps/symbol.cmx \
-    utils/misc.cmx \
-    lambda/lambda.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    parsing/asttypes.cmi \
-    middle_end/flambda/alias_analysis.cmi
-middle_end/flambda/alias_analysis.cmi : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    lambda/tag.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    lambda/lambda.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    parsing/asttypes.cmi
-middle_end/flambda/allocated_const.cmo : \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/allocated_const.cmi
-middle_end/flambda/allocated_const.cmx : \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/allocated_const.cmi
-middle_end/flambda/allocated_const.cmi :
-middle_end/flambda/augment_specialised_args.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    utils/misc.cmi \
-    middle_end/internal_variable_names.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/inlining/inlining_cost.cmi \
-    utils/identifiable.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    lambda/debuginfo.cmi \
-    middle_end/flambda/basic/closure_origin.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    utils/clflags.cmi \
-    middle_end/backend_intf.cmi \
-    middle_end/flambda/augment_specialised_args.cmi
-middle_end/flambda/augment_specialised_args.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    utils/misc.cmx \
-    middle_end/internal_variable_names.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/inlining/inlining_cost.cmx \
-    utils/identifiable.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    lambda/debuginfo.cmx \
-    middle_end/flambda/basic/closure_origin.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
-    utils/clflags.cmx \
-    middle_end/backend_intf.cmi \
-    middle_end/flambda/augment_specialised_args.cmi
-middle_end/flambda/augment_specialised_args.cmi : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/inlining/inlining_cost.cmi \
-    middle_end/flambda/terms/flambda.cmi
-middle_end/flambda/build_export_info.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/basic/var_within_closure.cmi \
-    lambda/tag.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    utils/misc.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/basic/export_id.cmi \
-    middle_end/compilenv.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    utils/clflags.cmi \
-    middle_end/backend_intf.cmi \
-    middle_end/flambda/build_export_info.cmi
-middle_end/flambda/build_export_info.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/basic/var_within_closure.cmx \
-    lambda/tag.cmx \
-    middle_end/flambda/compilenv_deps/symbol.cmx \
-    utils/misc.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    middle_end/flambda/basic/export_id.cmx \
-    middle_end/compilenv.cmx \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
-    utils/clflags.cmx \
-    middle_end/backend_intf.cmi \
-    middle_end/flambda/build_export_info.cmi
-middle_end/flambda/build_export_info.cmi : \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/backend_intf.cmi
-middle_end/flambda/closure_conversion.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    lambda/tag.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    lambda/simplif.cmi \
-    typing/predef.cmi \
-    utils/numbers.cmi \
-    utils/misc.cmi \
-    lambda/lambda.cmi \
-    middle_end/internal_variable_names.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
     typing/ident.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    lambda/debuginfo.cmi \
-    middle_end/convert_primitives.cmi \
-    utils/config.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    middle_end/flambda/basic/closure_origin.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    middle_end/flambda/from_lambda/closure_conversion_aux.cmi \
-    utils/clflags.cmi \
-    middle_end/clambda_primitives.cmi \
-    middle_end/backend_intf.cmi \
-    middle_end/flambda/closure_conversion.cmi
-middle_end/flambda/closure_conversion.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    lambda/tag.cmx \
-    middle_end/flambda/compilenv_deps/symbol.cmx \
-    lambda/simplif.cmx \
-    typing/predef.cmx \
-    utils/numbers.cmx \
-    utils/misc.cmx \
-    lambda/lambda.cmx \
-    middle_end/internal_variable_names.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    typing/ident.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    lambda/debuginfo.cmx \
-    middle_end/convert_primitives.cmx \
-    utils/config.cmx \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmx \
-    middle_end/flambda/basic/closure_origin.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
-    middle_end/flambda/from_lambda/closure_conversion_aux.cmx \
-    utils/clflags.cmx \
-    middle_end/clambda_primitives.cmx \
-    middle_end/backend_intf.cmi \
-    middle_end/flambda/closure_conversion.cmi
-middle_end/flambda/closure_conversion.cmi : \
-    lambda/lambda.cmi \
-    typing/ident.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/backend_intf.cmi
-middle_end/flambda/closure_conversion_aux.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    utils/numbers.cmi \
-    utils/misc.cmi \
-    lambda/lambda.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    typing/ident.cmi \
-    middle_end/flambda/closure_conversion_aux.cmi
-middle_end/flambda/closure_conversion_aux.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/compilenv_deps/symbol.cmx \
-    utils/numbers.cmx \
-    utils/misc.cmx \
-    lambda/lambda.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    typing/ident.cmx \
-    middle_end/flambda/closure_conversion_aux.cmi
-middle_end/flambda/closure_conversion_aux.cmi : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    lambda/lambda.cmi \
-    typing/ident.cmi
-middle_end/flambda/closure_offsets.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/basic/var_within_closure.cmi \
-    utils/misc.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    middle_end/flambda/closure_offsets.cmi
-middle_end/flambda/closure_offsets.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/basic/var_within_closure.cmx \
-    utils/misc.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
-    middle_end/flambda/closure_offsets.cmi
-middle_end/flambda/closure_offsets.cmi : \
-    middle_end/flambda/basic/var_within_closure.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/basic/closure_id.cmi
-middle_end/flambda/effect_analysis.cmo : \
-    middle_end/semantics_of_primitives.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/clambda_primitives.cmi \
-    middle_end/flambda/effect_analysis.cmi
-middle_end/flambda/effect_analysis.cmx : \
-    middle_end/semantics_of_primitives.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    middle_end/clambda_primitives.cmx \
-    middle_end/flambda/effect_analysis.cmi
-middle_end/flambda/effect_analysis.cmi : \
-    middle_end/flambda/terms/flambda.cmi
-middle_end/flambda/export_info.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/basic/var_within_closure.cmi \
-    lambda/tag.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/basic/export_id.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    middle_end/flambda/export_info.cmi
-middle_end/flambda/export_info.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/basic/var_within_closure.cmx \
-    lambda/tag.cmx \
-    middle_end/flambda/compilenv_deps/symbol.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    middle_end/flambda/basic/export_id.cmx \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
-    middle_end/flambda/export_info.cmi
-middle_end/flambda/export_info.cmi : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/basic/var_within_closure.cmi \
-    lambda/tag.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/basic/export_id.cmi \
+    middle_end/flambda/cmx/flambda_cmx_format.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/basic/closure_id.cmi
-middle_end/flambda/export_info_for_pack.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/basic/var_within_closure.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/basic/set_of_closures_origin.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/basic/export_id.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    middle_end/flambda/export_info_for_pack.cmi
-middle_end/flambda/export_info_for_pack.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/basic/var_within_closure.cmx \
-    middle_end/flambda/compilenv_deps/symbol.cmx \
-    middle_end/flambda/basic/set_of_closures_origin.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    middle_end/flambda/basic/export_id.cmx \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
-    middle_end/flambda/export_info_for_pack.cmi
-middle_end/flambda/export_info_for_pack.cmi : \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi
-middle_end/flambda/extract_projections.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/basic/var_within_closure.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    middle_end/flambda/extract_projections.cmi
-middle_end/flambda/extract_projections.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/basic/var_within_closure.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
-    middle_end/flambda/extract_projections.cmi
-middle_end/flambda/extract_projections.cmi : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/terms/flambda.cmi
-middle_end/flambda/find_recursive_functions.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    utils/strongly_connected_components.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/backend_intf.cmi \
-    middle_end/flambda/find_recursive_functions.cmi
-middle_end/flambda/find_recursive_functions.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    utils/strongly_connected_components.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    middle_end/backend_intf.cmi \
-    middle_end/flambda/find_recursive_functions.cmi
-middle_end/flambda/find_recursive_functions.cmi : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/backend_intf.cmi
-middle_end/flambda/flambda.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    lambda/tag.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/basic/set_of_closures_origin.cmi \
-    lambda/printlambda.cmi \
-    middle_end/printclambda_primitives.cmi \
-    utils/numbers.cmi \
-    utils/misc.cmi \
-    lambda/lambda.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    utils/identifiable.cmi \
-    lambda/debuginfo.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    middle_end/flambda/basic/closure_origin.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    utils/clflags.cmi \
-    middle_end/clambda_primitives.cmi \
-    parsing/asttypes.cmi \
-    middle_end/flambda/flambda.cmi
-middle_end/flambda/flambda.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    lambda/tag.cmx \
-    middle_end/flambda/compilenv_deps/symbol.cmx \
-    middle_end/flambda/basic/set_of_closures_origin.cmx \
-    lambda/printlambda.cmx \
-    middle_end/printclambda_primitives.cmx \
-    utils/numbers.cmx \
-    utils/misc.cmx \
-    lambda/lambda.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    utils/identifiable.cmx \
-    lambda/debuginfo.cmx \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmx \
-    middle_end/flambda/basic/closure_origin.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
-    utils/clflags.cmx \
-    middle_end/clambda_primitives.cmx \
-    parsing/asttypes.cmi \
-    middle_end/flambda/flambda.cmi
-middle_end/flambda/flambda.cmi : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    lambda/tag.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/basic/set_of_closures_origin.cmi \
-    utils/numbers.cmi \
-    lambda/lambda.cmi \
-    utils/identifiable.cmi \
-    lambda/debuginfo.cmi \
-    middle_end/flambda/basic/closure_origin.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    middle_end/clambda_primitives.cmi \
-    parsing/asttypes.cmi
-middle_end/flambda/flambda_invariants.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/basic/var_within_closure.cmi \
-    lambda/tag.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/basic/set_of_closures_origin.cmi \
-    middle_end/printclambda_primitives.cmi \
-    utils/numbers.cmi \
-    lambda/lambda.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    lambda/debuginfo.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    middle_end/clambda_primitives.cmi \
-    parsing/asttypes.cmi \
-    middle_end/flambda/flambda_invariants.cmi
-middle_end/flambda/flambda_invariants.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/basic/var_within_closure.cmx \
-    lambda/tag.cmx \
-    middle_end/flambda/compilenv_deps/symbol.cmx \
-    middle_end/flambda/basic/set_of_closures_origin.cmx \
-    middle_end/printclambda_primitives.cmx \
-    utils/numbers.cmx \
-    lambda/lambda.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    lambda/debuginfo.cmx \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
-    middle_end/clambda_primitives.cmx \
-    parsing/asttypes.cmi \
-    middle_end/flambda/flambda_invariants.cmi
-middle_end/flambda/flambda_invariants.cmi : \
-    middle_end/flambda/terms/flambda.cmi
-middle_end/flambda/flambda_iterators.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/flambda_iterators.cmi
-middle_end/flambda/flambda_iterators.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    middle_end/flambda/flambda_iterators.cmi
-middle_end/flambda/flambda_iterators.cmi : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/terms/flambda.cmi
 middle_end/flambda/flambda_middle_end.cmo : \
-    utils/warnings.cmi \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
+    middle_end/flambda/simplify/simplify.cmi \
     utils/profile.cmi \
-    middle_end/printclambda.cmi \
+    lambda/printlambda.cmi \
+    middle_end/flambda/from_lambda/prepare_lambda.cmi \
     utils/misc.cmi \
-    parsing/location.cmi \
-    middle_end/flambda/compilenv_deps/linkage_name.cmi \
-    lambda/lambda.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/inlining/inlining_cost.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    lambda/debuginfo.cmi \
-    middle_end/compilenv.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
+    middle_end/flambda/from_lambda/ilambda.cmi \
+    middle_end/flambda/terms/flambda_unit.cmi \
+    middle_end/flambda/compilenv_deps/flambda_colours.cmi \
+    middle_end/flambda/cmx/flambda_cmx_format.cmi \
+    middle_end/flambda/from_lambda/eliminate_mutable_vars.cmi \
+    middle_end/flambda/from_lambda/cps_conversion.cmi \
+    middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/from_lambda/closure_conversion.cmi \
     utils/clflags.cmi \
-    middle_end/clambda.cmi \
-    middle_end/backend_intf.cmi \
     middle_end/flambda/flambda_middle_end.cmi
 middle_end/flambda/flambda_middle_end.cmx : \
-    utils/warnings.cmx \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/compilenv_deps/symbol.cmx \
+    middle_end/flambda/simplify/simplify.cmx \
     utils/profile.cmx \
-    middle_end/printclambda.cmx \
+    lambda/printlambda.cmx \
+    middle_end/flambda/from_lambda/prepare_lambda.cmx \
     utils/misc.cmx \
-    parsing/location.cmx \
-    middle_end/flambda/compilenv_deps/linkage_name.cmx \
-    lambda/lambda.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/inlining/inlining_cost.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    lambda/debuginfo.cmx \
-    middle_end/compilenv.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
+    middle_end/flambda/from_lambda/ilambda.cmx \
+    middle_end/flambda/terms/flambda_unit.cmx \
+    middle_end/flambda/compilenv_deps/flambda_colours.cmx \
+    middle_end/flambda/cmx/flambda_cmx_format.cmx \
+    middle_end/flambda/from_lambda/eliminate_mutable_vars.cmx \
+    middle_end/flambda/from_lambda/cps_conversion.cmx \
+    middle_end/flambda/basic/continuation.cmx \
     middle_end/flambda/from_lambda/closure_conversion.cmx \
     utils/clflags.cmx \
-    middle_end/clambda.cmx \
-    middle_end/backend_intf.cmi \
     middle_end/flambda/flambda_middle_end.cmi
 middle_end/flambda/flambda_middle_end.cmi : \
     lambda/lambda.cmi \
-    middle_end/clambda.cmi \
-    middle_end/backend_intf.cmi
-middle_end/flambda/flambda_to_clambda.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/basic/var_within_closure.cmi \
-    lambda/tag.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    typing/primitive.cmi \
-    utils/numbers.cmi \
-    utils/misc.cmi \
-    middle_end/flambda/compilenv_deps/linkage_name.cmi \
-    lambda/lambda.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    lambda/debuginfo.cmi \
-    middle_end/compilenv.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    utils/clflags.cmi \
-    middle_end/clambda.cmi \
-    middle_end/backend_var.cmi \
-    middle_end/flambda/flambda_to_clambda.cmi
-middle_end/flambda/flambda_to_clambda.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/basic/var_within_closure.cmx \
-    lambda/tag.cmx \
-    middle_end/flambda/compilenv_deps/symbol.cmx \
-    typing/primitive.cmx \
-    utils/numbers.cmx \
-    utils/misc.cmx \
-    middle_end/flambda/compilenv_deps/linkage_name.cmx \
-    lambda/lambda.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    lambda/debuginfo.cmx \
-    middle_end/compilenv.cmx \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
-    utils/clflags.cmx \
-    middle_end/clambda.cmx \
-    middle_end/backend_var.cmx \
-    middle_end/flambda/flambda_to_clambda.cmi
-middle_end/flambda/flambda_to_clambda.cmi : \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/clambda.cmi
-middle_end/flambda/flambda_utils.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/basic/var_within_closure.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    lambda/switch.cmi \
-    utils/numbers.cmi \
-    utils/misc.cmi \
-    lambda/lambda.cmi \
-    middle_end/internal_variable_names.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    lambda/debuginfo.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    middle_end/flambda/basic/closure_origin.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    middle_end/clambda_primitives.cmi \
-    parsing/asttypes.cmi \
-    middle_end/flambda/flambda_utils.cmi
-middle_end/flambda/flambda_utils.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/basic/var_within_closure.cmx \
-    middle_end/flambda/compilenv_deps/symbol.cmx \
-    lambda/switch.cmx \
-    utils/numbers.cmx \
-    utils/misc.cmx \
-    lambda/lambda.cmx \
-    middle_end/internal_variable_names.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    lambda/debuginfo.cmx \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmx \
-    middle_end/flambda/basic/closure_origin.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
-    middle_end/clambda_primitives.cmx \
-    parsing/asttypes.cmi \
-    middle_end/flambda/flambda_utils.cmi
-middle_end/flambda/flambda_utils.cmi : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/basic/var_within_closure.cmi \
-    lambda/tag.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    lambda/switch.cmi \
-    middle_end/internal_variable_names.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/basic/closure_id.cmi
-middle_end/flambda/freshening.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/basic/var_within_closure.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    utils/misc.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    utils/identifiable.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    middle_end/flambda/freshening.cmi
-middle_end/flambda/freshening.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/basic/var_within_closure.cmx \
-    middle_end/flambda/compilenv_deps/symbol.cmx \
-    utils/misc.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    utils/identifiable.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
-    middle_end/flambda/freshening.cmi
-middle_end/flambda/freshening.cmi : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/basic/var_within_closure.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/basic/closure_id.cmi
-middle_end/flambda/import_approx.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/basic/var_within_closure.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    utils/misc.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/basic/export_id.cmi \
-    middle_end/compilenv.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    middle_end/flambda/import_approx.cmi
-middle_end/flambda/import_approx.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/basic/var_within_closure.cmx \
-    middle_end/flambda/compilenv_deps/symbol.cmx \
-    utils/misc.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    middle_end/flambda/basic/export_id.cmx \
-    middle_end/compilenv.cmx \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
-    middle_end/flambda/import_approx.cmi
-middle_end/flambda/import_approx.cmi : \
-    middle_end/flambda/compilenv_deps/symbol.cmi
-middle_end/flambda/inconstant_idents.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    utils/numbers.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    utils/identifiable.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    middle_end/backend_intf.cmi \
-    parsing/asttypes.cmi \
-    middle_end/flambda/inconstant_idents.cmi
-middle_end/flambda/inconstant_idents.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/compilenv_deps/symbol.cmx \
-    utils/numbers.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    utils/identifiable.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
-    middle_end/backend_intf.cmi \
-    parsing/asttypes.cmi \
-    middle_end/flambda/inconstant_idents.cmi
-middle_end/flambda/inconstant_idents.cmi : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    middle_end/backend_intf.cmi
-middle_end/flambda/initialize_symbol_to_let_symbol.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    utils/misc.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/initialize_symbol_to_let_symbol.cmi
-middle_end/flambda/initialize_symbol_to_let_symbol.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    utils/misc.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    middle_end/flambda/initialize_symbol_to_let_symbol.cmi
-middle_end/flambda/initialize_symbol_to_let_symbol.cmi : \
-    middle_end/flambda/terms/flambda.cmi
-middle_end/flambda/inline_and_simplify.cmo : \
-    utils/warnings.cmi \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/basic/var_within_closure.cmi \
-    lambda/tag.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    typing/predef.cmi \
-    utils/misc.cmi \
-    parsing/location.cmi \
-    lambda/lambda.cmi \
-    middle_end/internal_variable_names.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/inlining/inlining_decision.cmi \
-    middle_end/flambda/inlining/inlining_cost.cmi \
     typing/ident.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    lambda/debuginfo.cmi \
-    utils/config.cmi \
-    middle_end/flambda/basic/closure_origin.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    utils/clflags.cmi \
-    middle_end/clambda_primitives.cmi \
-    middle_end/backend_intf.cmi \
-    middle_end/flambda/inline_and_simplify.cmi
-middle_end/flambda/inline_and_simplify.cmx : \
-    utils/warnings.cmx \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/basic/var_within_closure.cmx \
-    lambda/tag.cmx \
-    middle_end/flambda/compilenv_deps/symbol.cmx \
-    typing/predef.cmx \
-    utils/misc.cmx \
-    parsing/location.cmx \
-    lambda/lambda.cmx \
-    middle_end/internal_variable_names.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/inlining/inlining_decision.cmx \
-    middle_end/flambda/inlining/inlining_cost.cmx \
-    typing/ident.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    lambda/debuginfo.cmx \
-    utils/config.cmx \
-    middle_end/flambda/basic/closure_origin.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
-    utils/clflags.cmx \
-    middle_end/clambda_primitives.cmx \
-    middle_end/backend_intf.cmi \
-    middle_end/flambda/inline_and_simplify.cmi
-middle_end/flambda/inline_and_simplify.cmi : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/backend_intf.cmi
-middle_end/flambda/inline_and_simplify_aux.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/basic/var_within_closure.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/basic/set_of_closures_origin.cmi \
-    utils/misc.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/inlining/inlining_cost.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    lambda/debuginfo.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    middle_end/flambda/basic/closure_origin.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    utils/clflags.cmi \
-    middle_end/backend_intf.cmi \
-    middle_end/flambda/inline_and_simplify_aux.cmi
-middle_end/flambda/inline_and_simplify_aux.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/basic/var_within_closure.cmx \
-    middle_end/flambda/compilenv_deps/symbol.cmx \
-    middle_end/flambda/basic/set_of_closures_origin.cmx \
-    utils/misc.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/inlining/inlining_cost.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    lambda/debuginfo.cmx \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmx \
-    middle_end/flambda/basic/closure_origin.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
-    utils/clflags.cmx \
-    middle_end/backend_intf.cmi \
-    middle_end/flambda/inline_and_simplify_aux.cmi
-middle_end/flambda/inline_and_simplify_aux.cmi : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/basic/set_of_closures_origin.cmi \
-    middle_end/flambda/inlining/inlining_cost.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    lambda/debuginfo.cmi \
-    middle_end/flambda/basic/closure_origin.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    middle_end/backend_intf.cmi
-middle_end/flambda/inlining_cost.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    typing/primitive.cmi \
-    utils/misc.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    utils/clflags.cmi \
-    middle_end/clambda_primitives.cmi \
-    middle_end/flambda/inlining_cost.cmi
-middle_end/flambda/inlining_cost.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    typing/primitive.cmx \
-    utils/misc.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    utils/clflags.cmx \
-    middle_end/clambda_primitives.cmx \
-    middle_end/flambda/inlining_cost.cmi
-middle_end/flambda/inlining_cost.cmi : \
-    middle_end/flambda/terms/flambda.cmi
-middle_end/flambda/inlining_decision.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/basic/var_within_closure.cmi \
-    utils/misc.cmi \
-    lambda/lambda.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/inlining/inlining_transforms.cmi \
-    middle_end/flambda/inlining/inlining_cost.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    utils/clflags.cmi \
-    middle_end/flambda/inlining_decision.cmi
-middle_end/flambda/inlining_decision.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/basic/var_within_closure.cmx \
-    utils/misc.cmx \
-    lambda/lambda.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/inlining/inlining_transforms.cmx \
-    middle_end/flambda/inlining/inlining_cost.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
-    utils/clflags.cmx \
-    middle_end/flambda/inlining_decision.cmi
-middle_end/flambda/inlining_decision.cmi : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    lambda/lambda.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    lambda/debuginfo.cmi \
-    middle_end/flambda/basic/closure_id.cmi
-middle_end/flambda/inlining_decision_intf.cmi : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    lambda/debuginfo.cmi \
-    middle_end/flambda/basic/closure_id.cmi
-middle_end/flambda/inlining_stats.cmo : \
-    utils/misc.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    lambda/debuginfo.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    utils/clflags.cmi \
-    middle_end/flambda/inlining_stats.cmi
-middle_end/flambda/inlining_stats.cmx : \
-    utils/misc.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    lambda/debuginfo.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
-    utils/clflags.cmx \
-    middle_end/flambda/inlining_stats.cmi
-middle_end/flambda/inlining_stats.cmi : \
-    lambda/debuginfo.cmi \
-    middle_end/flambda/basic/closure_id.cmi
-middle_end/flambda/inlining_stats_types.cmo : \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/inlining/inlining_cost.cmi \
-    middle_end/flambda/inlining_stats_types.cmi
-middle_end/flambda/inlining_stats_types.cmx : \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/inlining/inlining_cost.cmx \
-    middle_end/flambda/inlining_stats_types.cmi
-middle_end/flambda/inlining_stats_types.cmi : \
-    middle_end/flambda/inlining/inlining_cost.cmi
-middle_end/flambda/inlining_transforms.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/basic/var_within_closure.cmi \
-    lambda/lambda.cmi \
-    middle_end/internal_variable_names.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/inlining/inlining_cost.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    lambda/debuginfo.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    middle_end/flambda/basic/closure_origin.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    middle_end/flambda/inlining_transforms.cmi
-middle_end/flambda/inlining_transforms.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/basic/var_within_closure.cmx \
-    lambda/lambda.cmx \
-    middle_end/internal_variable_names.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/inlining/inlining_cost.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    lambda/debuginfo.cmx \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmx \
-    middle_end/flambda/basic/closure_origin.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
-    middle_end/flambda/inlining_transforms.cmi
-middle_end/flambda/inlining_transforms.cmi : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    lambda/lambda.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    lambda/debuginfo.cmi \
-    middle_end/flambda/basic/closure_id.cmi
-middle_end/flambda/invariant_params.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    utils/clflags.cmi \
-    middle_end/backend_intf.cmi \
-    middle_end/flambda/invariant_params.cmi
-middle_end/flambda/invariant_params.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/compilenv_deps/symbol.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
-    utils/clflags.cmx \
-    middle_end/backend_intf.cmi \
-    middle_end/flambda/invariant_params.cmi
-middle_end/flambda/invariant_params.cmi : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/backend_intf.cmi
-middle_end/flambda/lift_code.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    utils/strongly_connected_components.cmi \
-    lambda/lambda.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    middle_end/flambda/lift_code.cmi
-middle_end/flambda/lift_code.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    utils/strongly_connected_components.cmx \
-    lambda/lambda.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmx \
-    middle_end/flambda/lift_code.cmi
-middle_end/flambda/lift_code.cmi : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/internal_variable_names.cmi \
-    middle_end/flambda/terms/flambda.cmi
-middle_end/flambda/lift_constants.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/basic/var_within_closure.cmi \
-    lambda/tag.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    utils/strongly_connected_components.cmi \
-    utils/misc.cmi \
-    middle_end/internal_variable_names.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    middle_end/backend_intf.cmi \
-    parsing/asttypes.cmi \
-    middle_end/flambda/lift_constants.cmi
-middle_end/flambda/lift_constants.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/basic/var_within_closure.cmx \
-    lambda/tag.cmx \
-    middle_end/flambda/compilenv_deps/symbol.cmx \
-    utils/strongly_connected_components.cmx \
-    utils/misc.cmx \
-    middle_end/internal_variable_names.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
-    middle_end/backend_intf.cmi \
-    parsing/asttypes.cmi \
-    middle_end/flambda/lift_constants.cmi
-middle_end/flambda/lift_constants.cmi : \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/backend_intf.cmi
-middle_end/flambda/lift_let_to_initialize_symbol.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    lambda/tag.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/internal_variable_names.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    lambda/debuginfo.cmi \
-    parsing/asttypes.cmi \
-    middle_end/flambda/lift_let_to_initialize_symbol.cmi
-middle_end/flambda/lift_let_to_initialize_symbol.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    lambda/tag.cmx \
-    middle_end/flambda/compilenv_deps/symbol.cmx \
-    middle_end/internal_variable_names.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    lambda/debuginfo.cmx \
-    parsing/asttypes.cmi \
-    middle_end/flambda/lift_let_to_initialize_symbol.cmi
-middle_end/flambda/lift_let_to_initialize_symbol.cmi : \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/backend_intf.cmi
-middle_end/flambda/parameter.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    utils/identifiable.cmi \
-    middle_end/flambda/parameter.cmi
-middle_end/flambda/parameter.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    utils/identifiable.cmx \
-    middle_end/flambda/parameter.cmi
-middle_end/flambda/parameter.cmi : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    utils/identifiable.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi
-middle_end/flambda/pass_wrapper.cmo : \
-    utils/int_replace_polymorphic_compare.cmi \
-    utils/clflags.cmi \
-    middle_end/flambda/pass_wrapper.cmi
-middle_end/flambda/pass_wrapper.cmx : \
-    utils/int_replace_polymorphic_compare.cmx \
-    utils/clflags.cmx \
-    middle_end/flambda/pass_wrapper.cmi
-middle_end/flambda/pass_wrapper.cmi :
-middle_end/flambda/projection.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/basic/var_within_closure.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    utils/identifiable.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    middle_end/flambda/projection.cmi
-middle_end/flambda/projection.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/basic/var_within_closure.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    utils/identifiable.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
-    middle_end/flambda/projection.cmi
-middle_end/flambda/projection.cmi : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/basic/var_within_closure.cmi \
-    utils/identifiable.cmi \
-    middle_end/flambda/basic/closure_id.cmi
-middle_end/flambda/ref_to_variables.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    lambda/lambda.cmi \
-    middle_end/internal_variable_names.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    parsing/asttypes.cmi \
-    middle_end/flambda/ref_to_variables.cmi
-middle_end/flambda/ref_to_variables.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    lambda/lambda.cmx \
-    middle_end/internal_variable_names.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    parsing/asttypes.cmi \
-    middle_end/flambda/ref_to_variables.cmi
-middle_end/flambda/ref_to_variables.cmi : \
-    middle_end/flambda/terms/flambda.cmi
-middle_end/flambda/remove_free_vars_equal_to_args.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/remove_free_vars_equal_to_args.cmi
-middle_end/flambda/remove_free_vars_equal_to_args.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    middle_end/flambda/remove_free_vars_equal_to_args.cmi
-middle_end/flambda/remove_free_vars_equal_to_args.cmi : \
-    middle_end/flambda/terms/flambda.cmi
-middle_end/flambda/remove_unused_arguments.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    middle_end/flambda/basic/closure_origin.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    utils/clflags.cmi \
-    middle_end/flambda/remove_unused_arguments.cmi
-middle_end/flambda/remove_unused_arguments.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmx \
-    middle_end/flambda/basic/closure_origin.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
-    utils/clflags.cmx \
-    middle_end/flambda/remove_unused_arguments.cmi
-middle_end/flambda/remove_unused_arguments.cmi : \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/backend_intf.cmi
-middle_end/flambda/remove_unused_closure_vars.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/basic/var_within_closure.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    middle_end/flambda/remove_unused_closure_vars.cmi
-middle_end/flambda/remove_unused_closure_vars.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/basic/var_within_closure.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
-    middle_end/flambda/remove_unused_closure_vars.cmi
-middle_end/flambda/remove_unused_closure_vars.cmi : \
-    middle_end/flambda/terms/flambda.cmi
-middle_end/flambda/remove_unused_program_constructs.cmo : \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/remove_unused_program_constructs.cmi
-middle_end/flambda/remove_unused_program_constructs.cmx : \
-    middle_end/flambda/compilenv_deps/symbol.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    middle_end/flambda/remove_unused_program_constructs.cmi
-middle_end/flambda/remove_unused_program_constructs.cmi : \
-    middle_end/flambda/terms/flambda.cmi
-middle_end/flambda/share_constants.cmo : \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/share_constants.cmi
-middle_end/flambda/share_constants.cmx : \
-    middle_end/flambda/compilenv_deps/symbol.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    middle_end/flambda/share_constants.cmi
-middle_end/flambda/share_constants.cmi : \
-    middle_end/flambda/terms/flambda.cmi
-middle_end/flambda/simple_value_approx.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/basic/var_within_closure.cmi \
-    lambda/tag.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/basic/set_of_closures_origin.cmi \
-    utils/misc.cmi \
-    lambda/lambda.cmi \
-    middle_end/internal_variable_names.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/inlining/inlining_cost.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/basic/export_id.cmi \
-    lambda/debuginfo.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    middle_end/flambda/basic/closure_origin.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    middle_end/flambda/simple_value_approx.cmi
-middle_end/flambda/simple_value_approx.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/basic/var_within_closure.cmx \
-    lambda/tag.cmx \
-    middle_end/flambda/compilenv_deps/symbol.cmx \
-    middle_end/flambda/basic/set_of_closures_origin.cmx \
-    utils/misc.cmx \
-    lambda/lambda.cmx \
-    middle_end/internal_variable_names.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/inlining/inlining_cost.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    middle_end/flambda/basic/export_id.cmx \
-    lambda/debuginfo.cmx \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmx \
-    middle_end/flambda/basic/closure_origin.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
-    middle_end/flambda/simple_value_approx.cmi
-middle_end/flambda/simple_value_approx.cmi : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/basic/var_within_closure.cmi \
-    lambda/tag.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/basic/set_of_closures_origin.cmi \
-    lambda/lambda.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/basic/export_id.cmi \
-    lambda/debuginfo.cmi \
-    middle_end/flambda/basic/closure_origin.cmi \
-    middle_end/flambda/basic/closure_id.cmi
-middle_end/flambda/simplify_boxed_integer_ops.cmo : \
-    middle_end/flambda/simplify/simplify_common.cmi \
-    lambda/lambda.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/inlining/inlining_cost.cmi \
-    middle_end/clambda_primitives.cmi \
-    middle_end/flambda/simplify_boxed_integer_ops.cmi
-middle_end/flambda/simplify_boxed_integer_ops.cmx : \
-    middle_end/flambda/simplify/simplify_common.cmx \
-    lambda/lambda.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/inlining/inlining_cost.cmx \
-    middle_end/clambda_primitives.cmx \
-    middle_end/flambda/simplify_boxed_integer_ops.cmi
-middle_end/flambda/simplify_boxed_integer_ops.cmi :
-middle_end/flambda/simplify_boxed_integer_ops_intf.cmi : \
-    middle_end/flambda/inlining/inlining_cost.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/clambda_primitives.cmi
-middle_end/flambda/simplify_common.cmo : \
-    lambda/lambda.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/inlining/inlining_cost.cmi \
-    middle_end/flambda/simplify_common.cmi
-middle_end/flambda/simplify_common.cmx : \
-    lambda/lambda.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/inlining/inlining_cost.cmx \
-    middle_end/flambda/simplify_common.cmi
-middle_end/flambda/simplify_common.cmi : \
-    lambda/lambda.cmi \
-    middle_end/flambda/inlining/inlining_cost.cmi \
-    middle_end/flambda/terms/flambda.cmi
-middle_end/flambda/simplify_primitives.cmo : \
-    lambda/tag.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/simplify/simplify_common.cmi \
-    middle_end/semantics_of_primitives.cmi \
-    utils/misc.cmi \
-    lambda/lambda.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/inlining/inlining_cost.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    utils/clflags.cmi \
-    middle_end/clambda_primitives.cmi \
-    parsing/asttypes.cmi \
-    middle_end/flambda/simplify_primitives.cmi
-middle_end/flambda/simplify_primitives.cmx : \
-    lambda/tag.cmx \
-    middle_end/flambda/compilenv_deps/symbol.cmx \
-    middle_end/flambda/simplify/simplify_common.cmx \
-    middle_end/semantics_of_primitives.cmx \
-    utils/misc.cmx \
-    lambda/lambda.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/inlining/inlining_cost.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    utils/clflags.cmx \
-    middle_end/clambda_primitives.cmx \
-    parsing/asttypes.cmi \
-    middle_end/flambda/simplify_primitives.cmi
-middle_end/flambda/simplify_primitives.cmi : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/inlining/inlining_cost.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    lambda/debuginfo.cmi \
-    middle_end/clambda_primitives.cmi
-middle_end/flambda/traverse_for_exported_symbols.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/basic/var_within_closure.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    utils/misc.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/basic/export_id.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    middle_end/flambda/traverse_for_exported_symbols.cmi
-middle_end/flambda/traverse_for_exported_symbols.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/basic/var_within_closure.cmx \
-    middle_end/flambda/compilenv_deps/symbol.cmx \
-    utils/misc.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    middle_end/flambda/basic/export_id.cmx \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
-    middle_end/flambda/traverse_for_exported_symbols.cmi
-middle_end/flambda/traverse_for_exported_symbols.cmi : \
-    middle_end/flambda/basic/var_within_closure.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/basic/export_id.cmi \
-    middle_end/flambda/basic/closure_id.cmi
-middle_end/flambda/un_anf.cmo : \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/semantics_of_primitives.cmi \
-    middle_end/printclambda.cmi \
-    utils/misc.cmi \
-    lambda/lambda.cmi \
-    lambda/debuginfo.cmi \
-    utils/clflags.cmi \
-    middle_end/clambda_primitives.cmi \
-    middle_end/clambda.cmi \
-    middle_end/backend_var.cmi \
-    parsing/asttypes.cmi \
-    middle_end/flambda/un_anf.cmi
-middle_end/flambda/un_anf.cmx : \
-    middle_end/flambda/compilenv_deps/symbol.cmx \
-    middle_end/semantics_of_primitives.cmx \
-    middle_end/printclambda.cmx \
-    utils/misc.cmx \
-    lambda/lambda.cmx \
-    lambda/debuginfo.cmx \
-    utils/clflags.cmx \
-    middle_end/clambda_primitives.cmx \
-    middle_end/clambda.cmx \
-    middle_end/backend_var.cmx \
-    parsing/asttypes.cmi \
-    middle_end/flambda/un_anf.cmi
-middle_end/flambda/un_anf.cmi : \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/clambda.cmi
-middle_end/flambda/unbox_closures.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/inlining/inlining_cost.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    utils/clflags.cmi \
-    middle_end/flambda/unbox_closures.cmi
-middle_end/flambda/unbox_closures.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/inlining/inlining_cost.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
-    utils/clflags.cmx \
-    middle_end/flambda/unbox_closures.cmi
-middle_end/flambda/unbox_closures.cmi : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/inlining/inlining_cost.cmi \
-    middle_end/flambda/terms/flambda.cmi
-middle_end/flambda/unbox_free_vars_of_closures.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    utils/misc.cmi \
-    middle_end/internal_variable_names.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/inlining/inlining_cost.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    utils/clflags.cmi \
-    middle_end/flambda/unbox_free_vars_of_closures.cmi
-middle_end/flambda/unbox_free_vars_of_closures.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    utils/misc.cmx \
-    middle_end/internal_variable_names.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/inlining/inlining_cost.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    utils/clflags.cmx \
-    middle_end/flambda/unbox_free_vars_of_closures.cmi
-middle_end/flambda/unbox_free_vars_of_closures.cmi : \
-    middle_end/flambda/inlining/inlining_cost.cmi \
-    middle_end/flambda/terms/flambda.cmi
-middle_end/flambda/unbox_specialised_args.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    utils/clflags.cmi \
-    middle_end/flambda/unbox_specialised_args.cmi
-middle_end/flambda/unbox_specialised_args.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    utils/clflags.cmx \
-    middle_end/flambda/unbox_specialised_args.cmi
-middle_end/flambda/unbox_specialised_args.cmi : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/inlining/inlining_cost.cmi \
-    middle_end/flambda/terms/flambda.cmi
-middle_end/flambda/base_types/closure_element.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/base_types/closure_element.cmi
-middle_end/flambda/base_types/closure_element.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/base_types/closure_element.cmi
-middle_end/flambda/base_types/closure_element.cmi : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    utils/identifiable.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi
-middle_end/flambda/base_types/closure_id.cmo : \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/base_types/closure_id.cmi
-middle_end/flambda/base_types/closure_id.cmx : \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/base_types/closure_id.cmi
-middle_end/flambda/base_types/closure_id.cmi :
-middle_end/flambda/base_types/closure_origin.cmo : \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    middle_end/flambda/base_types/closure_origin.cmi
-middle_end/flambda/base_types/closure_origin.cmx : \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
-    middle_end/flambda/base_types/closure_origin.cmi
-middle_end/flambda/base_types/closure_origin.cmi : \
-    utils/identifiable.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    middle_end/flambda/basic/closure_id.cmi
-middle_end/flambda/base_types/compilation_unit.cmo : \
-    utils/misc.cmi \
-    middle_end/flambda/compilenv_deps/linkage_name.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    utils/identifiable.cmi \
-    typing/ident.cmi \
-    middle_end/flambda/base_types/compilation_unit.cmi
-middle_end/flambda/base_types/compilation_unit.cmx : \
-    utils/misc.cmx \
-    middle_end/flambda/compilenv_deps/linkage_name.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    utils/identifiable.cmx \
-    typing/ident.cmx \
-    middle_end/flambda/base_types/compilation_unit.cmi
-middle_end/flambda/base_types/compilation_unit.cmi : \
-    middle_end/flambda/compilenv_deps/linkage_name.cmi \
-    utils/identifiable.cmi \
-    typing/ident.cmi
-middle_end/flambda/base_types/export_id.cmo : \
-    utils/int_replace_polymorphic_compare.cmi \
-    utils/identifiable.cmi \
-    middle_end/flambda/basic/id_types.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    middle_end/flambda/base_types/export_id.cmi
-middle_end/flambda/base_types/export_id.cmx : \
-    utils/int_replace_polymorphic_compare.cmx \
-    utils/identifiable.cmx \
-    middle_end/flambda/basic/id_types.cmx \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmx \
-    middle_end/flambda/base_types/export_id.cmi
-middle_end/flambda/base_types/export_id.cmi : \
-    utils/identifiable.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi
-middle_end/flambda/base_types/id_types.cmo : \
-    utils/int_replace_polymorphic_compare.cmi \
-    utils/identifiable.cmi \
-    middle_end/flambda/base_types/id_types.cmi
-middle_end/flambda/base_types/id_types.cmx : \
-    utils/int_replace_polymorphic_compare.cmx \
-    utils/identifiable.cmx \
-    middle_end/flambda/base_types/id_types.cmi
-middle_end/flambda/base_types/id_types.cmi : \
-    utils/identifiable.cmi
-middle_end/flambda/base_types/linkage_name.cmo : \
-    utils/int_replace_polymorphic_compare.cmi \
-    utils/identifiable.cmi \
-    middle_end/flambda/base_types/linkage_name.cmi
-middle_end/flambda/base_types/linkage_name.cmx : \
-    utils/int_replace_polymorphic_compare.cmx \
-    utils/identifiable.cmx \
-    middle_end/flambda/base_types/linkage_name.cmi
-middle_end/flambda/base_types/linkage_name.cmi : \
-    utils/identifiable.cmi
-middle_end/flambda/base_types/mutable_variable.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/base_types/mutable_variable.cmi
-middle_end/flambda/base_types/mutable_variable.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/base_types/mutable_variable.cmi
-middle_end/flambda/base_types/mutable_variable.cmi : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/internal_variable_names.cmi \
-    utils/identifiable.cmi \
-    typing/ident.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi
-middle_end/flambda/base_types/set_of_closures_id.cmo : \
-    utils/int_replace_polymorphic_compare.cmi \
-    utils/identifiable.cmi \
-    middle_end/flambda/basic/id_types.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    middle_end/flambda/base_types/set_of_closures_id.cmi
-middle_end/flambda/base_types/set_of_closures_id.cmx : \
-    utils/int_replace_polymorphic_compare.cmx \
-    utils/identifiable.cmx \
-    middle_end/flambda/basic/id_types.cmx \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmx \
-    middle_end/flambda/base_types/set_of_closures_id.cmi
-middle_end/flambda/base_types/set_of_closures_id.cmi : \
-    utils/identifiable.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi
-middle_end/flambda/base_types/set_of_closures_origin.cmo : \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/base_types/set_of_closures_origin.cmi
-middle_end/flambda/base_types/set_of_closures_origin.cmx : \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/base_types/set_of_closures_origin.cmi
-middle_end/flambda/base_types/set_of_closures_origin.cmi : \
-    utils/identifiable.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi
-middle_end/flambda/base_types/static_exception.cmo : \
-    utils/numbers.cmi \
-    lambda/lambda.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/base_types/static_exception.cmi
-middle_end/flambda/base_types/static_exception.cmx : \
-    utils/numbers.cmx \
-    lambda/lambda.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/base_types/static_exception.cmi
-middle_end/flambda/base_types/static_exception.cmi : \
-    utils/identifiable.cmi
-middle_end/flambda/base_types/symbol.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    utils/misc.cmi \
-    middle_end/flambda/compilenv_deps/linkage_name.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    utils/identifiable.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    middle_end/flambda/base_types/symbol.cmi
-middle_end/flambda/base_types/symbol.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    utils/misc.cmx \
-    middle_end/flambda/compilenv_deps/linkage_name.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    utils/identifiable.cmx \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmx \
-    middle_end/flambda/base_types/symbol.cmi
-middle_end/flambda/base_types/symbol.cmi : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/compilenv_deps/linkage_name.cmi \
-    utils/identifiable.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi
-middle_end/flambda/base_types/var_within_closure.cmo : \
-    utils/int_replace_polymorphic_compare.cmi \
-    middle_end/flambda/base_types/var_within_closure.cmi
-middle_end/flambda/base_types/var_within_closure.cmx : \
-    utils/int_replace_polymorphic_compare.cmx \
-    middle_end/flambda/base_types/var_within_closure.cmi
-middle_end/flambda/base_types/var_within_closure.cmi :
-middle_end/flambda/base_types/variable.cmo : \
-    utils/misc.cmi \
-    middle_end/internal_variable_names.cmi \
-    utils/int_replace_polymorphic_compare.cmi \
-    utils/identifiable.cmi \
-    typing/ident.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    middle_end/flambda/base_types/variable.cmi
-middle_end/flambda/base_types/variable.cmx : \
-    utils/misc.cmx \
-    middle_end/internal_variable_names.cmx \
-    utils/int_replace_polymorphic_compare.cmx \
-    utils/identifiable.cmx \
-    typing/ident.cmx \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmx \
-    middle_end/flambda/base_types/variable.cmi
-middle_end/flambda/base_types/variable.cmi : \
-    middle_end/internal_variable_names.cmi \
-    utils/identifiable.cmi \
-    typing/ident.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi
+    middle_end/flambda/terms/flambda_unit.cmi \
+    middle_end/flambda/cmx/flambda_cmx_format.cmi \
+    middle_end/flambda/flambda_backend_intf.cmi
 asmcomp/debug/available_regs.cmo : \
     asmcomp/debug/reg_with_debug_info.cmi \
     asmcomp/debug/reg_availability_set.cmi \
@@ -5866,6 +4437,24 @@ middle_end/flambda/cmx/contains_ids.cmo : \
     middle_end/flambda/cmx/ids_for_export.cmi
 middle_end/flambda/cmx/contains_ids.cmx : \
     middle_end/flambda/cmx/ids_for_export.cmx
+middle_end/flambda/cmx/exported_code.cmo : \
+    middle_end/flambda/naming/name_occurrences.cmi \
+    utils/misc.cmi \
+    middle_end/flambda/cmx/ids_for_export.cmi \
+    middle_end/flambda/terms/flambda.cmi \
+    middle_end/flambda/basic/code_id.cmi \
+    middle_end/flambda/cmx/exported_code.cmi
+middle_end/flambda/cmx/exported_code.cmx : \
+    middle_end/flambda/naming/name_occurrences.cmx \
+    utils/misc.cmx \
+    middle_end/flambda/cmx/ids_for_export.cmx \
+    middle_end/flambda/terms/flambda.cmx \
+    middle_end/flambda/basic/code_id.cmx \
+    middle_end/flambda/cmx/exported_code.cmi
+middle_end/flambda/cmx/exported_code.cmi : \
+    middle_end/flambda/terms/flambda.cmi \
+    middle_end/flambda/cmx/contains_ids.cmo \
+    middle_end/flambda/basic/code_id.cmi
 middle_end/flambda/cmx/exported_offsets.cmo : \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/basic/closure_id.cmi \
@@ -5883,9 +4472,9 @@ middle_end/flambda/cmx/flambda_cmx.cmo : \
     middle_end/flambda/cmx/flambda_cmx_format.cmi \
     middle_end/flambda/flambda_backend_intf.cmi \
     middle_end/flambda/cmx/exported_offsets.cmi \
+    middle_end/flambda/cmx/exported_code.cmi \
     middle_end/flambda/simplify/env/continuation_uses_env.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    middle_end/flambda/basic/code_id.cmi \
     utils/clflags.cmi \
     middle_end/flambda/cmx/flambda_cmx.cmi
 middle_end/flambda/cmx/flambda_cmx.cmx : \
@@ -5894,9 +4483,9 @@ middle_end/flambda/cmx/flambda_cmx.cmx : \
     middle_end/flambda/cmx/flambda_cmx_format.cmx \
     middle_end/flambda/flambda_backend_intf.cmi \
     middle_end/flambda/cmx/exported_offsets.cmx \
+    middle_end/flambda/cmx/exported_code.cmx \
     middle_end/flambda/simplify/env/continuation_uses_env.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
-    middle_end/flambda/basic/code_id.cmx \
     utils/clflags.cmx \
     middle_end/flambda/cmx/flambda_cmx.cmi
 middle_end/flambda/cmx/flambda_cmx.cmi : \
@@ -5918,8 +4507,8 @@ middle_end/flambda/cmx/flambda_cmx_format.cmo : \
     utils/misc.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/types/flambda_type.cmi \
-    middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/cmx/exported_offsets.cmi \
+    middle_end/flambda/cmx/exported_code.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/cmx/flambda_cmx_format.cmi
@@ -5931,17 +4520,16 @@ middle_end/flambda/cmx/flambda_cmx_format.cmx : \
     utils/misc.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/types/flambda_type.cmx \
-    middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/cmx/exported_offsets.cmx \
+    middle_end/flambda/cmx/exported_code.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
     middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/cmx/flambda_cmx_format.cmi
 middle_end/flambda/cmx/flambda_cmx_format.cmi : \
     middle_end/flambda/types/flambda_type.cmi \
-    middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/cmx/exported_offsets.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    middle_end/flambda/basic/code_id.cmi
+    middle_end/flambda/cmx/exported_code.cmi \
+    middle_end/flambda/compilenv_deps/compilation_unit.cmi
 middle_end/flambda/cmx/ids_for_export.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
@@ -5991,6 +4579,7 @@ middle_end/flambda/from_lambda/closure_conversion.cmo : \
     lambda/lambda.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
     utils/int_replace_polymorphic_compare.cmi \
+    middle_end/flambda/basic/inline_attribute.cmi \
     middle_end/flambda/from_lambda/ilambda.cmi \
     typing/ident.cmi \
     middle_end/flambda/terms/flambda_unit.cmi \
@@ -6040,6 +4629,7 @@ middle_end/flambda/from_lambda/closure_conversion.cmx : \
     lambda/lambda.cmx \
     middle_end/flambda/basic/kinded_parameter.cmx \
     utils/int_replace_polymorphic_compare.cmx \
+    middle_end/flambda/basic/inline_attribute.cmx \
     middle_end/flambda/from_lambda/ilambda.cmx \
     typing/ident.cmx \
     middle_end/flambda/terms/flambda_unit.cmx \
@@ -6456,6 +5046,7 @@ middle_end/flambda/lifting/lift_inconstants.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
+    lambda/tag.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/lifting/sort_lifted_constants.cmi \
     middle_end/flambda/simplify/simplify_import.cmi \
@@ -6469,6 +5060,8 @@ middle_end/flambda/lifting/lift_inconstants.cmo : \
     middle_end/flambda/terms/function_declarations.cmi \
     middle_end/flambda/terms/function_declaration.cmi \
     middle_end/flambda/compilenv_deps/flambda_features.cmi \
+    middle_end/flambda/terms/flambda.cmi \
+    middle_end/flambda/simplify/env/downwards_acc.cmi \
     middle_end/flambda/basic/continuation_extra_params_and_args.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/basic/code_id.cmi \
@@ -6478,6 +5071,7 @@ middle_end/flambda/lifting/lift_inconstants.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
     middle_end/flambda/basic/var_within_closure.cmx \
     middle_end/flambda/naming/var_in_binding_pos.cmx \
+    lambda/tag.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/lifting/sort_lifted_constants.cmx \
     middle_end/flambda/simplify/simplify_import.cmx \
@@ -6491,6 +5085,8 @@ middle_end/flambda/lifting/lift_inconstants.cmx : \
     middle_end/flambda/terms/function_declarations.cmx \
     middle_end/flambda/terms/function_declaration.cmx \
     middle_end/flambda/compilenv_deps/flambda_features.cmx \
+    middle_end/flambda/terms/flambda.cmx \
+    middle_end/flambda/simplify/env/downwards_acc.cmx \
     middle_end/flambda/basic/continuation_extra_params_and_args.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
     middle_end/flambda/basic/code_id.cmx \
@@ -6513,6 +5109,7 @@ middle_end/flambda/lifting/reification.cmo : \
     middle_end/flambda/simplify/basic/reachable.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
+    middle_end/flambda/basic/mutability.cmi \
     utils/misc.cmi \
     middle_end/flambda/compilenv_deps/linkage_name.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
@@ -6526,6 +5123,7 @@ middle_end/flambda/lifting/reification.cmx : \
     middle_end/flambda/simplify/basic/reachable.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
+    middle_end/flambda/basic/mutability.cmx \
     utils/misc.cmx \
     middle_end/flambda/compilenv_deps/linkage_name.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
@@ -6951,12 +5549,14 @@ middle_end/flambda/simplify/simplify.cmo : \
     middle_end/flambda/terms/function_declarations.cmi \
     middle_end/flambda/terms/function_declaration.cmi \
     middle_end/flambda/terms/flambda_unit.cmi \
+    middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/cmx/flambda_cmx_format.cmi \
     middle_end/flambda/cmx/flambda_cmx.cmi \
-    middle_end/flambda/types/kinds/flambda_arity.cmi \
     middle_end/flambda/flambda_backend_intf.cmi \
+    middle_end/flambda/types/kinds/flambda_arity.cmi \
     middle_end/flambda/terms/flambda.cmi \
+    middle_end/flambda/cmx/exported_code.cmi \
     middle_end/flambda/basic/exn_continuation.cmi \
     middle_end/flambda/simplify/env/downwards_acc.cmi \
     lambda/debuginfo.cmi \
@@ -7015,12 +5615,14 @@ middle_end/flambda/simplify/simplify.cmx : \
     middle_end/flambda/terms/function_declarations.cmx \
     middle_end/flambda/terms/function_declaration.cmx \
     middle_end/flambda/terms/flambda_unit.cmx \
+    middle_end/flambda/types/kinds/flambda_kind.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/cmx/flambda_cmx_format.cmx \
     middle_end/flambda/cmx/flambda_cmx.cmx \
-    middle_end/flambda/types/kinds/flambda_arity.cmx \
     middle_end/flambda/flambda_backend_intf.cmi \
+    middle_end/flambda/types/kinds/flambda_arity.cmx \
     middle_end/flambda/terms/flambda.cmx \
+    middle_end/flambda/cmx/exported_code.cmx \
     middle_end/flambda/basic/exn_continuation.cmx \
     middle_end/flambda/simplify/env/downwards_acc.cmx \
     lambda/debuginfo.cmx \
@@ -7167,6 +5769,7 @@ middle_end/flambda/simplify/simplify_expr.rec.cmo : \
     middle_end/flambda/basic/reg_width_const.cmi \
     middle_end/flambda/basic/recursive.cmi \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
+    middle_end/flambda/simplify/basic/reachable.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
@@ -7213,6 +5816,7 @@ middle_end/flambda/simplify/simplify_expr.rec.cmx : \
     middle_end/flambda/basic/reg_width_const.cmx \
     middle_end/flambda/basic/recursive.cmx \
     middle_end/flambda/compilenv_deps/rec_info.cmx \
+    middle_end/flambda/simplify/basic/reachable.cmx \
     middle_end/flambda/types/basic/or_bottom.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
@@ -7297,13 +5901,16 @@ middle_end/flambda/simplify/simplify_import.cmi : \
     middle_end/flambda/basic/continuation_extra_params_and_args.cmi
 middle_end/flambda/simplify/simplify_named.rec.cmo : \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
+    middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/simplify/simplify_primitive.cmi \
     middle_end/flambda/simplify/simplify_import.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/lifting/reification.cmi \
     middle_end/flambda/simplify/basic/reachable.cmi \
+    middle_end/flambda/naming/name_mode.cmi \
     utils/misc.cmi \
     middle_end/flambda/lifting/lift_inconstants.cmi \
+    middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/simplify/env/downwards_acc.cmi \
     utils/clflags.cmi \
@@ -7311,20 +5918,25 @@ middle_end/flambda/simplify/simplify_named.rec.cmo : \
     middle_end/flambda/simplify/simplify_named.rec.cmi
 middle_end/flambda/simplify/simplify_named.rec.cmx : \
     middle_end/flambda/naming/var_in_binding_pos.cmx \
+    middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/simplify/simplify_primitive.cmx \
     middle_end/flambda/simplify/simplify_import.cmx \
     middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/lifting/reification.cmx \
     middle_end/flambda/simplify/basic/reachable.cmx \
+    middle_end/flambda/naming/name_mode.cmx \
     utils/misc.cmx \
     middle_end/flambda/lifting/lift_inconstants.cmx \
+    middle_end/flambda/types/kinds/flambda_kind.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/simplify/env/downwards_acc.cmx \
     utils/clflags.cmx \
     middle_end/flambda/naming/bindable_let_bound.cmx \
     middle_end/flambda/simplify/simplify_named.rec.cmi
 middle_end/flambda/simplify/simplify_named.rec.cmi : \
+    middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/simplify/basic/reachable.cmi \
+    middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/simplify/env/downwards_acc.cmi \
     middle_end/flambda/naming/bindable_let_bound.cmi
@@ -7727,9 +6339,10 @@ middle_end/flambda/simplify/env/simplify_env_and_result.cmo : \
     utils/misc.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/types/flambda_type.cmi \
-    middle_end/flambda/types/kinds/flambda_arity.cmi \
     middle_end/flambda/flambda_backend_intf.cmi \
+    middle_end/flambda/types/kinds/flambda_arity.cmi \
     middle_end/flambda/terms/flambda.cmi \
+    middle_end/flambda/cmx/exported_code.cmi \
     middle_end/flambda/basic/exn_continuation.cmi \
     lambda/debuginfo.cmi \
     middle_end/flambda/simplify/basic/continuation_in_env.cmi \
@@ -7752,9 +6365,10 @@ middle_end/flambda/simplify/env/simplify_env_and_result.cmx : \
     utils/misc.cmx \
     middle_end/flambda/basic/kinded_parameter.cmx \
     middle_end/flambda/types/flambda_type.cmx \
-    middle_end/flambda/types/kinds/flambda_arity.cmx \
     middle_end/flambda/flambda_backend_intf.cmi \
+    middle_end/flambda/types/kinds/flambda_arity.cmx \
     middle_end/flambda/terms/flambda.cmx \
+    middle_end/flambda/cmx/exported_code.cmx \
     middle_end/flambda/basic/exn_continuation.cmx \
     lambda/debuginfo.cmx \
     middle_end/flambda/simplify/basic/continuation_in_env.cmx \
@@ -7777,8 +6391,8 @@ middle_end/flambda/simplify/env/simplify_env_and_result_intf.cmo : \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/types/flambda_type.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
-    middle_end/flambda/types/kinds/flambda_arity.cmi \
     middle_end/flambda/flambda_backend_intf.cmi \
+    middle_end/flambda/types/kinds/flambda_arity.cmi \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/basic/exn_continuation.cmi \
     lambda/debuginfo.cmi \
@@ -7799,8 +6413,8 @@ middle_end/flambda/simplify/env/simplify_env_and_result_intf.cmx : \
     middle_end/flambda/basic/kinded_parameter.cmx \
     middle_end/flambda/types/flambda_type.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
-    middle_end/flambda/types/kinds/flambda_arity.cmx \
     middle_end/flambda/flambda_backend_intf.cmi \
+    middle_end/flambda/types/kinds/flambda_arity.cmx \
     middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/basic/exn_continuation.cmx \
     lambda/debuginfo.cmx \
@@ -8759,18 +7373,21 @@ middle_end/flambda/to_cmm/un_cps.cmo : \
     middle_end/flambda/terms/function_declaration.cmi \
     middle_end/flambda/terms/flambda_unit.cmi \
     middle_end/flambda/terms/flambda_primitive.cmi \
+    middle_end/flambda/flambda_middle_end.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/cmx/flambda_cmx_format.cmi \
-    middle_end/flambda/flambda_middle_end.cmi \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/cmx/exported_offsets.cmi \
     middle_end/flambda/basic/exn_continuation.cmi \
     middle_end/flambda/basic/effects_and_coeffects.cmi \
+    middle_end/flambda/basic/effects.cmi \
     lambda/debuginfo.cmi \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/compilenv.cmi \
+    middle_end/flambda/compilenv_deps/compilation_unit.cmi \
+    middle_end/flambda/basic/coeffects.cmi \
     middle_end/flambda/basic/code_id_or_symbol.cmi \
     middle_end/flambda/basic/code_id.cmi \
     asmcomp/cmm_helpers.cmi \
@@ -8817,18 +7434,21 @@ middle_end/flambda/to_cmm/un_cps.cmx : \
     middle_end/flambda/terms/function_declaration.cmx \
     middle_end/flambda/terms/flambda_unit.cmx \
     middle_end/flambda/terms/flambda_primitive.cmx \
+    middle_end/flambda/flambda_middle_end.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
     middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/cmx/flambda_cmx_format.cmx \
-    middle_end/flambda/flambda_middle_end.cmx \
     middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/cmx/exported_offsets.cmx \
     middle_end/flambda/basic/exn_continuation.cmx \
     middle_end/flambda/basic/effects_and_coeffects.cmx \
+    middle_end/flambda/basic/effects.cmx \
     lambda/debuginfo.cmx \
     middle_end/flambda/basic/continuation.cmx \
     middle_end/compilenv.cmx \
+    middle_end/flambda/compilenv_deps/compilation_unit.cmx \
+    middle_end/flambda/basic/coeffects.cmx \
     middle_end/flambda/basic/code_id_or_symbol.cmx \
     middle_end/flambda/basic/code_id.cmx \
     asmcomp/cmm_helpers.cmx \
@@ -8889,6 +7509,7 @@ middle_end/flambda/to_cmm/un_cps_env.cmo : \
     middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/cmx/exported_offsets.cmi \
+    middle_end/flambda/cmx/exported_code.cmi \
     middle_end/flambda/basic/effects_and_coeffects.cmi \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
@@ -8908,6 +7529,7 @@ middle_end/flambda/to_cmm/un_cps_env.cmx : \
     middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/cmx/exported_offsets.cmx \
+    middle_end/flambda/cmx/exported_code.cmx \
     middle_end/flambda/basic/effects_and_coeffects.cmx \
     middle_end/flambda/basic/continuation.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
@@ -8924,6 +7546,7 @@ middle_end/flambda/to_cmm/un_cps_env.cmi : \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/cmx/exported_offsets.cmi \
+    middle_end/flambda/cmx/exported_code.cmi \
     middle_end/flambda/basic/effects_and_coeffects.cmi \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/basic/code_id_or_symbol.cmi \
@@ -9073,8 +7696,11 @@ middle_end/flambda/to_cmm/un_cps_static.cmx : \
 middle_end/flambda/to_cmm/un_cps_static.cmi : \
     middle_end/flambda/to_cmm/un_cps_result.cmi \
     middle_end/flambda/to_cmm/un_cps_env.cmi \
+    middle_end/flambda/compilenv_deps/symbol.cmi \
+    middle_end/flambda/terms/set_of_closures.cmi \
     middle_end/flambda/terms/flambda.cmi \
-    asmcomp/cmm.cmi
+    asmcomp/cmm.cmi \
+    middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/types/flambda_type.cmo : \
     middle_end/flambda/naming/with_delayed_permutation.cmi \
     middle_end/flambda/compilenv_deps/variable.cmi \
@@ -10061,8 +8687,7 @@ middle_end/flambda/types/type_of_kind/type_of_kind_naked_float0.rec.cmx : \
 middle_end/flambda/types/type_of_kind/type_of_kind_naked_float0.rec.cmi : \
     middle_end/flambda/types/type_head_intf.cmo \
     utils/numbers.cmi
- \
-    middle_end/flambda/types/type_of_kind/type_of_kind_naked_immediate0.rec.cmo : \
+middle_end/flambda/types/type_of_kind/type_of_kind_naked_immediate0.rec.cmo : \
     middle_end/flambda/compilenv_deps/target_imm.cmi \
     lambda/tag.cmi \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
@@ -10074,8 +8699,7 @@ middle_end/flambda/types/type_of_kind/type_of_kind_naked_float0.rec.cmi : \
     middle_end/flambda/types/structures/lattice_ops_intf.cmo \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/types/type_of_kind/type_of_kind_naked_immediate0.rec.cmi
- \
-    middle_end/flambda/types/type_of_kind/type_of_kind_naked_immediate0.rec.cmx : \
+middle_end/flambda/types/type_of_kind/type_of_kind_naked_immediate0.rec.cmx : \
     middle_end/flambda/compilenv_deps/target_imm.cmx \
     lambda/tag.cmx \
     middle_end/flambda/compilenv_deps/rec_info.cmx \
@@ -10087,8 +8711,7 @@ middle_end/flambda/types/type_of_kind/type_of_kind_naked_float0.rec.cmi : \
     middle_end/flambda/types/structures/lattice_ops_intf.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/types/type_of_kind/type_of_kind_naked_immediate0.rec.cmi
- \
-    middle_end/flambda/types/type_of_kind/type_of_kind_naked_immediate0.rec.cmi : \
+middle_end/flambda/types/type_of_kind/type_of_kind_naked_immediate0.rec.cmi : \
     middle_end/flambda/types/type_head_intf.cmo \
     middle_end/flambda/compilenv_deps/target_imm.cmi
 middle_end/flambda/types/type_of_kind/type_of_kind_naked_int32_0.rec.cmo : \
@@ -10131,8 +8754,7 @@ middle_end/flambda/types/type_of_kind/type_of_kind_naked_int64_0.rec.cmx : \
     middle_end/flambda/types/type_of_kind/type_of_kind_naked_int64_0.rec.cmi
 middle_end/flambda/types/type_of_kind/type_of_kind_naked_int64_0.rec.cmi : \
     middle_end/flambda/types/type_head_intf.cmo
- \
-    middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.cmo : \
+middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.cmo : \
     utils/targetint.cmi \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
     middle_end/flambda/types/basic/or_bottom_or_absorbing.cmi \
@@ -10141,8 +8763,7 @@ middle_end/flambda/types/type_of_kind/type_of_kind_naked_int64_0.rec.cmi : \
     middle_end/flambda/types/structures/lattice_ops_intf.cmo \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.cmi
- \
-    middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.cmx : \
+middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.cmx : \
     utils/targetint.cmx \
     middle_end/flambda/compilenv_deps/rec_info.cmx \
     middle_end/flambda/types/basic/or_bottom_or_absorbing.cmx \
@@ -10151,8 +8772,7 @@ middle_end/flambda/types/type_of_kind/type_of_kind_naked_int64_0.rec.cmi : \
     middle_end/flambda/types/structures/lattice_ops_intf.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.cmi
- \
-    middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.cmi : \
+middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.cmi : \
     middle_end/flambda/types/type_head_intf.cmo \
     utils/targetint.cmi
 middle_end/flambda/types/type_of_kind/type_of_kind_value0.rec.cmo : \
@@ -10235,14 +8855,11 @@ middle_end/flambda/types/type_of_kind/variant.rec.cmi : \
  \
     middle_end/flambda/types/type_of_kind/boilerplate/type_of_kind_naked_nativeint.rec.cmi : \
     middle_end/flambda/types/type_descr_intf.cmo
- \
-    middle_end/flambda/types/type_of_kind/boilerplate/type_of_kind_value.rec.cmo : \
+middle_end/flambda/types/type_of_kind/boilerplate/type_of_kind_value.rec.cmo : \
     middle_end/flambda/types/type_of_kind/boilerplate/type_of_kind_value.rec.cmi
- \
-    middle_end/flambda/types/type_of_kind/boilerplate/type_of_kind_value.rec.cmx : \
+middle_end/flambda/types/type_of_kind/boilerplate/type_of_kind_value.rec.cmx : \
     middle_end/flambda/types/type_of_kind/boilerplate/type_of_kind_value.rec.cmi
- \
-    middle_end/flambda/types/type_of_kind/boilerplate/type_of_kind_value.rec.cmi : \
+middle_end/flambda/types/type_of_kind/boilerplate/type_of_kind_value.rec.cmi : \
     middle_end/flambda/types/type_descr_intf.cmo
 middle_end/flambda/unboxing/unbox_continuation_params.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
@@ -10289,6 +8906,7 @@ driver/compenv.cmo : \
     utils/profile.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
+    middle_end/flambda/terms/flambda.cmi \
     utils/config.cmi \
     utils/clflags.cmi \
     utils/ccomp.cmi \
@@ -10298,6 +8916,7 @@ driver/compenv.cmx : \
     utils/profile.cmx \
     utils/misc.cmx \
     parsing/location.cmx \
+    middle_end/flambda/terms/flambda.cmx \
     utils/config.cmx \
     utils/clflags.cmx \
     utils/ccomp.cmx \
@@ -10475,6 +9094,7 @@ driver/main_args.cmo : \
     utils/warnings.cmi \
     utils/profile.cmi \
     utils/misc.cmi \
+    middle_end/flambda/terms/flambda.cmi \
     utils/config.cmi \
     driver/compenv.cmi \
     utils/clflags.cmi \
@@ -10483,6 +9103,7 @@ driver/main_args.cmx : \
     utils/warnings.cmx \
     utils/profile.cmx \
     utils/misc.cmx \
+    middle_end/flambda/terms/flambda.cmx \
     utils/config.cmx \
     driver/compenv.cmx \
     utils/clflags.cmx \

--- a/Makefile
+++ b/Makefile
@@ -331,6 +331,7 @@ MIDDLE_END_FLAMBDA_TERMS=\
 
 MIDDLE_END_FLAMBDA_CMX=\
   middle_end/flambda/cmx/exported_offsets.cmo \
+  middle_end/flambda/cmx/exported_code.cmo \
   middle_end/flambda/cmx/flambda_cmx_format.cmo
 
 MIDDLE_END_FLAMBDA_SIMPLIFY=\

--- a/middle_end/flambda/cmx/exported_code.ml
+++ b/middle_end/flambda/cmx/exported_code.ml
@@ -1,0 +1,170 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Vincent Laviron, OCamlPro                        *)
+(*                                                                        *)
+(*   Copyright 2020 OCamlPro SAS                                          *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+module P = Flambda.Function_params_and_body
+
+module Calling_convention = struct
+  type t = {
+    needs_closure_arg : bool;
+  }
+
+  let needs_closure_arg t = t.needs_closure_arg
+
+  let print ppf { needs_closure_arg; } =
+    Format.fprintf ppf
+      "@[<hov 1>(needs_closure_arg@ %b)@]"
+      needs_closure_arg
+
+  let equal
+        { needs_closure_arg = needs_closure_arg1; }
+        { needs_closure_arg = needs_closure_arg2; } =
+    Bool.equal needs_closure_arg1 needs_closure_arg2
+
+  let compute ~params_and_body =
+    let f ~return_continuation:_ _exn_continuation _params ~body ~my_closure =
+      let free_vars = Flambda.Expr.free_names body in
+      let needs_closure_arg = Name_occurrences.mem_var free_vars my_closure in
+      { needs_closure_arg; }
+    in
+    P.pattern_match params_and_body ~f
+end
+
+type t0 =
+  | Present of {
+    params_and_body : P.t;
+    calling_convention : Calling_convention.t;
+  }
+  | Imported of { calling_convention : Calling_convention.t; }
+
+type t = t0 Code_id.Map.t
+
+let print0 ppf t0 =
+  match t0 with
+  | Present { params_and_body; calling_convention; } ->
+    Format.fprintf ppf
+      "@[<hov 1>(Present@ (\
+         @[<hov 1>(params_and_body@ %a)@]\
+         @[<hov 1>(calling_convention@ %a)@]\
+       ))@]"
+      P.print params_and_body
+      Calling_convention.print calling_convention
+  | Imported { calling_convention; } ->
+    Format.fprintf ppf
+      "@[<hov 1>(Imported@ (calling_convention@ %a))@]"
+      Calling_convention.print calling_convention
+
+let print ppf t =
+  Code_id.Map.print print0 ppf t
+
+let empty = Code_id.Map.empty
+
+let add_code code t =
+  let with_calling_convention =
+    Code_id.Map.map (fun params_and_body ->
+        let calling_convention =
+          Calling_convention.compute ~params_and_body
+        in
+        Present { params_and_body; calling_convention; })
+      code
+  in
+  Code_id.Map.disjoint_union with_calling_convention t
+
+let mark_as_imported t =
+  let forget_params_and_body t0 =
+    match t0 with
+    | Imported _ -> t0
+    | Present { params_and_body = _; calling_convention; } ->
+      Imported { calling_convention; }
+  in
+  Code_id.Map.map forget_params_and_body t
+
+let merge t1 t2 =
+  let merge_one code_id t01 t02 =
+    match t01, t02 with
+    | Imported { calling_convention = cc1; },
+      Imported { calling_convention = cc2; } ->
+      if Calling_convention.equal cc1 cc2 then Some t01
+      else
+        Misc.fatal_errorf
+          "Code id %a is imported with different calling conventions\
+           (%a and %a)"
+          Code_id.print code_id
+          Calling_convention.print cc1
+          Calling_convention.print cc2
+    | Present _, Present _ ->
+      Misc.fatal_errorf "Cannot merge two definitions for code id %a"
+        Code_id.print code_id
+    | Imported { calling_convention = cc_imported; },
+      (Present { calling_convention = cc_present; params_and_body = _; } as t0)
+    | (Present { calling_convention = cc_present; params_and_body = _; } as t0),
+      Imported { calling_convention = cc_imported; } ->
+      if Calling_convention.equal cc_present cc_imported then Some t0
+      else
+        Misc.fatal_errorf
+          "Code_id %a is present with calling convention %a\
+           but imported with calling convention %a"
+          Code_id.print code_id
+          Calling_convention.print cc_present
+          Calling_convention.print cc_imported
+  in
+  Code_id.Map.union merge_one t1 t2
+
+let mem code_id t =
+  Code_id.Map.mem code_id t
+
+let find_code t code_id =
+  match Code_id.Map.find code_id t with
+  | exception Not_found ->
+    Misc.fatal_errorf "Code ID %a not bound" Code_id.print code_id
+  | Present { params_and_body; calling_convention = _; } -> params_and_body
+  | Imported _ ->
+    Misc.fatal_errorf "Actual code for Code ID %a is missing"
+      Code_id.print code_id
+
+let find_calling_convention t code_id =
+  match Code_id.Map.find code_id t with
+  | exception Not_found ->
+    Misc.fatal_errorf "Code ID %a not bound" Code_id.print code_id
+  | Present { params_and_body = _; calling_convention; } -> calling_convention
+  | Imported { calling_convention; } -> calling_convention
+
+let all_ids_for_export t =
+  Code_id.Map.fold (fun code_id code_data all_ids ->
+      let all_ids = Ids_for_export.add_code_id all_ids code_id in
+      match code_data with
+      | Present { params_and_body; calling_convention = _; } ->
+        Ids_for_export.union all_ids
+          (P.all_ids_for_export params_and_body)
+      | Imported { calling_convention = _; } -> all_ids)
+    t
+    Ids_for_export.empty
+
+let import import_map t =
+  Code_id.Map.fold (fun code_id code_data all_code ->
+      let code_id = Ids_for_export.Import_map.code_id import_map code_id in
+      let code_data =
+        match code_data with
+        | Present { calling_convention; params_and_body; } ->
+          let params_and_body =
+            Flambda.Function_params_and_body.import import_map params_and_body
+          in
+          Present { calling_convention; params_and_body; }
+        | Imported { calling_convention; } ->
+          Imported { calling_convention; }
+      in
+      Code_id.Map.add code_id code_data all_code)
+    t
+    Code_id.Map.empty

--- a/middle_end/flambda/cmx/exported_code.mli
+++ b/middle_end/flambda/cmx/exported_code.mli
@@ -1,0 +1,41 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Vincent Laviron, OCamlPro                        *)
+(*                                                                        *)
+(*   Copyright 2020 OCamlPro SAS                                          *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+module Calling_convention : sig
+  type t
+
+  val print : Format.formatter -> t -> unit
+
+  val needs_closure_arg : t -> bool
+end
+
+type t
+
+include Contains_ids.S with type t := t
+
+val print : Format.formatter -> t -> unit
+
+val empty : t
+
+val add_code : Flambda.Function_params_and_body.t Code_id.Map.t -> t -> t
+
+val mark_as_imported : t -> t
+
+val merge : t -> t -> t
+
+val mem : Code_id.t -> t -> bool
+
+val find_code : t -> Code_id.t -> Flambda.Function_params_and_body.t
+
+val find_calling_convention : t -> Code_id.t -> Calling_convention.t

--- a/middle_end/flambda/cmx/flambda_cmx.ml
+++ b/middle_end/flambda/cmx/flambda_cmx.ml
@@ -44,7 +44,7 @@ let rec load_cmx_file_contents backend comp_unit ~imported_units ~imported_names
       in
       let newly_imported_names = TE.name_domain typing_env in
       imported_names := Name.Set.union newly_imported_names !imported_names;
-      imported_code := Code_id.Map.disjoint_union code !imported_code;
+      imported_code := Exported_code.merge code !imported_code;
       let offsets = Flambda_cmx_format.exported_offsets cmx in
       Exported_offsets.import_offsets offsets;
       imported_units :=
@@ -71,5 +71,5 @@ let prepare_cmx_file_contents ~return_cont_env:cont_uses_env
          after Un_cps_closure *)
       Exported_offsets.imported_offsets ()
     in
-    Some (Flambda_cmx_format.create ~final_typing_env ~all_code
-            ~exported_offsets)
+    Some (Flambda_cmx_format.create
+            ~final_typing_env ~all_code ~exported_offsets)

--- a/middle_end/flambda/cmx/flambda_cmx.mli
+++ b/middle_end/flambda/cmx/flambda_cmx.mli
@@ -19,19 +19,17 @@
 (** Dumping and restoring of simplification environment information to and
     from .cmx files. *)
 
-open! Simplify_import
-
 val load_cmx_file_contents
    : (module Flambda_backend_intf.S)
   -> Compilation_unit.t
   -> imported_units:Flambda_type.Typing_env.t option Compilation_unit.Map.t ref
   -> imported_names:Name.Set.t ref
-  -> imported_code:Function_params_and_body.t Code_id.Map.t ref
+  -> imported_code:Exported_code.t ref
   -> Flambda_type.Typing_env.t option
 
 val prepare_cmx_file_contents
    : return_cont_env:Continuation_uses_env.t
   -> return_continuation:Continuation.t
   -> module_symbol:Symbol.t
-  -> Function_params_and_body.t Code_id.Map.t
+  -> Exported_code.t
   -> Flambda_cmx_format.t option

--- a/middle_end/flambda/cmx/flambda_cmx_format.mli
+++ b/middle_end/flambda/cmx/flambda_cmx_format.mli
@@ -23,16 +23,18 @@ type t
 
 val create
    : final_typing_env:Flambda_type.Typing_env.Serializable.t
-  -> all_code:Flambda.Function_params_and_body.t Code_id.Map.t
+  -> all_code:Exported_code.t
   -> exported_offsets:Exported_offsets.t
   -> t
 
 val import_typing_env_and_code
    : t
   -> Flambda_type.Typing_env.Serializable.t *
-     Flambda.Function_params_and_body.t Code_id.Map.t
+     Exported_code.t
 
 val exported_offsets : t -> Exported_offsets.t
+
+val functions_info : t -> Exported_code.t
 
 val with_exported_offsets : t -> Exported_offsets.t -> t
 

--- a/middle_end/flambda/flambda_middle_end.ml
+++ b/middle_end/flambda/flambda_middle_end.ml
@@ -20,6 +20,7 @@ type middle_end_result = {
   (* CR mshinwell: This next field is redundant *)
   cmx : Flambda_cmx_format.t option;
   unit : Flambda_unit.t;
+  all_code : Exported_code.t;
 }
 
 let check_invariants unit =
@@ -130,6 +131,7 @@ let middle_end ~ppf_dump:ppf ~prefixname ~backend ~filename ~module_ident
     in
     { cmx = simplify_result.cmx;
       unit = simplify_result.unit;
+      all_code = simplify_result.all_code;
     }
   with Misc.Fatal_error -> begin
     Format.eprintf "\n%sOriginal backtrace is:%s\n%s\n"

--- a/middle_end/flambda/flambda_middle_end.mli
+++ b/middle_end/flambda/flambda_middle_end.mli
@@ -21,6 +21,7 @@
 type middle_end_result = private {
   cmx : Flambda_cmx_format.t option;
   unit : Flambda_unit.t;
+  all_code : Exported_code.t;
 }
 
 (** This function is not currently re-entrant. *)

--- a/middle_end/flambda/simplify/env/simplify_env_and_result_intf.ml
+++ b/middle_end/flambda/simplify/env/simplify_env_and_result_intf.ml
@@ -21,7 +21,7 @@ open! Flambda.Import
 type resolver = Compilation_unit.t -> Flambda_type.Typing_env.t option
 type get_imported_names = unit -> Name.Set.t
 type get_imported_code =
-  unit -> Function_params_and_body.t Code_id.Map.t
+  unit -> Exported_code.t
 
 module type Downwards_env = sig
   type t
@@ -302,7 +302,7 @@ module type Result = sig
     -> Flambda.Function_params_and_body.t Code_id.Map.t
     -> t
 
-  val all_code : t -> Flambda.Function_params_and_body.t Code_id.Map.t
+  val all_code : t -> Exported_code.t
 
   val clear_lifted_constants : t -> t
 

--- a/middle_end/flambda/simplify/simplify.mli
+++ b/middle_end/flambda/simplify/simplify.mli
@@ -26,6 +26,7 @@
 type simplify_result = private {
   cmx : Flambda_cmx_format.t option;
   unit : Flambda_unit.t;
+  all_code : Exported_code.t;
 }
 
 val run

--- a/middle_end/flambda/simplify/template/simplify.templ.ml
+++ b/middle_end/flambda/simplify/template/simplify.templ.ml
@@ -25,6 +25,7 @@ open! Simplify_import
 type simplify_result = {
   cmx : Flambda_cmx_format.t option;
   unit : Flambda_unit.t;
+  all_code : Exported_code.t;
 }
 
 let predefined_exception_typing_env ~backend ~resolver ~get_imported_names =
@@ -103,4 +104,5 @@ let run ~backend ~round unit =
   in
   { cmx;
     unit;
+    all_code;
   }

--- a/middle_end/flambda/simplify/template/simplify.templ.ml
+++ b/middle_end/flambda/simplify/template/simplify.templ.ml
@@ -48,7 +48,7 @@ let run ~backend ~round unit =
   let exn_continuation = FU.exn_continuation unit in
   let module_symbol = FU.module_symbol unit in
   let imported_names = ref Name.Set.empty in
-  let imported_code = ref Code_id.Map.empty in
+  let imported_code = ref Exported_code.empty in
   let imported_units = ref Compilation_unit.Map.empty in
   let resolver comp_unit =
     Flambda_cmx.load_cmx_file_contents backend comp_unit ~imported_names
@@ -90,9 +90,13 @@ let run ~backend ~round unit =
       ~exn_cont_scope
   in
   let return_cont_env = DA.continuation_uses_env dacc in
+  let all_code =
+    Exported_code.merge (R.all_code r)
+      (Exported_code.mark_as_imported !imported_code)
+  in
   let cmx =
     Flambda_cmx.prepare_cmx_file_contents ~return_cont_env
-      ~return_continuation ~module_symbol (R.all_code r)
+      ~return_continuation ~module_symbol all_code
   in
   let unit =
     FU.create ~return_continuation ~exn_continuation ~module_symbol ~body

--- a/middle_end/flambda/to_cmm/un_cps.ml
+++ b/middle_end/flambda/to_cmm/un_cps.ml
@@ -890,11 +890,11 @@ and apply_call env e =
     let ty = machtype_of_return_arity return_arity in
     let args, env, _ = arg_list env (Apply_expr.args e) in
     let args, env =
-      match (info : Env.function_info option) with
-      | None | Some { needs_closure_arg = true; } ->
+      if Exported_code.Calling_convention.needs_closure_arg info
+      then
         let f, env, _ = simple env f in
         args @ [f], env
-      | Some { needs_closure_arg = false; } ->
+      else
         args, env
     in
     let f_code = symbol (Code_id.code_symbol code_id) in
@@ -1378,10 +1378,15 @@ and params_and_body env res fun_name p =
 
 let unit (middle_end_result : Flambda_middle_end.middle_end_result) =
   let unit = middle_end_result.unit in
-  let offsets =
+  let offsets, functions_info =
     match middle_end_result.cmx with
-    | None -> Exported_offsets.imported_offsets ()
-    | Some cmx -> Flambda_cmx_format.exported_offsets cmx
+    | None ->
+      Exported_offsets.imported_offsets (),
+      (* CR vlaviron: recover imported code *)
+      Exported_code.empty
+    | Some cmx ->
+      Flambda_cmx_format.exported_offsets cmx,
+      Flambda_cmx_format.functions_info cmx
   in
   Profile.record_call "flambda_to_cmm" (fun () ->
     let offsets = Un_cps_closure.compute_offsets offsets unit in
@@ -1398,7 +1403,7 @@ let unit (middle_end_result : Flambda_middle_end.middle_end_result) =
        arrange that the return continuation turns into "return unit".
        (Module initialisers return the unit value). *)
     let env =
-      Env.mk offsets dummy_k
+      Env.mk offsets functions_info dummy_k
         (Flambda_unit.exn_continuation unit)
         used_closure_vars
     in

--- a/middle_end/flambda/to_cmm/un_cps.ml
+++ b/middle_end/flambda/to_cmm/un_cps.ml
@@ -1378,16 +1378,14 @@ and params_and_body env res fun_name p =
 
 let unit (middle_end_result : Flambda_middle_end.middle_end_result) =
   let unit = middle_end_result.unit in
-  let offsets, functions_info =
+  let offsets =
     match middle_end_result.cmx with
     | None ->
-      Exported_offsets.imported_offsets (),
-      (* CR vlaviron: recover imported code *)
-      Exported_code.empty
+      Exported_offsets.imported_offsets ()
     | Some cmx ->
-      Flambda_cmx_format.exported_offsets cmx,
-      Flambda_cmx_format.functions_info cmx
+      Flambda_cmx_format.exported_offsets cmx
   in
+  let functions_info = middle_end_result.all_code in
   Profile.record_call "flambda_to_cmm" (fun () ->
     let offsets = Un_cps_closure.compute_offsets offsets unit in
     begin match middle_end_result.cmx with

--- a/middle_end/flambda/to_cmm/un_cps_env.mli
+++ b/middle_end/flambda/to_cmm/un_cps_env.mli
@@ -47,6 +47,7 @@ type t
 
 val mk :
   Exported_offsets.t ->
+  Exported_code.t ->
   Continuation.t -> Continuation.t ->
   Var_within_closure.Set.t -> t
 (** [mk offsets k k_exn used_closure_vars] creates a local environment for
@@ -57,9 +58,6 @@ val enter_function_def : t -> Continuation.t -> Continuation.t -> t
 (** [enter_function_def env k k_exn] creates a local environment for
     translating a flambda expression, with return continuation [k], exception
     continuation [k_exn], preserving the global info from [env]. *)
-
-val dummy : Exported_offsets.t -> Var_within_closure.Set.t -> t
-(** Create an environment with dummy return adn exception continuations. *)
 
 
 (** {2 Continuations} *)
@@ -73,15 +71,7 @@ val exn_cont : t -> Continuation.t
 
 (** {2 Function info *)
 
-type function_info = {
-  needs_closure_arg : bool;
-  (* Whether direct calls need to provide a closure or can skip it *)
-}
-
-val add_function_info : t -> Code_id.t -> function_info -> t
-(** Add information on the given function *)
-
-val get_function_info : t -> Code_id.t -> function_info option
+val get_function_info : t -> Code_id.t -> Exported_code.Calling_convention.t
 (** Retrieve known information on the given function *)
 
 

--- a/middle_end/flambda/to_cmm/un_cps_static.ml
+++ b/middle_end/flambda/to_cmm/un_cps_static.ml
@@ -246,14 +246,6 @@ and fill_static_up_to j acc i =
   if i = j then acc
   else fill_static_up_to j (C.cint 1n :: acc) (i + 1)
 
-let update_env_for_function
-    env code_id ~return_continuation:_ _exn_k _ps ~body ~my_closure =
-  let free_vars = Expr.free_names body in
-  (* Format.eprintf "Free vars: %a@." Variable.Set.print free_vars; *)
-  let needs_closure_arg = Name_occurrences.mem_var free_vars my_closure in
-  let info : Env.function_info = { needs_closure_arg; } in
-  Env.add_function_info env code_id info
-
 let update_env_for_set_of_closure env { SCCSC.code; set_of_closures = _; } =
   Code_id.Map.fold
     (fun code_id SC.Code.({ params_and_body = p; newer_version_of; }) env ->
@@ -269,8 +261,8 @@ let update_env_for_set_of_closure env { SCCSC.code; set_of_closures = _; } =
        | Deleted ->
          Env.mark_code_id_as_deleted env code_id
        | Present p ->
-         Function_params_and_body.pattern_match p
-           ~f:(update_env_for_function env code_id)
+         (* Function info should be already computed *)
+         env
     ) code env
 
 let add_function env r ~params_and_body code_id p =


### PR DESCRIPTION
For now this only tracks whether functions need their closure parameter.
This also works with imported functions, so calls to foreign functions can now omit the extra closure argument when it's possible.