### PR TITLE
Stop generating duplicated partial application wrappers

### DIFF
--- a/middle_end/flambda/simplify/env/simplify_env_and_result.ml
+++ b/middle_end/flambda/simplify/env/simplify_env_and_result.ml
@@ -806,6 +806,16 @@ end = struct
     create_pieces_of_code denv ?newer_versions_of
       (Code_id.Map.singleton code_id params_and_body)
 
+  let create_deleted_piece_of_code denv ?newer_versions_of code_id =
+    let bound_symbols, defining_expr =
+      Let_symbol.deleted_pieces_of_code ?newer_versions_of
+        (Code_id.Set.singleton code_id)
+    in
+    { denv;
+      bound_symbols;
+      defining_expr;
+      types_of_symbols = Symbol.Map.empty;
+    }
   let denv_at_definition t = t.denv
   let bound_symbols t = t.bound_symbols
   let defining_expr t = t.defining_expr

--- a/middle_end/flambda/simplify/env/simplify_env_and_result_intf.ml
+++ b/middle_end/flambda/simplify/env/simplify_env_and_result_intf.ml
@@ -342,6 +342,12 @@ module type Lifted_constant = sig
     -> Flambda.Function_params_and_body.t Code_id.Map.t
     -> t
 
+  val create_deleted_piece_of_code
+     : downwards_env
+    -> ?newer_versions_of:Code_id.t Code_id.Map.t
+    -> Code_id.t
+    -> t
+
   val denv_at_definition : t -> downwards_env
   val bound_symbols : t -> Flambda.Let_symbol_expr.Bound_symbols.t
   val defining_expr : t -> Flambda.Static_const.t

--- a/middle_end/flambda/simplify/simplify_expr.rec.ml
+++ b/middle_end/flambda/simplify/simplify_expr.rec.ml
@@ -919,14 +919,22 @@ and simplify_direct_partial_application
     let closure_elements =
       Var_within_closure.Map.of_list applied_args_with_closure_vars
     in
-    (* CR mshinwell: Factor out this next part into a helper function *)
+    let dummy_code =
+      (* We should not add the real piece of code as a lifted constant.
+         A new piece of code will always be generated when the [Let] we
+         generate below is simplified.  As such we can simply add a lifted
+         constant identifying deleted code.  This will ensure, if for some
+         reason the constant makes it to Cmm stage, that code size is not
+         increased unnecessarily. *)
+      Lifted_constant.create_deleted_piece_of_code (DA.denv dacc) code_id
+    in
     let code =
       Lifted_constant.create_piece_of_code (DA.denv dacc) code_id
         params_and_body
     in
     let dacc =
       dacc
-      |> DA.map_r ~f:(fun r -> R.new_lifted_constant r code)
+      |> DA.map_r ~f:(fun r -> R.new_lifted_constant r dummy_code)
       |> DA.map_denv ~f:(fun denv ->
         DE.add_lifted_constants denv ~lifted:[code])
     in

--- a/middle_end/flambda/terms/flambda.mli
+++ b/middle_end/flambda/terms/flambda.mli
@@ -291,6 +291,11 @@ end and Let_symbol_expr : sig
     -> ?set_of_closures:(Symbol.t Closure_id.Map.t * Set_of_closures.t)
     -> Function_params_and_body.t Code_id.Map.t
     -> Bound_symbols.t * Static_const.t
+
+  val deleted_pieces_of_code
+     : ?newer_versions_of:Code_id.t Code_id.Map.t
+    -> Code_id.Set.t
+    -> Bound_symbols.t * Static_const.t
 end and Let_cont_expr : sig
   (** Values of type [t] represent alpha-equivalence classes of the definitions
       of continuations:

--- a/middle_end/flambda/terms/let_symbol_expr.rec.ml
+++ b/middle_end/flambda/terms/let_symbol_expr.rec.ml
@@ -461,3 +461,35 @@ let pieces_of_code ?newer_versions_of ?set_of_closures code =
     }]
   in
   bound_symbols, static_const
+
+let deleted_pieces_of_code ?newer_versions_of code_ids =
+  let newer_versions_of =
+    Option.value newer_versions_of ~default:Code_id.Map.empty
+  in
+  let code =
+    Code_id.Set.fold (fun id code_map ->
+        let newer_version_of =
+          Code_id.Map.find_opt id newer_versions_of
+        in
+        let code : Static_const.Code.t =
+          { params_and_body = Deleted;
+            newer_version_of;
+          }
+        in
+        Code_id.Map.add id code code_map)
+      code_ids
+      Code_id.Map.empty
+  in
+  let static_const : Static_const.t =
+    Sets_of_closures [{
+      code;
+      set_of_closures = Set_of_closures.empty;
+    }]
+  in
+  let bound_symbols : Bound_symbols.t =
+    Sets_of_closures [{
+      code_ids = Code_id.Map.keys code;
+      closure_symbols = Closure_id.Map.empty;
+    }]
+  in
+  bound_symbols, static_const

--- a/middle_end/flambda/terms/let_symbol_expr.rec.mli
+++ b/middle_end/flambda/terms/let_symbol_expr.rec.mli
@@ -84,3 +84,8 @@ val pieces_of_code
   -> ?set_of_closures:(Symbol.t Closure_id.Map.t * Set_of_closures.t)
   -> Function_params_and_body.t Code_id.Map.t
   -> Bound_symbols.t * Static_const.t
+
+val deleted_pieces_of_code
+   : ?newer_versions_of:Code_id.t Code_id.Map.t
+  -> Code_id.Set.t
+  -> Bound_symbols.t * Static_const.t


### PR DESCRIPTION
It's guaranteed that a new version of the code for these wrappers will be produced (yielding a `Let_symbol`) when the `Let` generated by the partial application code binding the set of closures is simplified.  So there should be no need for a second constant actually containing code, only for the code age relation.