### PR TITLE
Use lists rather than maps when lookups aren't necessary

### DIFF
--- a/.depend
+++ b/.depend
@@ -70,6 +70,13 @@ utils/int_replace_polymorphic_compare.cmo : \
 utils/int_replace_polymorphic_compare.cmx : \
     utils/int_replace_polymorphic_compare.cmi
 utils/int_replace_polymorphic_compare.cmi :
+utils/lmap.cmo : \
+    utils/misc.cmi \
+    utils/lmap.cmi
+utils/lmap.cmx : \
+    utils/misc.cmx \
+    utils/lmap.cmi
+utils/lmap.cmi :
 utils/load_path.cmo : \
     utils/misc.cmi \
     utils/load_path.cmi
@@ -6887,6 +6894,7 @@ middle_end/flambda/terms/flambda.cmi : \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/basic/name.cmi \
     middle_end/flambda/basic/mutability.cmi \
+    utils/lmap.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/basic/invalid_term_semantics.cmi \
     utils/identifiable.cmi \

--- a/.depend
+++ b/.depend
@@ -4003,18 +4003,21 @@ middle_end/flambda/basic/apply_cont_rewrite_id.cmi : \
     utils/identifiable.cmi
 middle_end/flambda/basic/closure_id.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
+    utils/lmap.cmi \
     utils/identifiable.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/basic/closure_id.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
+    utils/lmap.cmx \
     utils/identifiable.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
     middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/basic/closure_id.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
+    utils/lmap.cmi \
     utils/identifiable.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi
 middle_end/flambda/basic/closure_origin.cmo : \
@@ -4032,6 +4035,7 @@ middle_end/flambda/basic/code_id.cmo : \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/compilenv_deps/patricia_tree.cmi \
     utils/numbers.cmi \
+    utils/lmap.cmi \
     middle_end/flambda/compilenv_deps/linkage_name.cmi \
     utils/identifiable.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
@@ -4042,6 +4046,7 @@ middle_end/flambda/basic/code_id.cmx : \
     middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/compilenv_deps/patricia_tree.cmx \
     utils/numbers.cmx \
+    utils/lmap.cmx \
     middle_end/flambda/compilenv_deps/linkage_name.cmx \
     utils/identifiable.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
@@ -4049,6 +4054,7 @@ middle_end/flambda/basic/code_id.cmx : \
     middle_end/flambda/basic/code_id.cmi
 middle_end/flambda/basic/code_id.cmi : \
     middle_end/flambda/compilenv_deps/symbol.cmi \
+    utils/lmap.cmi \
     utils/identifiable.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi
 middle_end/flambda/basic/code_id_or_symbol.cmo : \
@@ -4588,6 +4594,7 @@ middle_end/flambda/from_lambda/closure_conversion.cmo : \
     middle_end/flambda/naming/name_mode.cmi \
     utils/misc.cmi \
     middle_end/flambda/compilenv_deps/linkage_name.cmi \
+    middle_end/flambda/from_lambda/lambda_to_flambda_primitives_helpers.cmi \
     middle_end/flambda/from_lambda/lambda_to_flambda_primitives.cmi \
     middle_end/flambda/from_lambda/lambda_conversions.cmi \
     lambda/lambda.cmi \
@@ -4596,7 +4603,6 @@ middle_end/flambda/from_lambda/closure_conversion.cmo : \
     middle_end/flambda/basic/inline_attribute.cmi \
     middle_end/flambda/from_lambda/ilambda.cmi \
     typing/ident.cmi \
-    middle_end/flambda/terms/function_declarations.cmi \
     middle_end/flambda/terms/flambda_unit.cmi \
     middle_end/flambda/terms/flambda_primitive.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
@@ -4639,6 +4645,7 @@ middle_end/flambda/from_lambda/closure_conversion.cmx : \
     middle_end/flambda/naming/name_mode.cmx \
     utils/misc.cmx \
     middle_end/flambda/compilenv_deps/linkage_name.cmx \
+    middle_end/flambda/from_lambda/lambda_to_flambda_primitives_helpers.cmx \
     middle_end/flambda/from_lambda/lambda_to_flambda_primitives.cmx \
     middle_end/flambda/from_lambda/lambda_conversions.cmx \
     lambda/lambda.cmx \
@@ -4647,7 +4654,6 @@ middle_end/flambda/from_lambda/closure_conversion.cmx : \
     middle_end/flambda/basic/inline_attribute.cmx \
     middle_end/flambda/from_lambda/ilambda.cmx \
     typing/ident.cmx \
-    middle_end/flambda/terms/function_declarations.cmx \
     middle_end/flambda/terms/flambda_unit.cmx \
     middle_end/flambda/terms/flambda_primitive.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
@@ -4884,9 +4890,12 @@ middle_end/flambda/from_lambda/lambda_to_flambda_primitives_helpers.cmo : \
     middle_end/flambda/basic/trap_action.cmi \
     middle_end/flambda/compilenv_deps/target_imm.cmi \
     lambda/tag.cmi \
+    middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     utils/misc.cmi \
+    middle_end/flambda/compilenv_deps/linkage_name.cmi \
+    middle_end/flambda/basic/inline_attribute.cmi \
     middle_end/flambda/terms/flambda_primitive.cmi \
     middle_end/flambda/flambda_backend_intf.cmi \
     middle_end/flambda/terms/flambda.cmi \
@@ -4894,6 +4903,8 @@ middle_end/flambda/from_lambda/lambda_to_flambda_primitives_helpers.cmo : \
     middle_end/flambda/from_lambda/delayed_handlers.cmi \
     lambda/debuginfo.cmi \
     middle_end/flambda/basic/continuation.cmi \
+    middle_end/flambda/compilenv_deps/compilation_unit.cmi \
+    middle_end/flambda/terms/call_kind.cmi \
     middle_end/flambda/from_lambda/lambda_to_flambda_primitives_helpers.cmi
 middle_end/flambda/from_lambda/lambda_to_flambda_primitives_helpers.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
@@ -4901,9 +4912,12 @@ middle_end/flambda/from_lambda/lambda_to_flambda_primitives_helpers.cmx : \
     middle_end/flambda/basic/trap_action.cmx \
     middle_end/flambda/compilenv_deps/target_imm.cmx \
     lambda/tag.cmx \
+    middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     utils/misc.cmx \
+    middle_end/flambda/compilenv_deps/linkage_name.cmx \
+    middle_end/flambda/basic/inline_attribute.cmx \
     middle_end/flambda/terms/flambda_primitive.cmx \
     middle_end/flambda/flambda_backend_intf.cmi \
     middle_end/flambda/terms/flambda.cmx \
@@ -4911,6 +4925,8 @@ middle_end/flambda/from_lambda/lambda_to_flambda_primitives_helpers.cmx : \
     middle_end/flambda/from_lambda/delayed_handlers.cmx \
     lambda/debuginfo.cmx \
     middle_end/flambda/basic/continuation.cmx \
+    middle_end/flambda/compilenv_deps/compilation_unit.cmx \
+    middle_end/flambda/terms/call_kind.cmx \
     middle_end/flambda/from_lambda/lambda_to_flambda_primitives_helpers.cmi
 middle_end/flambda/from_lambda/lambda_to_flambda_primitives_helpers.cmi : \
     middle_end/flambda/compilenv_deps/symbol.cmi \
@@ -5056,8 +5072,7 @@ middle_end/flambda/inlining/inlining_transforms.cmi : \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/basic/exn_continuation.cmi \
     middle_end/flambda/simplify/env/downwards_acc.cmi \
-    lambda/debuginfo.cmi \
-    middle_end/flambda/basic/continuation.cmi
+    lambda/debuginfo.cmi
 middle_end/flambda/lifting/lift_inconstants.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/var_within_closure.cmi \
@@ -5777,6 +5792,7 @@ middle_end/flambda/simplify/simplify_expr.rec.cmo : \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/unboxing/unbox_continuation_params.cmi \
     middle_end/flambda/compilenv_deps/target_imm.cmi \
+    middle_end/flambda/compilenv_deps/symbol.cmi \
     lambda/switch.cmi \
     middle_end/flambda/lifting/sort_lifted_constants.cmi \
     middle_end/flambda/simplify/simplify_import.cmi \
@@ -5824,6 +5840,7 @@ middle_end/flambda/simplify/simplify_expr.rec.cmx : \
     middle_end/flambda/basic/var_within_closure.cmx \
     middle_end/flambda/unboxing/unbox_continuation_params.cmx \
     middle_end/flambda/compilenv_deps/target_imm.cmx \
+    middle_end/flambda/compilenv_deps/symbol.cmx \
     lambda/switch.cmx \
     middle_end/flambda/lifting/sort_lifted_constants.cmx \
     middle_end/flambda/simplify/simplify_import.cmx \
@@ -6609,6 +6626,7 @@ middle_end/flambda/terms/apply_expr.cmo : \
     middle_end/flambda/basic/invariant_env.cmi \
     middle_end/flambda/basic/inline_attribute.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
+    utils/identifiable.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/types/kinds/flambda_arity.cmi \
@@ -6625,6 +6643,7 @@ middle_end/flambda/terms/apply_expr.cmx : \
     middle_end/flambda/basic/invariant_env.cmx \
     middle_end/flambda/basic/inline_attribute.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
+    utils/identifiable.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/types/kinds/flambda_arity.cmx \
@@ -6636,10 +6655,12 @@ middle_end/flambda/terms/apply_expr.cmx : \
 middle_end/flambda/terms/apply_expr.cmi : \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/basic/inline_attribute.cmi \
+    utils/identifiable.cmi \
     middle_end/flambda/basic/expr_std.cmo \
     middle_end/flambda/basic/exn_continuation.cmi \
     lambda/debuginfo.cmi \
     middle_end/flambda/basic/continuation.cmi \
+    middle_end/flambda/naming/contains_names.cmo \
     middle_end/flambda/cmx/contains_ids.cmo \
     middle_end/flambda/terms/call_kind.cmi
 middle_end/flambda/terms/call_kind.cmo : \
@@ -6894,7 +6915,6 @@ middle_end/flambda/terms/flambda.cmi : \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/basic/name.cmi \
     middle_end/flambda/basic/mutability.cmi \
-    utils/lmap.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/basic/invalid_term_semantics.cmi \
     utils/identifiable.cmi \
@@ -6979,18 +6999,21 @@ middle_end/flambda/terms/flambda_unit.cmo : \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/basic/continuation.cmi \
+    middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/terms/flambda_unit.cmi
 middle_end/flambda/terms/flambda_unit.cmx : \
     middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/basic/continuation.cmx \
+    middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/terms/flambda_unit.cmi
 middle_end/flambda/terms/flambda_unit.cmi : \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/basic/continuation.cmi
