### PR TITLE
Compute reachability of exported names and code IDs to reduce size of cmx

### DIFF
--- a/middle_end/flambda/cmx/exported_code.mli
+++ b/middle_end/flambda/cmx/exported_code.mli
@@ -38,4 +38,11 @@ val mem : Code_id.t -> t -> bool
 
 val find_code : t -> Code_id.t -> Flambda.Function_params_and_body.t
 
+val find_code_if_not_imported
+   : t
+  -> Code_id.t
+  -> Flambda.Function_params_and_body.t option
+
 val find_calling_convention : t -> Code_id.t -> Calling_convention.t
+
+val remove_unreachable : t -> reachable_names:Name_occurrences.t -> t

--- a/middle_end/flambda/cmx/flambda_cmx.ml
+++ b/middle_end/flambda/cmx/flambda_cmx.ml
@@ -51,6 +51,58 @@ let rec load_cmx_file_contents backend comp_unit ~imported_units ~imported_names
         Compilation_unit.Map.add comp_unit (Some typing_env) !imported_units;
       Some typing_env
 
+let compute_reachable_names_and_code ~module_symbol typing_env code =
+  let rec fixpoint names_to_add names_already_added =
+    if Name_occurrences.is_empty names_to_add
+    then names_already_added
+    else begin
+      let names_already_added =
+        Name_occurrences.union names_to_add names_already_added
+      in
+      let fold_code_id names_to_add code_id =
+        match Exported_code.find_code_if_not_imported code code_id with
+        | None -> names_to_add
+        | Some params_and_body ->
+          let params_and_body_names =
+            Function_params_and_body.free_names params_and_body
+          in
+          let names_to_consider =
+            Name_occurrences.with_only_names_and_code_ids params_and_body_names
+          in
+          let new_names =
+            Name_occurrences.diff names_to_consider names_already_added
+          in
+          Name_occurrences.union new_names names_to_add
+      in
+      let fold_name names_to_add name =
+        let ty = TE.find typing_env name None in
+        let ty_names = T.free_names ty in
+        let names_to_consider =
+          Name_occurrences.with_only_names_and_code_ids ty_names
+        in
+        let new_names =
+          Name_occurrences.diff names_to_consider names_already_added
+        in
+        Name_occurrences.union new_names names_to_add
+      in
+      let from_code_ids =
+        Name_occurrences.fold_code_ids names_to_add
+          ~init:Name_occurrences.empty
+          ~f:fold_code_id
+      in
+      let from_names_and_code_ids =
+        Name_occurrences.fold_names names_to_add
+          ~init:from_code_ids
+          ~f:fold_name
+      in
+      fixpoint from_names_and_code_ids names_already_added
+    end
+  in
+  let init_names =
+    Name_occurrences.singleton_symbol module_symbol Name_mode.normal
+  in
+  fixpoint init_names Name_occurrences.empty
+
 let prepare_cmx_file_contents ~return_cont_env:cont_uses_env
       ~return_continuation ~module_symbol all_code =
   match
@@ -62,8 +114,14 @@ let prepare_cmx_file_contents ~return_cont_env:cont_uses_env
   | Some final_typing_env ->
     (* CR mshinwell: We should remove typing information about names that
        do not occur (transitively) in the type of the module block. *)
+    let reachable_names =
+      compute_reachable_names_and_code ~module_symbol final_typing_env all_code
+    in
+    let all_code =
+      Exported_code.remove_unreachable all_code ~reachable_names
+    in
     let final_typing_env =
-      TE.clean_for_export final_typing_env ~module_symbol
+      TE.clean_for_export final_typing_env ~reachable_names
       |> TE.Serializable.create
     in
     let exported_offsets =

--- a/middle_end/flambda/cmx/flambda_cmx.ml
+++ b/middle_end/flambda/cmx/flambda_cmx.ml
@@ -75,15 +75,19 @@ let compute_reachable_names_and_code ~module_symbol typing_env code =
           Name_occurrences.union new_names names_to_add
       in
       let fold_name names_to_add name =
