### PR TITLE
Use the simplified body of functions to compute function types

### DIFF
--- a/middle_end/flambda/inlining/inlining_decision.ml
+++ b/middle_end/flambda/inlining/inlining_decision.ml
@@ -45,7 +45,7 @@ module Function_declaration_decision = struct
     | Inline -> true
 end
 
-let make_decision_for_function_declaration denv function_decl
+let make_decision_for_function_declaration denv ?params_and_body function_decl
       : Function_declaration_decision.t =
   (* At present, we follow Closure, taking inlining decisions without
      first examining call sites. *)
@@ -56,7 +56,12 @@ let make_decision_for_function_declaration denv function_decl
     if Function_declaration.stub function_decl then Stub
     else
       let code_id = Function_declaration.code_id function_decl in
-      let params_and_body = DE.find_code denv code_id in
+      let params_and_body =
+        match params_and_body with
+        | None ->
+          DE.find_code denv code_id
+        | Some params_and_body -> params_and_body
+      in
       Function_params_and_body.pattern_match params_and_body
         ~f:(fun ~return_continuation:_ _exn_continuation _params ~body
                 ~my_closure:_ : Function_declaration_decision.t ->

--- a/middle_end/flambda/inlining/inlining_decision.mli
+++ b/middle_end/flambda/inlining/inlining_decision.mli
@@ -30,6 +30,7 @@ end
 
 val make_decision_for_function_declaration
    : Simplify_env_and_result.Downwards_env.t
+  -> ?params_and_body:Function_params_and_body.t
   -> Function_declaration.t
   -> Function_declaration_decision.t
 

--- a/middle_end/flambda/simplify/simplify_set_of_closures.rec.ml
+++ b/middle_end/flambda/simplify/simplify_set_of_closures.rec.ml
@@ -406,7 +406,7 @@ let simplify_function context r closure_id function_decl
     let function_decl = FD.update_code_id function_decl new_code_id in
     let function_type =
       (* We need to use [dacc_after_body] to ensure that all [code_ids] in
-         [function_decl] are available for the inlining decision code. *)
+         [params_and_body] are available for the inlining decision code. *)
       function_decl_type (DA.denv dacc_after_body) function_decl
         ~params_and_body Rec_info.initial
     in

--- a/middle_end/flambda/simplify/simplify_set_of_closures.rec.ml
+++ b/middle_end/flambda/simplify/simplify_set_of_closures.rec.ml
@@ -22,10 +22,10 @@ open! Simplify_import
    simplification of sets of closures, taking the used-var-in-closures
    set from the previous round. *)
 
-let function_decl_type denv function_decl ?code_id rec_info =
+let function_decl_type denv function_decl ?code_id ?params_and_body rec_info =
   let decision =
     Inlining_decision.make_decision_for_function_declaration
-      denv function_decl
+      denv ?params_and_body function_decl
   in
   let code_id = Option.value code_id ~default:(FD.code_id function_decl) in
   if Inlining_decision.Function_declaration_decision.can_inline decision then
@@ -408,7 +408,7 @@ let simplify_function context r closure_id function_decl
       (* We need to use [dacc_after_body] to ensure that all [code_ids] in
          [function_decl] are available for the inlining decision code. *)
       function_decl_type (DA.denv dacc_after_body) function_decl
-        Rec_info.initial
+        ~params_and_body Rec_info.initial
     in
     let code_age_relation =
       TE.code_age_relation (DA.typing_env dacc_after_body)


### PR DESCRIPTION
Function types are computed in two places:
- As part of the context for simplifying sets of closures (this case is unchanged, as the bodies haven't been simplified yet anyway)
- In `simplify_function`, to compute the result type. In this last case, since the new `params_and_body` hasn't been added to the code map yet, the function type computation reused the old body despite the new one being available. This is now fixed to use the new body.