+    middle_end/flambda/basic/continuation.cmi \
+    middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/terms/function_declaration.cmo : \
     middle_end/flambda/basic/recursive.cmi \
     utils/printing_cache.cmi \
@@ -7028,7 +7051,6 @@ middle_end/flambda/terms/function_declaration.cmi : \
 middle_end/flambda/terms/function_declarations.cmo : \
     utils/printing_cache.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
-    utils/misc.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/terms/function_declaration.cmi \
     middle_end/flambda/basic/closure_id.cmi \
@@ -7036,7 +7058,6 @@ middle_end/flambda/terms/function_declarations.cmo : \
 middle_end/flambda/terms/function_declarations.cmx : \
     utils/printing_cache.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
-    utils/misc.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/terms/function_declaration.cmx \
     middle_end/flambda/basic/closure_id.cmx \

--- a/.depend
+++ b/.depend
@@ -59,8 +59,10 @@ utils/domainstate.cmx : \
     utils/domainstate.cmi
 utils/domainstate.cmi :
 utils/identifiable.cmo : \
+    utils/misc.cmi \
     utils/identifiable.cmi
 utils/identifiable.cmx : \
+    utils/misc.cmx \
     utils/identifiable.cmi
 utils/identifiable.cmi :
 utils/int_replace_polymorphic_compare.cmo : \
@@ -3676,6 +3678,7 @@ middle_end/flambda/flambda_middle_end.cmo : \
     middle_end/flambda/terms/flambda_unit.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/cmx/flambda_cmx_format.cmi \
+    middle_end/flambda/cmx/exported_code.cmi \
     middle_end/flambda/from_lambda/eliminate_mutable_vars.cmi \
     middle_end/flambda/from_lambda/cps_conversion.cmi \
     middle_end/flambda/basic/continuation.cmi \
@@ -3692,6 +3695,7 @@ middle_end/flambda/flambda_middle_end.cmx : \
     middle_end/flambda/terms/flambda_unit.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/cmx/flambda_cmx_format.cmx \
+    middle_end/flambda/cmx/exported_code.cmx \
     middle_end/flambda/from_lambda/eliminate_mutable_vars.cmx \
     middle_end/flambda/from_lambda/cps_conversion.cmx \
     middle_end/flambda/basic/continuation.cmx \
@@ -3703,7 +3707,8 @@ middle_end/flambda/flambda_middle_end.cmi : \
     typing/ident.cmi \
     middle_end/flambda/terms/flambda_unit.cmi \
     middle_end/flambda/cmx/flambda_cmx_format.cmi \
-    middle_end/flambda/flambda_backend_intf.cmi
+    middle_end/flambda/flambda_backend_intf.cmi \
+    middle_end/flambda/cmx/exported_code.cmi
 asmcomp/debug/available_regs.cmo : \
     asmcomp/debug/reg_with_debug_info.cmi \
     asmcomp/debug/reg_availability_set.cmi \
@@ -3950,6 +3955,7 @@ middle_end/flambda/flambda_middle_end.cmo : \
     middle_end/flambda/terms/flambda_unit.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/cmx/flambda_cmx_format.cmi \
+    middle_end/flambda/cmx/exported_code.cmi \
     middle_end/flambda/from_lambda/eliminate_mutable_vars.cmi \
     middle_end/flambda/from_lambda/cps_conversion.cmi \
     middle_end/flambda/basic/continuation.cmi \
@@ -3966,6 +3972,7 @@ middle_end/flambda/flambda_middle_end.cmx : \
     middle_end/flambda/terms/flambda_unit.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/cmx/flambda_cmx_format.cmx \
+    middle_end/flambda/cmx/exported_code.cmx \
     middle_end/flambda/from_lambda/eliminate_mutable_vars.cmx \
     middle_end/flambda/from_lambda/cps_conversion.cmx \
     middle_end/flambda/basic/continuation.cmx \
@@ -3977,7 +3984,8 @@ middle_end/flambda/flambda_middle_end.cmi : \
     typing/ident.cmi \
     middle_end/flambda/terms/flambda_unit.cmi \
     middle_end/flambda/cmx/flambda_cmx_format.cmi \
-    middle_end/flambda/flambda_backend_intf.cmi
+    middle_end/flambda/flambda_backend_intf.cmi \
+    middle_end/flambda/cmx/exported_code.cmi
 middle_end/flambda/basic/apply_cont_rewrite_id.cmo : \
     utils/numbers.cmi \
     middle_end/flambda/basic/apply_cont_rewrite_id.cmi
@@ -4490,15 +4498,14 @@ middle_end/flambda/cmx/flambda_cmx.cmx : \
     middle_end/flambda/cmx/flambda_cmx.cmi
 middle_end/flambda/cmx/flambda_cmx.cmi : \
     middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/simplify/simplify_import.cmi \
     middle_end/flambda/basic/name.cmi \
     middle_end/flambda/types/flambda_type.cmi \
     middle_end/flambda/cmx/flambda_cmx_format.cmi \
     middle_end/flambda/flambda_backend_intf.cmi \
+    middle_end/flambda/cmx/exported_code.cmi \
     middle_end/flambda/simplify/env/continuation_uses_env.cmi \
     middle_end/flambda/basic/continuation.cmi \
-    middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    middle_end/flambda/basic/code_id.cmi
+    middle_end/flambda/compilenv_deps/compilation_unit.cmi
 middle_end/flambda/cmx/flambda_cmx_format.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
@@ -4582,6 +4589,7 @@ middle_end/flambda/from_lambda/closure_conversion.cmo : \
     middle_end/flambda/basic/inline_attribute.cmi \
     middle_end/flambda/from_lambda/ilambda.cmi \
     typing/ident.cmi \
+    middle_end/flambda/terms/function_declarations.cmi \
     middle_end/flambda/terms/flambda_unit.cmi \
     middle_end/flambda/terms/flambda_primitive.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
@@ -4632,6 +4640,7 @@ middle_end/flambda/from_lambda/closure_conversion.cmx : \
     middle_end/flambda/basic/inline_attribute.cmx \
     middle_end/flambda/from_lambda/ilambda.cmx \
     typing/ident.cmx \
+    middle_end/flambda/terms/function_declarations.cmx \
     middle_end/flambda/terms/flambda_unit.cmx \
     middle_end/flambda/terms/flambda_primitive.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
@@ -5643,7 +5652,8 @@ middle_end/flambda/simplify/simplify.cmx : \
 middle_end/flambda/simplify/simplify.cmi : \
     middle_end/flambda/terms/flambda_unit.cmi \
     middle_end/flambda/cmx/flambda_cmx_format.cmi \
-    middle_end/flambda/flambda_backend_intf.cmi
+    middle_end/flambda/flambda_backend_intf.cmi \
+    middle_end/flambda/cmx/exported_code.cmi
 middle_end/flambda/simplify/simplify_binary_primitive.cmo : \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
     utils/targetint.cmi \
@@ -6394,6 +6404,7 @@ middle_end/flambda/simplify/env/simplify_env_and_result_intf.cmo : \
     middle_end/flambda/flambda_backend_intf.cmi \
     middle_end/flambda/types/kinds/flambda_arity.cmi \
     middle_end/flambda/terms/flambda.cmi \
+    middle_end/flambda/cmx/exported_code.cmi \
     middle_end/flambda/basic/exn_continuation.cmi \
     lambda/debuginfo.cmi \
     middle_end/flambda/simplify/basic/continuation_in_env.cmi \
@@ -6416,6 +6427,7 @@ middle_end/flambda/simplify/env/simplify_env_and_result_intf.cmx : \
     middle_end/flambda/flambda_backend_intf.cmi \
     middle_end/flambda/types/kinds/flambda_arity.cmx \
     middle_end/flambda/terms/flambda.cmx \
+    middle_end/flambda/cmx/exported_code.cmx \
     middle_end/flambda/basic/exn_continuation.cmx \
     lambda/debuginfo.cmx \
     middle_end/flambda/simplify/basic/continuation_in_env.cmx \
@@ -6959,21 +6971,18 @@ middle_end/flambda/terms/flambda_unit.cmo : \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/basic/continuation.cmi \
-    middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/terms/flambda_unit.cmi
 middle_end/flambda/terms/flambda_unit.cmx : \
     middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/basic/continuation.cmx \
-    middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/terms/flambda_unit.cmi
 middle_end/flambda/terms/flambda_unit.cmi : \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/basic/continuation.cmi \
-    middle_end/flambda/basic/closure_id.cmi
+    middle_end/flambda/basic/continuation.cmi
 middle_end/flambda/terms/function_declaration.cmo : \
     middle_end/flambda/basic/recursive.cmi \
     utils/printing_cache.cmi \
@@ -7011,6 +7020,7 @@ middle_end/flambda/terms/function_declaration.cmi : \
 middle_end/flambda/terms/function_declarations.cmo : \
     utils/printing_cache.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
+    utils/misc.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/terms/function_declaration.cmi \
     middle_end/flambda/basic/closure_id.cmi \
@@ -7018,6 +7028,7 @@ middle_end/flambda/terms/function_declarations.cmo : \
 middle_end/flambda/terms/function_declarations.cmx : \
     utils/printing_cache.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
+    utils/misc.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/terms/function_declaration.cmx \
     middle_end/flambda/basic/closure_id.cmx \
@@ -7380,6 +7391,7 @@ middle_end/flambda/to_cmm/un_cps.cmo : \
     middle_end/flambda/cmx/flambda_cmx_format.cmi \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/cmx/exported_offsets.cmi \
+    middle_end/flambda/cmx/exported_code.cmi \
     middle_end/flambda/basic/exn_continuation.cmi \
     middle_end/flambda/basic/effects_and_coeffects.cmi \
     middle_end/flambda/basic/effects.cmi \
@@ -7441,6 +7453,7 @@ middle_end/flambda/to_cmm/un_cps.cmx : \
     middle_end/flambda/cmx/flambda_cmx_format.cmx \
     middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/cmx/exported_offsets.cmx \
+    middle_end/flambda/cmx/exported_code.cmx \
     middle_end/flambda/basic/exn_continuation.cmx \
     middle_end/flambda/basic/effects_and_coeffects.cmx \
     middle_end/flambda/basic/effects.cmx \
@@ -7640,7 +7653,6 @@ middle_end/flambda/to_cmm/un_cps_static.cmo : \
     middle_end/flambda/basic/reg_width_const.cmi \
     middle_end/flambda/basic/or_variable.cmi \
     utils/numbers.cmi \
-    middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/basic/name.cmi \
     utils/misc.cmi \
     middle_end/flambda/compilenv_deps/linkage_name.cmi \