-        let ty = TE.find typing_env name None in
-        let ty_names = T.free_names ty in
-        let names_to_consider =
-          Name_occurrences.with_only_names_and_code_ids ty_names
-        in
-        let new_names =
-          Name_occurrences.diff names_to_consider names_already_added
-        in
-        Name_occurrences.union new_names names_to_add
+        match TE.find_or_missing typing_env name with
+        | Some ty ->
+          let ty_names = T.free_names ty in
+          let names_to_consider =
+            Name_occurrences.with_only_names_and_code_ids ty_names
+          in
+          let new_names =
+            Name_occurrences.diff names_to_consider names_already_added
+          in
+          Name_occurrences.union new_names names_to_add
+        | None ->
+          (* A missing type cannot refer to names defined in the current unit *)
+          names_to_add
       in
       let from_code_ids =
         Name_occurrences.fold_code_ids names_to_add

--- a/middle_end/flambda/naming/name_occurrences.ml
+++ b/middle_end/flambda/naming/name_occurrences.ml
@@ -921,6 +921,12 @@ let with_only_variables { names; _ } =
     names;
   }
 
+let with_only_names_and_code_ids { names; code_ids; _ } =
+  { empty with
+    names;
+    code_ids;
+  }
+
 let without_code_ids t =
   { t with
     code_ids = For_code_ids.empty;
@@ -942,3 +948,6 @@ let fold_continuations_including_in_trap_actions t ~init ~f =
 let filter_names t ~f =
   let names = For_names.filter t.names ~f in
   { t with names; }
+
+let fold_code_ids t ~init ~f =
+  For_code_ids.fold t.code_ids ~init ~f

--- a/middle_end/flambda/naming/name_occurrences.mli
+++ b/middle_end/flambda/naming/name_occurrences.mli
@@ -124,6 +124,8 @@ val without_code_ids : t -> t
 
 val with_only_variables :  t -> t
 
+val with_only_names_and_code_ids :  t -> t
+
 val mem_var : t -> Variable.t -> bool
 
 val mem_symbol : t -> Symbol.t -> bool
@@ -169,4 +171,10 @@ val fold_continuations_including_in_trap_actions
    : t
   -> init:'a
   -> f:('a -> Continuation.t -> 'a)
+  -> 'a
+
+val fold_code_ids
+   : t
+  -> init:'a
+  -> f:('a -> Code_id.t -> 'a)
   -> 'a

--- a/middle_end/flambda/types/env/aliases.ml
+++ b/middle_end/flambda/types/env/aliases.ml
@@ -568,7 +568,7 @@ let merge t1 t2 =
                 if Binding_time.(equal (With_name_mode.binding_time data1)
                                    imported_variables)
                 then Some data2
-                else if Binding_time.(equal (With_name_mode.binding_time data1)
+                else if Binding_time.(equal (With_name_mode.binding_time data2)
                                    imported_variables)
                 then Some data1
                 else

--- a/middle_end/flambda/types/env/typing_env.rec.ml
+++ b/middle_end/flambda/types/env/typing_env.rec.ml
@@ -56,7 +56,7 @@ module Cached : sig
 
   val with_cse : t -> cse:Simple.t Flambda_primitive.Eligible_for_cse.Map.t -> t
 
-  val clean_for_export : t -> module_symbol:Symbol.t -> t
+  val clean_for_export : t -> reachable_names:Name_occurrences.t -> t
 
   val import : Ids_for_export.Import_map.t -> t -> t
 
@@ -146,10 +146,10 @@ end = struct
 
   let with_cse t ~cse = { t with cse; }
 
-  let clean_for_export t =
+  let clean_for_export t ~reachable_names =
     (* Two things happen:
        - All variables are existentialized (mode is switched to in_types)
-       - Names coming from other compilation units are removed
+       - Names coming from other compilation units or unreachable are removed
     *)
     let names_to_types =
       Name.Map.mapi (fun name ((ty, binding_time, _mode) as info) ->
@@ -161,16 +161,14 @@ end = struct
     let current_compilation_unit = Compilation_unit.get_current_exn () in
     let names_to_types =
       Name.Map.filter (fun name _info ->
-          Compilation_unit.equal (Name.compilation_unit name)
-            current_compilation_unit)
+          Name_occurrences.mem_name reachable_names name
+          && Compilation_unit.equal (Name.compilation_unit name)
+               current_compilation_unit)
         names_to_types
     in
     { t with
       names_to_types;
     }
-
-  let clean_for_export t ~module_symbol:_ =
-    clean_for_export t
 
   let import import_map { names_to_types; aliases; cse; } =
     let module Import = Ids_for_export.Import_map in
@@ -283,10 +281,10 @@ module One_level = struct
     Typing_env_level.defines_name_but_no_equations t.level name
 *)
 
-  let clean_for_export t ~module_symbol =
+  let clean_for_export t ~reachable_names =
     { t with
       just_after_level =
-        Cached.clean_for_export t.just_after_level ~module_symbol;
+        Cached.clean_for_export t.just_after_level ~reachable_names;
     }
 end
 
@@ -1391,9 +1389,9 @@ and free_names_transitive0 t typ ~result =
 let free_names_transitive t typ =
   free_names_transitive0 t typ ~result:Name_occurrences.empty
 
-let clean_for_export t ~module_symbol =
+let clean_for_export t ~reachable_names =
   let current_level =
-    One_level.clean_for_export t.current_level ~module_symbol
+    One_level.clean_for_export t.current_level ~reachable_names
   in
   { t with
     current_level;

--- a/middle_end/flambda/types/env/typing_env.rec.mli
+++ b/middle_end/flambda/types/env/typing_env.rec.mli
@@ -63,6 +63,8 @@ val add_equations_on_params
     [variable_is_from_missing_cmx_file]. *)
 val find : t -> Name.t -> Flambda_kind.t option -> Type_grammar.t
 
+val find_or_missing : t -> Name.t -> Type_grammar.t option
+
 val find_params : t -> Kinded_parameter.t list -> Type_grammar.t list
 
 val variable_is_from_missing_cmx_file : t -> Name.t -> bool

--- a/middle_end/flambda/types/env/typing_env.rec.mli
+++ b/middle_end/flambda/types/env/typing_env.rec.mli
@@ -141,7 +141,7 @@ val free_names_transitive : t -> Type_grammar.t -> Name_occurrences.t
 
 val defined_symbols : t -> Symbol.Set.t
 
-val clean_for_export : t -> module_symbol:Symbol.t -> t
+val clean_for_export : t -> reachable_names:Name_occurrences.t -> t
 
 module Serializable : sig
   type typing_env = t

--- a/middle_end/flambda/types/flambda_type.mli
+++ b/middle_end/flambda/types/flambda_type.mli
@@ -150,7 +150,7 @@ module Typing_env : sig
     -> flambda_type
     -> Name_occurrences.t
 
-  val clean_for_export : t -> module_symbol:Symbol.t -> t
+  val clean_for_export : t -> reachable_names:Name_occurrences.t -> t
 
   module Serializable : sig
     type typing_env = t
@@ -234,6 +234,8 @@ module Closures_entry : sig
   val function_decl_types : t -> Function_declaration_type.t Closure_id.Map.t
   val closure_var_types : t -> flambda_type Var_within_closure.Map.t
 end
+
+val free_names : t -> Name_occurrences.t
 
 (** This function takes a type [t] and an environment [env] that assigns types
     to all the free names of [t].  It also takes an environment, called

--- a/middle_end/flambda/types/flambda_type.mli
+++ b/middle_end/flambda/types/flambda_type.mli
@@ -112,6 +112,8 @@ module Typing_env : sig
 
   val find : t -> Name.t -> Flambda_kind.t option -> flambda_type
 
+  val find_or_missing : t -> Name.t -> flambda_type option
+
   val find_params : t -> Kinded_parameter.t list -> flambda_type list
 
   val find_cse : t -> Flambda_primitive.Eligible_for_cse.t -> Simple.t option


### PR DESCRIPTION
Very anecdotal evidence suggests roughly 25% smaller sizes on average, some cases being much better (3 times smaller in one case)