@@ -7674,7 +7686,6 @@ middle_end/flambda/to_cmm/un_cps_static.cmx : \
     middle_end/flambda/basic/reg_width_const.cmx \
     middle_end/flambda/basic/or_variable.cmx \
     utils/numbers.cmx \
-    middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/basic/name.cmx \
     utils/misc.cmx \
     middle_end/flambda/compilenv_deps/linkage_name.cmx \

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,8 @@ UTILS=utils/config.cmo utils/build_path_prefix_map.cmo utils/misc.cmo \
 	utils/consistbl.cmo utils/strongly_connected_components.cmo \
 	utils/one_bit_fewer.cmo \
 	utils/targetint.cmo utils/int_replace_polymorphic_compare.cmo \
-	utils/domainstate.cmo utils/printing_cache.cmo
+	utils/domainstate.cmo utils/printing_cache.cmo \
+	utils/lmap.cmo
 
 PARSING=parsing/location.cmo parsing/longident.cmo \
   parsing/docstrings.cmo parsing/syntaxerr.cmo \

--- a/dune
+++ b/dune
@@ -53,7 +53,7 @@
    config build_path_prefix_map misc identifiable numbers arg_helper clflags
    profile terminfo ccomp warnings consistbl strongly_connected_components
    one_bit_fewer targetint load_path
-   int_replace_polymorphic_compare printing_cache
+   int_replace_polymorphic_compare printing_cache lmap
    ; manual update: mli only files
    targetint_intf
 

--- a/middle_end/flambda/basic/closure_id.ml
+++ b/middle_end/flambda/basic/closure_id.ml
@@ -57,6 +57,11 @@ end)
 
 include Self
 
+module Lmap = Lmap.Make(struct
+  type nonrec t = t
+  include Self
+end)
+
 let next_stamp = ref 0
 
 let get_next_stamp () =

--- a/middle_end/flambda/basic/closure_id.mli
+++ b/middle_end/flambda/basic/closure_id.mli
@@ -27,6 +27,8 @@
 
 include Identifiable.S
 
+module Lmap : Lmap.S with type key = t
+
 val wrap : Compilation_unit.t -> Variable.t -> t
 
 val unwrap : t -> Variable.t

--- a/middle_end/flambda/basic/code_id.ml
+++ b/middle_end/flambda/basic/code_id.ml
@@ -126,6 +126,7 @@ end
 module Set = Patricia_tree.Make_set (struct let print = print end)
 module Map = Patricia_tree.Make_map (struct let print = print end) (Set)
 module Tbl = Identifiable.Make_tbl (Numbers.Int) (Map)
+module Lmap = Lmap.Make(T)
 
 let invert_map map =
   Map.fold (fun older newer invert_map ->

--- a/middle_end/flambda/basic/code_id.mli
+++ b/middle_end/flambda/basic/code_id.mli
@@ -19,6 +19,8 @@
 include Identifiable.S
 type exported
 
+module Lmap : Lmap.S with type key = t
+
 val initialise : unit -> unit
 
 val create : name:string -> Compilation_unit.t -> t

--- a/middle_end/flambda/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion.ml
@@ -861,6 +861,12 @@ and close_functions t external_env function_declarations =
       Closure_id.Map.empty
       func_decl_list
   in
+  (* CR lmaurer: funs has arbitrary order (ultimately coming from
+     function_declarations) *)
+  let funs =
+    List.map Function_declarations.Binding.of_pair
+      (Closure_id.Map.bindings funs)
+  in
   let function_decls = Flambda.Function_declarations.create funs in
   let closure_elements =
     Ident.Map.fold (fun id var_within_closure map ->
@@ -1169,7 +1175,7 @@ let ilambda_to_flambda ~backend ~module_ident ~module_block_size_in_words
         let bound_symbols : Let_symbol.Bound_symbols.t =
           Sets_of_closures [{
             code_ids = Code_id.Set.singleton code_id;
-            closure_symbols = Closure_id.Map.empty;
+            closure_symbols = [];
           }]
         in
         let static_const : Static_const.t =
@@ -1179,7 +1185,7 @@ let ilambda_to_flambda ~backend ~module_ident ~module_block_size_in_words
             }
           in
           Sets_of_closures [{
-            code = Code_id.Map.singleton code_id code;
+            code = [{ code_id; code }];
             set_of_closures = Set_of_closures.empty;
           }]
         in

--- a/middle_end/flambda/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion.ml
@@ -864,8 +864,7 @@ and close_functions t external_env function_declarations =
   (* CR lmaurer: funs has arbitrary order (ultimately coming from
      function_declarations) *)
   let funs =
-    List.map Function_declarations.Binding.of_pair
-      (Closure_id.Map.bindings funs)
+    Closure_id.Lmap.of_list (Closure_id.Map.bindings funs)
   in
   let function_decls = Flambda.Function_declarations.create funs in
   let closure_elements =
@@ -1175,7 +1174,7 @@ let ilambda_to_flambda ~backend ~module_ident ~module_block_size_in_words
         let bound_symbols : Let_symbol.Bound_symbols.t =
           Sets_of_closures [{
             code_ids = Code_id.Set.singleton code_id;
-            closure_symbols = [];
+            closure_symbols = Closure_id.Lmap.empty;
           }]
         in
         let static_const : Static_const.t =
@@ -1185,7 +1184,7 @@ let ilambda_to_flambda ~backend ~module_ident ~module_block_size_in_words
             }
           in
           Sets_of_closures [{
-            code = [{ code_id; code }];
+            code = Code_id.Lmap.singleton code_id code;
             set_of_closures = Set_of_closures.empty;
           }]
         in

--- a/middle_end/flambda/lifting/lift_inconstants.ml
+++ b/middle_end/flambda/lifting/lift_inconstants.ml
@@ -65,24 +65,27 @@ let lift_set_of_closures_discovered_via_reified_continuation_param_types dacc
   let module I = T.Function_declaration_type.Inlinable in
   let set_of_closures =
     let function_decls =
-      Closure_id.Map.map (fun inlinable ->
-        Function_declaration.create ~code_id:(I.code_id inlinable)
-          ~params_arity:(I.param_arity inlinable)
-          ~result_arity:(I.result_arity inlinable)
-          ~stub:(I.stub inlinable)
-          ~dbg:(I.dbg inlinable)
-          ~inline:(I.inline inlinable)
-          ~is_a_functor:(I.is_a_functor inlinable)
-          ~recursive:(I.recursive inlinable))
+      List.map (fun (closure_id, inlinable) ->
+        let func_decl =
+          Function_declaration.create ~code_id:(I.code_id inlinable)
+            ~params_arity:(I.param_arity inlinable)
+            ~result_arity:(I.result_arity inlinable)
+            ~stub:(I.stub inlinable)
+            ~dbg:(I.dbg inlinable)
+            ~inline:(I.inline inlinable)
+            ~is_a_functor:(I.is_a_functor inlinable)
+            ~recursive:(I.recursive inlinable)
+        in
+        { Function_declarations.Binding.closure_id; func_decl })
         function_decls
       |> Function_declarations.create
     in
     Set_of_closures.create function_decls ~closure_elements:closure_vars
   in
-  let bind_continuation_param_to_symbol dacc ~closure_symbols =
+  let bind_continuation_param_to_symbol dacc ~closure_symbol_map =
     let dacc, symbol =
       DA.map_denv2 dacc ~f:(fun denv ->
-        match Closure_id.Map.find closure_id closure_symbols with
+        match Closure_id.Map.find closure_id closure_symbol_map with
         | exception Not_found ->
           Misc.fatal_errorf "Variable %a claimed to hold closure with \
               closure ID %a, but no symbol was found for that closure ID"
@@ -100,7 +103,7 @@ let lift_set_of_closures_discovered_via_reified_continuation_param_types dacc
   match Set_of_closures.Map.find set_of_closures closure_symbols_by_set with
   | exception Not_found ->
     let closure_symbols =
-      Closure_id.Map.mapi (fun closure_id _function_decl ->
+      List.map (fun (closure_id, _function_decl) ->
           (* CR mshinwell: share name computation with
              [Simplify_named] *)
           let name =
@@ -109,15 +112,18 @@ let lift_set_of_closures_discovered_via_reified_continuation_param_types dacc
             |> Closure_id.to_string
             |> Linkage_name.create
           in
-          Symbol.create (Compilation_unit.get_current_exn ()) name)
+          let symbol =
+            Symbol.create (Compilation_unit.get_current_exn ()) name
+          in
+          { Flambda.Let_symbol_expr.Closure_binding.closure_id; symbol })
         function_decls
     in
     let dacc =
       DA.map_denv dacc ~f:(fun denv ->
-        Closure_id.Map.fold (fun _closure_id closure_symbol denv ->
-            DE.define_symbol denv closure_symbol K.value)
-          closure_symbols
-          denv)
+        List.fold_left (fun denv { Let_symbol.Closure_binding.symbol; _ } ->
+            DE.define_symbol denv symbol K.value)
+          denv
+          closure_symbols)
     in
     let definition =
       (* We don't need to assign new code IDs, since we're not changing the
@@ -131,7 +137,7 @@ let lift_set_of_closures_discovered_via_reified_continuation_param_types dacc
       Let_symbol.pieces_of_code
         ~newer_versions_of:Code_id.Map.empty
         ~set_of_closures:(closure_symbols, set_of_closures)
-        Code_id.Map.empty
+        []
     in
     (* This reification process will result in [Let_symbol] bindings containing
        closure symbol definitions but no code.  The code will be simplified
@@ -173,18 +179,25 @@ let lift_set_of_closures_discovered_via_reified_continuation_param_types dacc
     let reified_definitions =
       (fst definition, snd definition, extra_deps) :: reified_definitions
     in
+    let closure_symbol_map =
+      List.map (fun { Let_symbol.Closure_binding.closure_id; symbol } ->
+          (closure_id, symbol))
+        closure_symbols
+      |> Closure_id.Map.of_list
+    in
     let closure_symbols_by_set =
-      Set_of_closures.Map.add set_of_closures closure_symbols
+      Set_of_closures.Map.add set_of_closures
+        closure_symbol_map
         closure_symbols_by_set
     in
     let dacc, reified_continuation_params_to_symbols =
-      bind_continuation_param_to_symbol dacc ~closure_symbols
+      bind_continuation_param_to_symbol dacc ~closure_symbol_map
     in
     dacc, reified_continuation_params_to_symbols, reified_definitions,
       closure_symbols_by_set
-  | closure_symbols ->
+  | closure_symbol_map ->
     let dacc, reified_continuation_params_to_symbols =
-      bind_continuation_param_to_symbol dacc ~closure_symbols
+      bind_continuation_param_to_symbol dacc ~closure_symbol_map
     in
     dacc, reified_continuation_params_to_symbols, reified_definitions,
       closure_symbols_by_set
@@ -261,6 +274,8 @@ let reify_types_of_continuation_param_types dacc ~params =
             dacc, reified_continuation_params_to_symbols, reified_definitions,
               closure_symbols_by_set
           else
+            (* CR lmaurer: function_decls has arbitrary order *)
+            let function_decls = Closure_id.Map.bindings function_decls in
             lift_set_of_closures_discovered_via_reified_continuation_param_types
               dacc var closure_id function_decls ~closure_vars
               ~reified_continuation_params_to_symbols

--- a/middle_end/flambda/simplify/env/simplify_env_and_result.ml
+++ b/middle_end/flambda/simplify/env/simplify_env_and_result.ml
@@ -456,16 +456,17 @@ end = struct
     in
     List.fold_left (fun denv lifted_constant ->
         let defining_expr = LC.defining_expr lifted_constant in
-        Code_id.Map.fold
-          (fun code_id
-               ({ params_and_body; newer_version_of; } : Static_const.Code.t)
-               denv ->
+        List.fold_left
+          (fun denv
+               { Static_const.Code_binding.code_id;
+                 code = { params_and_body; newer_version_of; } }
+               ->
             match params_and_body with
             | Present params_and_body ->
               define_code denv ?newer_version_of ~code_id ~params_and_body
             | Deleted -> denv)
-          (Static_const.get_pieces_of_code defining_expr)
-          denv)
+          denv
+          (Static_const.get_pieces_of_code defining_expr))
       (with_typing_env t typing_env)
       lifted
 
@@ -804,7 +805,7 @@ end = struct
       | Some older -> Some (Code_id.Map.singleton code_id older)
     in
     create_pieces_of_code denv ?newer_versions_of
-      (Code_id.Map.singleton code_id params_and_body)
+      [ code_id, params_and_body ]
 
   let create_deleted_piece_of_code denv ?newer_versions_of code_id =
     let bound_symbols, defining_expr =

--- a/middle_end/flambda/simplify/env/simplify_env_and_result.ml
+++ b/middle_end/flambda/simplify/env/simplify_env_and_result.ml
@@ -456,17 +456,16 @@ end = struct
     in
     List.fold_left (fun denv lifted_constant ->
         let defining_expr = LC.defining_expr lifted_constant in
-        List.fold_left
-          (fun denv
-               { Static_const.Code_binding.code_id;
-                 code = { params_and_body; newer_version_of; } }
-               ->
+        Code_id.Lmap.fold
+          (fun code_id
+               ({ params_and_body; newer_version_of; } : Static_const.Code.t)
+               denv ->
             match params_and_body with
             | Present params_and_body ->
               define_code denv ?newer_version_of ~code_id ~params_and_body
             | Deleted -> denv)
-          denv
-          (Static_const.get_pieces_of_code defining_expr))
+          (Static_const.get_pieces_of_code defining_expr)
+          denv)
       (with_typing_env t typing_env)
       lifted
 
@@ -805,7 +804,7 @@ end = struct
       | Some older -> Some (Code_id.Map.singleton code_id older)
     in
     create_pieces_of_code denv ?newer_versions_of
-      [ code_id, params_and_body ]
+      (Code_id.Lmap.singleton code_id params_and_body)
 
   let create_deleted_piece_of_code denv ?newer_versions_of code_id =
     let bound_symbols, defining_expr =

--- a/middle_end/flambda/simplify/env/simplify_env_and_result_intf.ml
+++ b/middle_end/flambda/simplify/env/simplify_env_and_result_intf.ml
@@ -339,7 +339,7 @@ module type Lifted_constant = sig
   val create_pieces_of_code
      : downwards_env
     -> ?newer_versions_of:Code_id.t Code_id.Map.t
-    -> Flambda.Function_params_and_body.t Code_id.Map.t
+    -> (Code_id.t * Flambda.Function_params_and_body.t) list
     -> t
 
   val create_deleted_piece_of_code

--- a/middle_end/flambda/simplify/env/simplify_env_and_result_intf.ml
+++ b/middle_end/flambda/simplify/env/simplify_env_and_result_intf.ml
@@ -339,7 +339,7 @@ module type Lifted_constant = sig
   val create_pieces_of_code
      : downwards_env
     -> ?newer_versions_of:Code_id.t Code_id.Map.t
-    -> (Code_id.t * Flambda.Function_params_and_body.t) list
+    -> Flambda.Function_params_and_body.t Code_id.Lmap.t
     -> t
 
   val create_deleted_piece_of_code

--- a/middle_end/flambda/simplify/simplify_common.ml
+++ b/middle_end/flambda/simplify/simplify_common.ml
@@ -297,7 +297,9 @@ let create_let_symbol0 r code_age_relation (bound_symbols : Bound_symbols.t)
       in
       let r =
         R.remember_code_for_cmx r
-          (Static_const.get_pieces_of_code' static_const)
+          (Static_const.get_pieces_of_code' static_const
+           |> Code_id.Lmap.bindings
+           |> Code_id.Map.of_list)
       in
       expr, r
 
@@ -348,6 +350,8 @@ let create_let_symbol r (scoping_rule : Let_symbol.Scoping_rule.t)
     in
     let r =
       R.remember_code_for_cmx r
-        (Static_const.get_pieces_of_code' static_const)
+        (Static_const.get_pieces_of_code' static_const
+         |> Code_id.Lmap.bindings
+         |> Code_id.Map.of_list)
     in
     expr, r

--- a/middle_end/flambda/simplify/simplify_expr.rec.ml
+++ b/middle_end/flambda/simplify/simplify_expr.rec.ml
@@ -902,7 +902,7 @@ and simplify_direct_partial_application
         ~name:(Closure_id.to_string callee's_closure_id ^ "_partial")
         (Compilation_unit.get_current_exn ())
     in
-    let function_decl =
+    let func_decl =
       Function_declaration.create ~code_id
         ~params_arity:(KP.List.arity remaining_params)
         ~result_arity
@@ -914,7 +914,7 @@ and simplify_direct_partial_application
     in
     let function_decls =
       Function_declarations.create
-        (Closure_id.Map.singleton wrapper_closure_id function_decl)
+        [{ closure_id = wrapper_closure_id; func_decl }]
     in
     let closure_elements =
       Var_within_closure.Map.of_list applied_args_with_closure_vars

--- a/middle_end/flambda/simplify/simplify_expr.rec.ml
+++ b/middle_end/flambda/simplify/simplify_expr.rec.ml
@@ -902,7 +902,7 @@ and simplify_direct_partial_application
         ~name:(Closure_id.to_string callee's_closure_id ^ "_partial")
         (Compilation_unit.get_current_exn ())
     in
-    let func_decl =
+    let function_decl =
       Function_declaration.create ~code_id
         ~params_arity:(KP.List.arity remaining_params)
         ~result_arity
@@ -914,7 +914,7 @@ and simplify_direct_partial_application
     in
     let function_decls =
       Function_declarations.create
-        [{ closure_id = wrapper_closure_id; func_decl }]
+        (Closure_id.Lmap.singleton wrapper_closure_id function_decl)
     in
     let closure_elements =
       Var_within_closure.Map.of_list applied_args_with_closure_vars

--- a/middle_end/flambda/terms/flambda.mli
+++ b/middle_end/flambda/terms/flambda.mli
@@ -224,18 +224,11 @@ end and Let_expr : sig
     -> f:(bound_vars:Bindable_let_bound.t -> body1:Expr.t -> body2:Expr.t -> 'a)
     -> 'a
 end and Let_symbol_expr : sig
-  module Closure_binding : sig
-    type t = {
-      symbol : Symbol.t;
-      closure_id : Closure_id.t;
-    }
-  end
-
   module Bound_symbols : sig
     module Code_and_set_of_closures : sig
       type t = {
         code_ids : Code_id.Set.t;
-        closure_symbols : Closure_binding.t list;
+        closure_symbols : Symbol.t Closure_id.Lmap.t
       }
 
       val print : Format.formatter -> t -> unit
@@ -295,8 +288,8 @@ end and Let_symbol_expr : sig
       version of [id2]. *)
   val pieces_of_code
      : ?newer_versions_of:Code_id.t Code_id.Map.t
-    -> ?set_of_closures:(Closure_binding.t list * Set_of_closures.t)
-    -> (Code_id.t * Function_params_and_body.t) list
+    -> ?set_of_closures:(Symbol.t Closure_id.Lmap.t * Set_of_closures.t)
+    -> Function_params_and_body.t Code_id.Lmap.t
     -> Bound_symbols.t * Static_const.t
 
   val deleted_pieces_of_code
@@ -617,21 +610,11 @@ end and Static_const : sig
     val make_deleted : t -> t
   end
 
-  (** The declaration of a single piece of code. *)
-  module Code_binding : sig
-    type t = {
-      code_id : Code_id.t;
-      code : Code.t;
-    }
-
-    val of_pair : Code_id.t * Code.t -> t
-  end
-
   (** The possibly-recursive declaration of pieces of code and any associated
       set of closures. *)
   module Code_and_set_of_closures : sig
     type t = {
-      code : Code_binding.t list;
+      code : Code.t Code_id.Lmap.t;
       (* CR mshinwell: Check the free names of the set of closures *)
       set_of_closures : Set_of_closures.t;
     }
@@ -660,9 +643,9 @@ end and Static_const : sig
   include Identifiable.S with type t := t
   include Contains_names.S with type t := t
 
-  val get_pieces_of_code : t -> Code_binding.t list
+  val get_pieces_of_code : t -> Code.t Code_id.Lmap.t
 
-  val get_pieces_of_code' : t -> Function_params_and_body.t Code_id.Map.t
+  val get_pieces_of_code' : t -> Function_params_and_body.t Code_id.Lmap.t
 
   (** Returns [true] iff the given term does not contain any variables,
       which means that the corresponding value can be statically allocated,

--- a/middle_end/flambda/terms/flambda_unit.ml
+++ b/middle_end/flambda/terms/flambda_unit.ml
@@ -149,8 +149,9 @@ module Iter_sets_of_closures = struct
              ({ code; set_of_closures; }
               : Static_const.Code_and_set_of_closures.t) ->
             f ~closure_symbols:(Some closure_symbols) set_of_closures;
-            Code_id.Map.iter (fun _ { Static_const.Code. params_and_body;
-                                      newer_version_of = _; } ->
+            List.iter (fun { Static_const.Code_binding.code_id = _;
+                             code = { Static_const.Code. params_and_body;
+                                      newer_version_of = _; } } ->
                 match params_and_body with
                 | Deleted -> ()
                 | Present params_and_body ->

--- a/middle_end/flambda/terms/flambda_unit.ml
+++ b/middle_end/flambda/terms/flambda_unit.ml
@@ -149,9 +149,8 @@ module Iter_sets_of_closures = struct
              ({ code; set_of_closures; }
               : Static_const.Code_and_set_of_closures.t) ->
             f ~closure_symbols:(Some closure_symbols) set_of_closures;
-            List.iter (fun { Static_const.Code_binding.code_id = _;
-                             code = { Static_const.Code. params_and_body;
-                                      newer_version_of = _; } } ->
+            Code_id.Lmap.iter (fun _ { Static_const.Code. params_and_body;
+                                       newer_version_of = _; } ->
                 match params_and_body with
                 | Deleted -> ()
                 | Present params_and_body ->

--- a/middle_end/flambda/terms/flambda_unit.mli
+++ b/middle_end/flambda/terms/flambda_unit.mli
@@ -47,7 +47,7 @@ val body : t -> Flambda.Expr.t
 
 val iter_sets_of_closures
    : t
-  -> f:(closure_symbols:Flambda.Let_symbol_expr.Closure_binding.t list option
+  -> f:(closure_symbols:Symbol.t Closure_id.Lmap.t option
      -> Flambda.Set_of_closures.t
      -> unit)
   -> unit

--- a/middle_end/flambda/terms/flambda_unit.mli
+++ b/middle_end/flambda/terms/flambda_unit.mli
@@ -47,7 +47,7 @@ val body : t -> Flambda.Expr.t
 
 val iter_sets_of_closures
    : t
-  -> f:(closure_symbols:Symbol.t Closure_id.Map.t option
+  -> f:(closure_symbols:Flambda.Let_symbol_expr.Closure_binding.t list option
      -> Flambda.Set_of_closures.t
      -> unit)
   -> unit

--- a/middle_end/flambda/terms/function_declarations.ml
+++ b/middle_end/flambda/terms/function_declarations.ml
@@ -16,49 +16,37 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
-module Binding = struct
-  type t = {
-    closure_id : Closure_id.t;
-    func_decl : Function_declaration.t;
-  }
-
-  let of_pair (closure_id, func_decl) = { closure_id; func_decl }
-
-  let to_pair { closure_id; func_decl } = closure_id, func_decl
-end
-
 type t = {
   funs : Function_declaration.t Closure_id.Map.t;
-  as_list : Binding.t list
+  in_order : Function_declaration.t Closure_id.Lmap.t
 }
 
 let invariant _env _t = ()
 
 let empty =
   { funs = Closure_id.Map.empty;
-    as_list = []
+    in_order = Closure_id.Lmap.empty
   }
 
 let is_empty { funs; _ } =
   Closure_id.Map.is_empty funs
 
-let create as_list =
-  { funs = Closure_id.Map.of_list (List.map Binding.to_pair as_list);
-    as_list
+let create in_order =
+  { funs = Closure_id.Map.of_list (Closure_id.Lmap.bindings in_order);
+    in_order
   }
 
 let funs t = t.funs
 
-let funs_in_order t = t.as_list
+let funs_in_order t = t.in_order
 
 let find ({ funs; _ } : t) closure_id =
   Closure_id.Map.find closure_id funs
 
-let print_with_cache ~cache ppf { as_list; _ } =
+let print_with_cache ~cache ppf { in_order; _ } =
   Format.fprintf ppf "@[<hov 1>(%a)@]"
-    (Misc.print_assoc
-      Closure_id.print (Function_declaration.print_with_cache ~cache))
-    (List.map Binding.to_pair as_list)
+    (Closure_id.Lmap.print (Function_declaration.print_with_cache ~cache))
+    in_order
 
 let print ppf t = print_with_cache ~cache:(Printing_cache.create ()) ppf t
 
@@ -69,18 +57,14 @@ let free_names { funs; _ } =
     funs
     (Name_occurrences.empty)
 
-let apply_name_permutation ({ as_list; _ } as t) perm =
-  let as_list' =
-    Misc.Stdlib.List.map_sharing (fun (binding : Binding.t) ->
-        let func_decl =
-          Function_declaration.apply_name_permutation binding.func_decl perm
-        in
-        if func_decl == binding.func_decl then binding
-        else { binding with Binding.func_decl })
-      as_list
+let apply_name_permutation ({ in_order; _ } as t) perm =
+  let in_order' =
+    Closure_id.Lmap.map_sharing (fun func_decl ->
+        Function_declaration.apply_name_permutation func_decl perm)
+      in_order
   in
-  if as_list == as_list' then t
-  else create as_list
+  if in_order == in_order' then t
+  else create in_order
 
 let all_ids_for_export { funs; _ } =
   Closure_id.Map.fold
@@ -90,21 +74,16 @@ let all_ids_for_export { funs; _ } =
     funs
     Ids_for_export.empty
 
-let import import_map { as_list; _ } =
-  let as_list = List.map (fun (binding : Binding.t) ->
-    let func_decl = Function_declaration.import import_map binding.func_decl in
-    { binding with func_decl }
-  ) as_list
+let import import_map { in_order; _ } =
+  let in_order =
+    Closure_id.Lmap.map (Function_declaration.import import_map) in_order
   in
-  create as_list
+  create in_order
 
 let compare { funs = funs1; _ } { funs = funs2; _ } =
   Closure_id.Map.compare Function_declaration.compare funs1 funs2
 
 let filter t ~f =
   let funs = Closure_id.Map.filter f t.funs in
-  let as_list =
-    List.filter (fun (binding : Binding.t) ->
-      f binding.closure_id binding.func_decl) t.as_list
-  in
-  { funs; as_list; }
+  let in_order = Closure_id.Lmap.filter f t.in_order in
+  { funs; in_order; }

--- a/middle_end/flambda/terms/function_declarations.ml
+++ b/middle_end/flambda/terms/function_declarations.ml
@@ -16,51 +16,73 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
+module Binding = struct
+  type t = {
+    closure_id : Closure_id.t;
+    func_decl : Function_declaration.t;
+  }
+
+  let of_pair (closure_id, func_decl) = { closure_id; func_decl }
+
+  let to_pair { closure_id; func_decl } = closure_id, func_decl
+end
+
 type t = {
   funs : Function_declaration.t Closure_id.Map.t;
+  as_list : Binding.t list
 }
 
 let invariant _env _t = ()
 
 let empty =
   { funs = Closure_id.Map.empty;
+    as_list = []
   }
 
-let is_empty { funs; } =
+let is_empty { funs; _ } =
   Closure_id.Map.is_empty funs
 
-let create funs =
-  { funs;
+let create as_list =
+  { funs = Closure_id.Map.of_list (List.map Binding.to_pair as_list);
+    as_list
   }
 
 let funs t = t.funs
 
-let find ({ funs; } : t) closure_id =
+let funs_in_order t = t.as_list
+
+let find ({ funs; _ } : t) closure_id =
   Closure_id.Map.find closure_id funs
 
-let print_with_cache ~cache ppf { funs; } =
+let print_with_cache ~cache ppf { as_list; _ } =
   Format.fprintf ppf "@[<hov 1>(%a)@]"
-    (Closure_id.Map.print (Function_declaration.print_with_cache ~cache)) funs
+    (Misc.print_assoc
+      Closure_id.print (Function_declaration.print_with_cache ~cache))
+    (List.map Binding.to_pair as_list)
 
 let print ppf t = print_with_cache ~cache:(Printing_cache.create ()) ppf t
 
-let free_names { funs; } =
+let free_names { funs; _ } =
   Closure_id.Map.fold
     (fun _closure_id (func_decl : Function_declaration.t) syms ->
       Name_occurrences.union syms (Function_declaration.free_names func_decl))
     funs
     (Name_occurrences.empty)
 
-let apply_name_permutation ({ funs; } as t) perm =
-  let funs' =
-    Closure_id.Map.map_sharing (fun func_decl ->
-        Function_declaration.apply_name_permutation func_decl perm)
-      funs
+let apply_name_permutation ({ as_list; _ } as t) perm =
+  let as_list' =
+    Misc.Stdlib.List.map_sharing (fun (binding : Binding.t) ->
+        let func_decl =
+          Function_declaration.apply_name_permutation binding.func_decl perm
+        in
+        if func_decl == binding.func_decl then binding
+        else { binding with Binding.func_decl })
+      as_list
   in
-  if funs == funs' then t
-  else { funs = funs'; }
+  if as_list == as_list' then t
+  else create as_list
 
-let all_ids_for_export { funs; } =
+let all_ids_for_export { funs; _ } =
   Closure_id.Map.fold
     (fun _closure_id (func_decl : Function_declaration.t) ids ->
       Ids_for_export.union ids
@@ -68,15 +90,21 @@ let all_ids_for_export { funs; } =
     funs
     Ids_for_export.empty
 
-let import import_map { funs; } =
-  let funs =
-    Closure_id.Map.map (Function_declaration.import import_map) funs
+let import import_map { as_list; _ } =
+  let as_list = List.map (fun (binding : Binding.t) ->
+    let func_decl = Function_declaration.import import_map binding.func_decl in
+    { binding with func_decl }
+  ) as_list
   in
-  { funs; }
+  create as_list
 
-let compare { funs = funs1; } { funs = funs2; } =
+let compare { funs = funs1; _ } { funs = funs2; _ } =
   Closure_id.Map.compare Function_declaration.compare funs1 funs2
 
 let filter t ~f =
   let funs = Closure_id.Map.filter f t.funs in
-  { funs; }
+  let as_list =
+    List.filter (fun (binding : Binding.t) ->
+      f binding.closure_id binding.func_decl) t.as_list
+  in
+  { funs; as_list; }

--- a/middle_end/flambda/terms/function_declarations.ml
+++ b/middle_end/flambda/terms/function_declarations.ml
@@ -64,7 +64,7 @@ let apply_name_permutation ({ in_order; _ } as t) perm =
       in_order
   in
   if in_order == in_order' then t
-  else create in_order
+  else create in_order'
 
 let all_ids_for_export { funs; _ } =
   Closure_id.Map.fold

--- a/middle_end/flambda/terms/function_declarations.mli
+++ b/middle_end/flambda/terms/function_declarations.mli
@@ -44,18 +44,8 @@ val empty : t
 
 val is_empty : t -> bool
 
-module Binding : sig
-  type t = {
-    closure_id : Closure_id.t;
-    func_decl : Function_declaration.t;
-  }
-
-  val of_pair : Closure_id.t * Function_declaration.t -> t
-end
-
-(** Create a set of function declarations given the individual
-    declarations. *)
-val create : Binding.t list -> t
+(** Create a set of function declarations in the given order. *)
+val create : Function_declaration.t Closure_id.Lmap.t -> t
 
 (** The function(s) defined by the set of function declarations, indexed
     by closure ID. *)
@@ -63,7 +53,7 @@ val funs : t -> Function_declaration.t Closure_id.Map.t
 
 (** The function(s) defined by the set of function declarations, in the order
     originally given. *)
-val funs_in_order : t -> Binding.t list
+val funs_in_order : t -> Function_declaration.t Closure_id.Lmap.t
 
 (** [find f t] raises [Not_found] if [f] is not in [t]. *)
 val find : t -> Closure_id.t -> Function_declaration.t

--- a/middle_end/flambda/terms/function_declarations.mli
+++ b/middle_end/flambda/terms/function_declarations.mli
@@ -44,13 +44,26 @@ val empty : t
 
 val is_empty : t -> bool
 
+module Binding : sig
+  type t = {
+    closure_id : Closure_id.t;
+    func_decl : Function_declaration.t;
+  }
+
+  val of_pair : Closure_id.t * Function_declaration.t -> t
+end
+
 (** Create a set of function declarations given the individual
     declarations. *)
-val create : Function_declaration.t Closure_id.Map.t -> t
+val create : Binding.t list -> t
 
 (** The function(s) defined by the set of function declarations, indexed
     by closure ID. *)
 val funs : t -> Function_declaration.t Closure_id.Map.t
+
+(** The function(s) defined by the set of function declarations, in the order
+    originally given. *)
+val funs_in_order : t -> Binding.t list
 
 (** [find f t] raises [Not_found] if [f] is not in [t]. *)
 val find : t -> Closure_id.t -> Function_declaration.t

--- a/middle_end/flambda/terms/let_symbol_expr.rec.ml
+++ b/middle_end/flambda/terms/let_symbol_expr.rec.ml
@@ -477,9 +477,9 @@ let deleted_pieces_of_code ?newer_versions_of code_ids =
             newer_version_of;
           }
         in
-        Code_id.Map.add id code code_map)
+        Code_id.Lmap.add id code code_map)
       code_ids
-      Code_id.Map.empty
+      Code_id.Lmap.empty
   in
   let static_const : Static_const.t =
     Sets_of_closures [{
@@ -489,8 +489,8 @@ let deleted_pieces_of_code ?newer_versions_of code_ids =
   in
   let bound_symbols : Bound_symbols.t =
     Sets_of_closures [{
-      code_ids = Code_id.Map.keys code;
-      closure_symbols = Closure_id.Map.empty;
+      code_ids = Code_id.Lmap.keys code |> Code_id.Set.of_list;
+      closure_symbols = Closure_id.Lmap.empty;
     }]
   in
   bound_symbols, static_const

--- a/middle_end/flambda/terms/let_symbol_expr.rec.ml
+++ b/middle_end/flambda/terms/let_symbol_expr.rec.ml
@@ -16,15 +16,22 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
+module Closure_binding = struct
+  type t = {
+    symbol : Symbol.t;
+    closure_id : Closure_id.t;
+  }
+end
+
 module Bound_symbols = struct
   module Code_and_set_of_closures = struct
     type t = {
       code_ids : Code_id.Set.t;
-      closure_symbols : Symbol.t Closure_id.Map.t;
+      closure_symbols : Closure_binding.t list;
     }
 
     (* CR mshinwell: Share with [Bindable_let_bound] and below *)
-    let print_closure_binding ppf (closure_id, sym) =
+    let print_closure_binding ppf { Closure_binding.closure_id; symbol = sym } =
       Format.fprintf ppf "@[%a @<0>%s\u{21a4}@<0>%s %a@]"
         Symbol.print sym
         (Flambda_colours.elide ())
@@ -33,7 +40,7 @@ module Bound_symbols = struct
 
     let print ppf { code_ids; closure_symbols; } =
       match
-        Code_id.Set.elements code_ids, Closure_id.Map.bindings closure_symbols
+        Code_id.Set.elements code_ids, closure_symbols
       with
       | [code_id], [] ->
         Format.fprintf ppf "%a" Code_id.print code_id
@@ -50,13 +57,13 @@ module Bound_symbols = struct
           Code_id.Set.print code_ids
           (Format.pp_print_list ~pp_sep:Format.pp_print_space
             print_closure_binding)
-          (Closure_id.Map.bindings closure_symbols)
+          closure_symbols
 
     let being_defined { code_ids = _; closure_symbols; } =
-      Closure_id.Map.fold (fun _closure_id symbol being_defined ->
+      List.fold_left (fun being_defined { Closure_binding.symbol; _ } ->
           Symbol.Set.add symbol being_defined)
-        closure_symbols
         Symbol.Set.empty
+        closure_symbols
 
     let closure_symbols_being_defined t = being_defined t
 
@@ -69,17 +76,17 @@ module Bound_symbols = struct
           code_ids
           Name_occurrences.empty
       in
-      Closure_id.Map.fold (fun _closure_id closure_sym bound_names ->
-          Name_occurrences.add_symbol bound_names closure_sym Name_mode.normal)
-        closure_symbols
+      List.fold_left (fun bound_names { Closure_binding.symbol; _ } ->
+          Name_occurrences.add_symbol bound_names symbol Name_mode.normal)
         from_code_ids
+        closure_symbols
 
     let all_ids_for_export { code_ids; closure_symbols; } =
       let symbols =
-        Closure_id.Map.fold (fun _closure_id sym symbols ->
-            Symbol.Set.add sym symbols)
-          closure_symbols
+        List.fold_left (fun symbols { Closure_binding.symbol; _ } ->
+            Symbol.Set.add symbol symbols)
           Symbol.Set.empty
+          closure_symbols
       in
       Ids_for_export.create ~code_ids ~symbols ()
 
@@ -88,8 +95,12 @@ module Bound_symbols = struct
         Code_id.Set.map (Ids_for_export.Import_map.code_id import_map) code_ids
       in
       let closure_symbols =
-        Closure_id.Map.map (Ids_for_export.Import_map.symbol import_map)
-          closure_symbols
+        List.map (fun (binding : Closure_binding.t) ->
+          let symbol =
+            Ids_for_export.Import_map.symbol import_map binding.symbol
+          in
+          { binding with symbol }
+        ) closure_symbols
       in
       { code_ids; closure_symbols; }
   end
@@ -218,7 +229,7 @@ let body t = t.body
 
 type flattened_for_printing_descr =
   | Code of Code_id.t * Static_const.Code.t
-  | Set_of_closures of Symbol.t Closure_id.Map.t * Set_of_closures.t
+  | Set_of_closures of Closure_binding.t list * Set_of_closures.t
   | Other of Symbol.t * Static_const.t
 
 type flattened_for_printing = {
@@ -253,7 +264,8 @@ let flatten_for_printing { scoping_rule; bound_symbols; defining_expr; _ } =
              ({ code; set_of_closures; }
                 : Static_const.Code_and_set_of_closures.t) ->
           let flattened, _ =
-            Code_id.Map.fold (fun code_id code (flattened', first) ->
+            List.fold_left (fun (flattened', first)
+                                { Static_const.Code_binding.code_id; code } ->
                 let flattened =
                   { second_or_later_binding_within_one_set = not first;
                     second_or_later_set_of_closures;
@@ -262,14 +274,14 @@ let flatten_for_printing { scoping_rule; bound_symbols; defining_expr; _ } =
                   }
                 in
                 flattened :: flattened', false)
-              code
               ([], true)
+              code
           in
           let flattened' =
             if Set_of_closures.is_empty set_of_closures then []
             else
               let second_or_later_binding_within_one_set =
-                not (Code_id.Map.is_empty code)
+                not (code = [])
               in
               [{ second_or_later_binding_within_one_set;
                  second_or_later_set_of_closures;
@@ -287,7 +299,7 @@ let flatten_for_printing { scoping_rule; bound_symbols; defining_expr; _ } =
     in
     flattened
 
-let print_closure_binding ppf (closure_id, sym) =
+let print_closure_binding ppf { Closure_binding.closure_id; symbol = sym } =
   Format.fprintf ppf "@[%a @<0>%s\u{21a4}@<0>%s %a@]"
     Symbol.print sym
     (Flambda_colours.elide ())
@@ -305,7 +317,7 @@ let print_flattened_descr_lhs ppf descr =
             (Flambda_colours.elide ())
             (Flambda_colours.normal ()))
         print_closure_binding)
-      (Closure_id.Map.bindings closure_symbols)
+      closure_symbols
   | Other (symbol, _) -> Symbol.print ppf symbol
 
 (* CR mshinwell: Use [print_with_cache]? *)
@@ -435,18 +447,21 @@ let pieces_of_code ?newer_versions_of ?set_of_closures code =
     Option.value newer_versions_of ~default:Code_id.Map.empty
   in
   let code =
-    Code_id.Map.mapi (fun id params_and_body : Static_const.Code.t ->
+    List.map (fun (id, params_and_body) : Static_const.Code_binding.t ->
         let newer_version_of =
           Code_id.Map.find_opt id newer_versions_of
         in
-        { params_and_body = Present params_and_body;
-          newer_version_of;
+        { code_id = id;
+          code =
+            { params_and_body = Present params_and_body;
+              newer_version_of;
+            }
         })
       code
   in
   let closure_symbols, set_of_closures =
     Option.value set_of_closures
-      ~default:(Closure_id.Map.empty, Set_of_closures.empty)
+      ~default:([], Set_of_closures.empty)
   in
   let static_const : Static_const.t =
     Sets_of_closures [{
@@ -454,9 +469,10 @@ let pieces_of_code ?newer_versions_of ?set_of_closures code =
       set_of_closures;
     }]
   in
+  let code_id { Static_const.Code_binding.code_id; code = _ } = code_id in
   let bound_symbols : Bound_symbols.t =
     Sets_of_closures [{
-      code_ids = Code_id.Map.keys code;
+      code_ids = Code_id.Set.of_list (List.map code_id code);
       closure_symbols;
     }]
   in

--- a/middle_end/flambda/terms/let_symbol_expr.rec.ml
+++ b/middle_end/flambda/terms/let_symbol_expr.rec.ml
@@ -118,7 +118,13 @@ module Bound_symbols = struct
   (* CR mshinwell: This should have an [invariant] function.  One thing to
      check is that the [closure_symbols] are all distinct. *)
 
-  let invariant _ _ = ()
+  let invariant _ t =
+    match t with
+    | Singleton _ -> ()
+    | Sets_of_closures sets ->
+      List.iter (fun { Code_and_set_of_closures.closure_symbols; _ } ->
+        Closure_id.Lmap.invariant closure_symbols
+      ) sets
 
   let being_defined t =
     match t with
@@ -387,8 +393,9 @@ let print_with_cache ~cache ppf t =
 let print ppf t = print_with_cache ~cache:(Printing_cache.create ()) ppf t
 
 let invariant env
-      { scoping_rule = _; bound_symbols = _; defining_expr = _; body; } =
+      { scoping_rule = _; bound_symbols; defining_expr = _; body; } =
   (* Static_const.invariant env defining_expr; *) (* CR mshinwell: FIXME *)
+  Bound_symbols.invariant env bound_symbols;
   Expr.invariant env body
 
 let free_names { scoping_rule = _; bound_symbols; defining_expr; body; } =

--- a/middle_end/flambda/terms/let_symbol_expr.rec.mli
+++ b/middle_end/flambda/terms/let_symbol_expr.rec.mli
@@ -18,12 +18,18 @@
 
 (** The form of expression that binds symbols to statically-allocated
     constants. *)
+module Closure_binding : sig
+  type t = {
+    symbol : Symbol.t;
+    closure_id : Closure_id.t;
+  }
+end
 
 module Bound_symbols : sig
   module Code_and_set_of_closures : sig
     type t = {
       code_ids : Code_id.Set.t;
-      closure_symbols : Symbol.t Closure_id.Map.t;
+      closure_symbols : Closure_binding.t list;
       (* CR mshinwell: keep a separate field for the symbols being defined? *)
     }
 
@@ -81,8 +87,8 @@ include Contains_ids.S with type t := t
     version of [id2]. *)
 val pieces_of_code
    : ?newer_versions_of:Code_id.t Code_id.Map.t
-  -> ?set_of_closures:(Symbol.t Closure_id.Map.t * Set_of_closures.t)
-  -> Function_params_and_body.t Code_id.Map.t
+  -> ?set_of_closures:(Closure_binding.t list * Set_of_closures.t)
+  -> (Code_id.t * Function_params_and_body.t) list
   -> Bound_symbols.t * Static_const.t
 
 val deleted_pieces_of_code

--- a/middle_end/flambda/terms/let_symbol_expr.rec.mli
+++ b/middle_end/flambda/terms/let_symbol_expr.rec.mli
@@ -18,18 +18,11 @@
 
 (** The form of expression that binds symbols to statically-allocated
     constants. *)
-module Closure_binding : sig
-  type t = {
-    symbol : Symbol.t;
-    closure_id : Closure_id.t;
-  }
-end
-
 module Bound_symbols : sig
   module Code_and_set_of_closures : sig
     type t = {
       code_ids : Code_id.Set.t;
-      closure_symbols : Closure_binding.t list;
+      closure_symbols : Symbol.t Closure_id.Lmap.t;
       (* CR mshinwell: keep a separate field for the symbols being defined? *)
     }
 
@@ -87,8 +80,8 @@ include Contains_ids.S with type t := t
     version of [id2]. *)
 val pieces_of_code
    : ?newer_versions_of:Code_id.t Code_id.Map.t
-  -> ?set_of_closures:(Closure_binding.t list * Set_of_closures.t)
-  -> (Code_id.t * Function_params_and_body.t) list
+  -> ?set_of_closures:(Symbol.t Closure_id.Lmap.t * Set_of_closures.t)
+  -> Function_params_and_body.t Code_id.Lmap.t
   -> Bound_symbols.t * Static_const.t
 
 val deleted_pieces_of_code

--- a/middle_end/flambda/terms/static_const.rec.mli
+++ b/middle_end/flambda/terms/static_const.rec.mli
@@ -55,21 +55,11 @@ end
 (* CR mshinwell: Somewhere there should be an invariant check that
    code has no free names. *)
 
-(** The definition of a single piece of code. *)
-module Code_binding : sig
-  type t = {
-    code_id : Code_id.t;
-    code : Code.t
-  }
-
-  val of_pair : Code_id.t * Code.t -> t
-end
-
 (** The possibly-recursive declaration of pieces of code and any associated set
     of closures. *)
 module Code_and_set_of_closures : sig
   type t = {
-    code : Code_binding.t list;
+    code : Code.t Code_id.Lmap.t;
     (* CR mshinwell: Check the free names of the set of closures *)
     set_of_closures : Set_of_closures.t;
   }
@@ -98,9 +88,9 @@ include Identifiable.S with type t := t
 include Contains_names.S with type t := t
 include Contains_ids.S with type t := t
 
-val get_pieces_of_code : t -> Code_binding.t list
+val get_pieces_of_code : t -> Code.t Code_id.Lmap.t
 
-val get_pieces_of_code' : t -> Function_params_and_body.t Code_id.Map.t
+val get_pieces_of_code' : t -> Function_params_and_body.t Code_id.Lmap.t
 
 val is_fully_static : t -> bool
 

--- a/middle_end/flambda/terms/static_const.rec.mli
+++ b/middle_end/flambda/terms/static_const.rec.mli
@@ -55,11 +55,21 @@ end
 (* CR mshinwell: Somewhere there should be an invariant check that
    code has no free names. *)
 
+(** The definition of a single piece of code. *)
+module Code_binding : sig
+  type t = {
+    code_id : Code_id.t;
+    code : Code.t
+  }
+
+  val of_pair : Code_id.t * Code.t -> t
+end
+
 (** The possibly-recursive declaration of pieces of code and any associated set
     of closures. *)
 module Code_and_set_of_closures : sig
   type t = {
-    code : Code.t Code_id.Map.t;
+    code : Code_binding.t list;
     (* CR mshinwell: Check the free names of the set of closures *)
     set_of_closures : Set_of_closures.t;
   }
@@ -88,7 +98,7 @@ include Identifiable.S with type t := t
 include Contains_names.S with type t := t
 include Contains_ids.S with type t := t
 
-val get_pieces_of_code : t -> Code.t Code_id.Map.t
+val get_pieces_of_code : t -> Code_binding.t list
 
 val get_pieces_of_code' : t -> Function_params_and_body.t Code_id.Map.t
 

--- a/utils/identifiable.ml
+++ b/utils/identifiable.ml
@@ -172,15 +172,7 @@ module Make_map (T : Thing) (Set : Set with module T := T) = struct
     of_list (List.map (fun (k, v) -> f k, v) (bindings m))
 
   let print print_datum ppf t =
-    if is_empty t then
-      Format.fprintf ppf "{}"
-    else
-      Format.fprintf ppf "@[<hov 1>{%a}@]"
-        (Format.pp_print_list ~pp_sep:Format.pp_print_space
-          (fun ppf (key, datum) ->
-            Format.fprintf ppf "@[<hov 1>(%a@ %a)@]"
-              T.print key print_datum datum))
-        (bindings t)
+    Misc.print_assoc T.print print_datum ppf (bindings t)
 
   let keys map = fold (fun k _ set -> Set.add k set) map Set.empty
 

--- a/utils/lmap.ml
+++ b/utils/lmap.ml
@@ -1,0 +1,84 @@
+module type Thing = sig
+  type t
+
+  val equal : t -> t -> bool
+
+  val print : Format.formatter -> t -> unit
+end
+
+module type S = sig
+  type key
+
+  type (+'a) t
+
+  val empty : 'a t
+  val is_empty : 'a t -> bool
+  val add : key -> 'a -> 'a t -> 'a t
+  val singleton : key -> 'a -> 'a t
+  val disjoint_union : 'a t -> 'a t -> 'a t
+  val disjoint_union_many : 'a t list -> 'a t
+  val iter : (key -> 'a -> unit) -> 'a t -> unit
+  val fold : (key -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
+  val filter : (key -> 'a -> bool) -> 'a t -> 'a t
+  val keys : _ t -> key list
+  val data : 'a t -> 'a list
+  val bindings : 'a t -> (key * 'a) list
+  val of_list : (key * 'a) list -> 'a t
+  val find : key -> 'a t -> 'a
+  val find_opt : key -> 'a t -> 'a option
+  val get_singleton : 'a t -> (key * 'a) option
+  val get_singleton_exn : 'a t -> key * 'a
+  val map: ('a -> 'b) -> 'a t -> 'b t
+  val mapi: (key -> 'a -> 'b) -> 'a t -> 'b t
+  val map_sharing: ('a -> 'a) -> 'a t -> 'a t
+  val filter_map: 'a t -> f:(key -> 'a -> 'b option) -> 'b t
+  val to_seq : 'a t -> (key * 'a) Seq.t
+  val add_seq : (key * 'a) Seq.t -> 'a t -> 'a t
+  val of_seq : (key * 'a) Seq.t -> 'a t
+
+  val print :
+    (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
+end
+
+module Make (T : Thing) : S with type key = T.t = struct
+  type key = T.t
+
+  type (+'a) t = (key * 'a) list
+
+  let empty = []
+  let is_empty m = m = []
+  let add k v m = (k, v) :: m
+  let singleton k v = [(k, v)]
+  let disjoint_union m1 m2 = m1 @ m2
+  let disjoint_union_many ms = List.concat ms
+  let iter f m = List.iter (fun (k, v) -> f k v) m
+  let fold f m b = List.fold_left (fun b (k, v) -> f k v b) b m
+  let filter p m = List.filter (fun (k, v) -> p k v) m
+  let keys m = List.map fst m
+  let data m = List.map snd m
+  let bindings m = m
+  let of_list m = m
+  let find_opt k m =
+    List.find_map (fun (k', v) -> if T.equal k k' then Some v else None) m
+  let find k m = match find_opt k m with
+    | Some v -> v
+    | None -> raise Not_found
+  let get_singleton = function
+    | [(k, v)] -> Some (k, v)
+    | _ -> None
+  let get_singleton_exn = function
+    | [(k, v)] -> (k, v)
+    | _ -> raise Not_found
+  let map f m = List.map (fun (k, v) -> k, f v) m
+  let mapi f m = List.map (fun (k, v) -> k, f k v) m
+  let map_sharing f m = Misc.Stdlib.List.map_sharing (fun ((k, v) as pair) ->
+    let v' = f v in if v' == v then pair else k, v') m
+  let filter_map m ~f = List.filter_map (fun (k, v) ->
+    f k v |> Option.map (fun v' -> k, v')) m
+  let to_seq m = List.to_seq m
+  let rec add_seq s m = match s () with
+    | Seq.Nil -> m
+    | Seq.Cons (pair, s') -> pair :: add_seq s' m
+  let of_seq m = List.of_seq m
+  let print f fmt m = Misc.print_assoc T.print f fmt m
+end

--- a/utils/lmap.ml
+++ b/utils/lmap.ml
@@ -38,6 +38,8 @@ module type S = sig
 
   val print :
     (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
+
+  val invariant : 'a t -> unit
 end
 
 module Make (T : Thing) : S with type key = T.t = struct
@@ -47,31 +49,10 @@ module Make (T : Thing) : S with type key = T.t = struct
 
   let empty = []
   let is_empty m = m = []
-  let rec remove k m = match m with
-    | [] -> []
-    | ((k', _) as pair) :: m -> if T.equal k k' then m else pair :: remove k m
-  let add k v m = (k, v) :: remove k m
+  let add k v m = (k, v) :: m
   let singleton k v = [(k, v)]
-  let check_for_absence k m =
-    List.iter (fun (k', _) ->
-      if T.equal k k' then invalid_arg "disjoint_union"
-    ) m
-  let disjoint_union m1 m2 =
-    List.iter (fun (k, _) -> check_for_absence k m2) m1;
-    m1 @ m2
-  let disjoint_union_many ms =
-    let rec loop ms prev =
-      match ms with
-      | [] -> ()
-      | m :: ms ->
-          List.iter (fun (k, _) ->
-            List.iter (check_for_absence k) ms;
-            List.iter (check_for_absence k) prev
-          ) m;
-          loop ms (m :: prev)
-    in
-    loop ms [];
-    List.concat ms
+  let disjoint_union m1 m2 = m1 @ m2
+  let disjoint_union_many ms = List.concat ms
   let iter f m = List.iter (fun (k, v) -> f k v) m
   let fold f m b = List.fold_left (fun b (k, v) -> f k v b) b m
   let filter p m = List.filter (fun (k, v) -> p k v) m
@@ -102,4 +83,12 @@ module Make (T : Thing) : S with type key = T.t = struct
     | Seq.Cons (pair, s') -> pair :: add_seq s' m
   let of_seq m = List.of_seq m
   let print f fmt m = Misc.print_assoc T.print f fmt m
+
+  let rec invariant m = match m with
+    | [] -> ()
+    | (k, _) :: m ->
+      List.iter (fun (k', _) ->
+        if T.equal k k' then Misc.fatal_errorf "Duplicate key: %a" T.print k
+      ) m;
+      invariant m
 end

--- a/utils/lmap.mli
+++ b/utils/lmap.mli
@@ -53,11 +53,14 @@ module type S = sig
 
   val empty : 'a t
   val is_empty : 'a t -> bool
+
   (** The key should not already exist in the map; this is not checked. *)
   val add : key -> 'a -> 'a t -> 'a t
   val singleton : key -> 'a -> 'a t
+  
   (** Unlike [disjoint_union] on maps, the disjointness is not checked. *)
   val disjoint_union : 'a t -> 'a t -> 'a t
+  
   (** The given maps must be pairwise disjoint, which is not checked. *)
   val disjoint_union_many: 'a t list -> 'a t
   val iter : (key -> 'a -> unit) -> 'a t -> unit
@@ -66,6 +69,7 @@ module type S = sig
   val keys : _ t -> key list
   val data : 'a t -> 'a list
   val bindings : 'a t -> (key * 'a) list
+  
   (** Keys in the list must be distinct, which is not checked. *)
   val of_list : (key * 'a) list -> 'a t
   val find : key -> 'a t -> 'a
@@ -77,9 +81,11 @@ module type S = sig
   val map_sharing: ('a -> 'a) -> 'a t -> 'a t
   val filter_map: 'a t -> f:(key -> 'a -> 'b option) -> 'b t
   val to_seq : 'a t -> (key * 'a) Seq.t
+  
   (** Keys in the sequence must be distinct from each other and from keys
       already in the map; neither of these conditions is checked. *)
   val add_seq : (key * 'a) Seq.t -> 'a t -> 'a t
+  
   (** Keys in the sequence must be distinct, which is not checked. *)
   val of_seq : (key * 'a) Seq.t -> 'a t
 

--- a/utils/lmap.mli
+++ b/utils/lmap.mli
@@ -1,0 +1,67 @@
+
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Pierre Chambart, OCamlPro                        *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2013--2016 OCamlPro SAS                                    *)
+(*   Copyright 2014--2016 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(**
+
+  {b Warning:} this module is unstable and part of
+  {{!Compiler_libs}compiler-libs}.
+
+*)
+
+module type Thing = sig
+  type t
+
+  val equal : t -> t -> bool
+
+  val print : Format.formatter -> t -> unit
+end
+
+module type S = sig
+  type key
+
+  type (+'a) t
+
+  val empty : 'a t
+  val is_empty : 'a t -> bool
+  val add : key -> 'a -> 'a t -> 'a t
+  val singleton : key -> 'a -> 'a t
+  val disjoint_union : 'a t -> 'a t -> 'a t
+  val disjoint_union_many: 'a t list -> 'a t
+  val iter : (key -> 'a -> unit) -> 'a t -> unit
+  val fold : (key -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
+  val filter : (key -> 'a -> bool) -> 'a t -> 'a t
+  val keys : _ t -> key list
+  val data : 'a t -> 'a list
+  val bindings : 'a t -> (key * 'a) list
+  val of_list : (key * 'a) list -> 'a t
+  val find : key -> 'a t -> 'a
+  val find_opt : key -> 'a t -> 'a option
+  val get_singleton : 'a t -> (key * 'a) option
+  val get_singleton_exn : 'a t -> key * 'a
+  val map: ('a -> 'b) -> 'a t -> 'b t
+  val mapi: (key -> 'a -> 'b) -> 'a t -> 'b t
+  val map_sharing: ('a -> 'a) -> 'a t -> 'a t
+  val filter_map: 'a t -> f:(key -> 'a -> 'b option) -> 'b t
+  val to_seq : 'a t -> (key * 'a) Seq.t
+  val add_seq : (key * 'a) Seq.t -> 'a t -> 'a t
+  val of_seq : (key * 'a) Seq.t -> 'a t
+
+  val print :
+    (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
+end
+
+module Make (T : Thing) : S with type key = T.t

--- a/utils/lmap.mli
+++ b/utils/lmap.mli
@@ -20,7 +20,23 @@
   {b Warning:} this module is unstable and part of
   {{!Compiler_libs}compiler-libs}.
 
+  This module supports lists of key-value pairs that aren't intended for
+  fast lookup. These are suitable for use in ASTs, where it's uncommon to look
+  up a value directly but very common to fold over the list to produce an
+  environment that is a true Map. They also preserve the order of the elements,
+  which is necessary for performing comparisons up to renaming of closure ids
+  and code ids.
+
+  Several operations on Map are provided here for consistency, but they do not
+  necessarily provide the same checks that a Map would and in most cases the
+  performance is different. Behavior will be the same provided that there are
+  never duplicate keys. You can manually invoke [invariant] to check for
+  duplicates.
 *)
+
+(* CR-soon lmaurer: It would be nice to have convenience functions for
+   conversion between maps and lmaps; this is complicated by the need to be
+   passed the Map.S implementation for the key type. *)
 
 module type Thing = sig
   type t
@@ -62,6 +78,10 @@ module type S = sig
 
   val print :
     (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
+
+  (** Check that there are no duplicates in the list, calling
+      [Misc.fatal_errorf] if a duplicate is found. *)
+  val invariant : 'a t -> unit
 end
 
 module Make (T : Thing) : S with type key = T.t

--- a/utils/lmap.mli
+++ b/utils/lmap.mli
@@ -53,9 +53,12 @@ module type S = sig
 
   val empty : 'a t
   val is_empty : 'a t -> bool
+  (** The key should not already exist in the map; this is not checked. *)
   val add : key -> 'a -> 'a t -> 'a t
   val singleton : key -> 'a -> 'a t
+  (** Unlike [disjoint_union] on maps, the disjointness is not checked. *)
   val disjoint_union : 'a t -> 'a t -> 'a t
+  (** The given maps must be pairwise disjoint, which is not checked. *)
   val disjoint_union_many: 'a t list -> 'a t
   val iter : (key -> 'a -> unit) -> 'a t -> unit
   val fold : (key -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
@@ -63,6 +66,7 @@ module type S = sig
   val keys : _ t -> key list
   val data : 'a t -> 'a list
   val bindings : 'a t -> (key * 'a) list
+  (** Keys in the list must be distinct, which is not checked. *)
   val of_list : (key * 'a) list -> 'a t
   val find : key -> 'a t -> 'a
   val find_opt : key -> 'a t -> 'a option
@@ -73,7 +77,10 @@ module type S = sig
   val map_sharing: ('a -> 'a) -> 'a t -> 'a t
   val filter_map: 'a t -> f:(key -> 'a -> 'b option) -> 'b t
   val to_seq : 'a t -> (key * 'a) Seq.t
+  (** Keys in the sequence must be distinct from each other and from keys
+      already in the map; neither of these conditions is checked. *)
   val add_seq : (key * 'a) Seq.t -> 'a t -> 'a t
+  (** Keys in the sequence must be distinct, which is not checked. *)
   val of_seq : (key * 'a) Seq.t -> 'a t
 
   val print :

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -368,6 +368,14 @@ module Stdlib = struct
       | a1::l1, a2::l2, a3::l3, a4::l4 ->
         fold_left4 f (f accu a1 a2 a3 a4) l1 l2 l3 l4
       | _, _, _, _ -> invalid_arg "List.fold_left4"
+
+    let rec map_sharing f l0 =
+      match l0 with
+      | a::l ->
+        let a' = f a in
+        let l' = map_sharing f l in
+        if a' == a && l' == l then l0 else a' :: l'
+      | [] -> []
   end
 
   module Option = struct
@@ -866,6 +874,18 @@ let pp_two_columns ?(sep = "|") ?max_lines ppf (lines: (string * string) list) =
     else Format.fprintf ppf "%*s %s %s@," left_column_size line_l sep line_r
   ) lines;
   Format.fprintf ppf "@]"
+
+let print_assoc print_key print_datum ppf l =
+  if l = [] then
+    Format.fprintf ppf "{}"
+  else
+    Format.fprintf ppf "@[<hov 1>{%a}@]"
+      (Format.pp_print_list ~pp_sep:Format.pp_print_space
+        (fun ppf (key, datum) ->
+          Format.fprintf ppf "@[<hov 1>(%a@ %a)@]"
+            print_key key print_datum datum))
+      l
+
 
 (* showing configuration and configuration variables *)
 let show_config_and_exit () =

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -150,6 +150,10 @@ module Stdlib : sig
       -> 'd list
       -> 'e list
       -> 'a
+
+    val map_sharing : ('a -> 'a) -> 'a t -> 'a t
+    (** Returns the original list if the function always returns a value
+        physically equal to its argument *)
   end
 
   module Option : sig
@@ -472,6 +476,11 @@ val pp_two_columns :
     bb  | dddddd
     v}
 *)
+
+(** Format an association list as a sequence of key-value pairs. *)
+val print_assoc :
+  (Format.formatter -> 'a -> unit) -> (Format.formatter -> 'b -> unit) ->
+  Format.formatter -> ('a * 'b) list -> unit
 
 (** configuration variables *)
 val show_config_and_exit : unit -> unit


### PR DESCRIPTION
Most places where a map is being stored in an Flambda AST don't actually
need a map---the only operation performed on them is a fold.  This is
wasteful, and also it will make it harder to perform comparisons on
Flambda programs.