### PR TITLE
Change Bindable_let_bound's closure_vars to a list

### DIFF
--- a/.depend
+++ b/.depend
@@ -4478,6 +4478,7 @@ middle_end/flambda/cmx/exported_code.cmx : \
     middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/cmx/exported_code.cmi
 middle_end/flambda/cmx/exported_code.cmi : \
+    middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/cmx/contains_ids.cmo \
     middle_end/flambda/basic/code_id.cmi
@@ -4494,6 +4495,8 @@ middle_end/flambda/cmx/exported_offsets.cmi : \
     middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/cmx/flambda_cmx.cmo : \
     middle_end/flambda/simplify/simplify_import.cmi \
+    middle_end/flambda/naming/name_occurrences.cmi \
+    middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/basic/name.cmi \
     middle_end/flambda/cmx/flambda_cmx_format.cmi \
     middle_end/flambda/flambda_backend_intf.cmi \
@@ -4505,6 +4508,8 @@ middle_end/flambda/cmx/flambda_cmx.cmo : \
     middle_end/flambda/cmx/flambda_cmx.cmi
 middle_end/flambda/cmx/flambda_cmx.cmx : \
     middle_end/flambda/simplify/simplify_import.cmx \
+    middle_end/flambda/naming/name_occurrences.cmx \
+    middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/basic/name.cmx \
     middle_end/flambda/cmx/flambda_cmx_format.cmx \
     middle_end/flambda/flambda_backend_intf.cmi \
@@ -4515,6 +4520,7 @@ middle_end/flambda/cmx/flambda_cmx.cmx : \
     utils/clflags.cmx \
     middle_end/flambda/cmx/flambda_cmx.cmi
 middle_end/flambda/cmx/flambda_cmx.cmi : \
+    middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/basic/name.cmi \
     middle_end/flambda/types/flambda_type.cmi \
@@ -4526,6 +4532,7 @@ middle_end/flambda/cmx/flambda_cmx.cmi : \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi
 middle_end/flambda/cmx/flambda_cmx_format.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
+    middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/compilenv_deps/reg_width_things.cmi \
@@ -4539,6 +4546,7 @@ middle_end/flambda/cmx/flambda_cmx_format.cmo : \
     middle_end/flambda/cmx/flambda_cmx_format.cmi
 middle_end/flambda/cmx/flambda_cmx_format.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
+    middle_end/flambda/basic/var_within_closure.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/compilenv_deps/reg_width_things.cmx \
@@ -4551,12 +4559,14 @@ middle_end/flambda/cmx/flambda_cmx_format.cmx : \
     middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/cmx/flambda_cmx_format.cmi
 middle_end/flambda/cmx/flambda_cmx_format.cmi : \
+    middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/types/flambda_type.cmi \
     middle_end/flambda/cmx/exported_offsets.cmi \
     middle_end/flambda/cmx/exported_code.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi
 middle_end/flambda/cmx/ids_for_export.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
+    middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/compilenv_deps/reg_width_things.cmi \
@@ -4565,6 +4575,7 @@ middle_end/flambda/cmx/ids_for_export.cmo : \
     middle_end/flambda/cmx/ids_for_export.cmi
 middle_end/flambda/cmx/ids_for_export.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
+    middle_end/flambda/basic/var_within_closure.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/compilenv_deps/reg_width_things.cmx \
@@ -4573,6 +4584,7 @@ middle_end/flambda/cmx/ids_for_export.cmx : \
     middle_end/flambda/cmx/ids_for_export.cmi
 middle_end/flambda/cmx/ids_for_export.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
+    middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/compilenv_deps/reg_width_things.cmi \
@@ -5131,7 +5143,6 @@ middle_end/flambda/lifting/lift_inconstants.cmx : \
 middle_end/flambda/lifting/lift_inconstants.cmi : \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/simplify/env/simplify_envs.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/types/flambda_type.cmi \
     middle_end/flambda/terms/flambda.cmi \
@@ -5258,8 +5269,6 @@ middle_end/flambda/naming/bindable_let_bound.cmo : \
     utils/misc.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     utils/identifiable.cmi \
-    middle_end/flambda/compilenv_deps/flambda_colours.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
     middle_end/flambda/terms/bound_symbols.cmi \
     middle_end/flambda/naming/bindable_let_bound.cmi
 middle_end/flambda/naming/bindable_let_bound.cmx : \
@@ -5272,8 +5281,6 @@ middle_end/flambda/naming/bindable_let_bound.cmx : \
     utils/misc.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     utils/identifiable.cmx \
-    middle_end/flambda/compilenv_deps/flambda_colours.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
     middle_end/flambda/terms/bound_symbols.cmx \
     middle_end/flambda/naming/bindable_let_bound.cmi
 middle_end/flambda/naming/bindable_let_bound.cmi : \
@@ -5282,7 +5289,6 @@ middle_end/flambda/naming/bindable_let_bound.cmi : \
     middle_end/flambda/basic/symbol_scoping_rule.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/cmx/contains_ids.cmo \
-    middle_end/flambda/basic/closure_id.cmi \
     middle_end/flambda/terms/bound_symbols.cmi \
     middle_end/flambda/naming/bindable.cmo
 middle_end/flambda/naming/bindable_variable_in_terms.cmo : \
@@ -6378,25 +6384,33 @@ middle_end/flambda/simplify/env/continuation_uses_env_intf.cmx : \
     middle_end/flambda/basic/continuation.cmx \
     middle_end/flambda/basic/apply_cont_rewrite_id.cmx
 middle_end/flambda/simplify/env/downwards_acc.cmo : \
+    middle_end/flambda/basic/var_within_closure.cmi \
+    middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/simplify/env/simplify_envs.cmi \
     middle_end/flambda/types/flambda_type.cmi \
+    middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/simplify/env/continuation_uses_env.cmi \
     middle_end/flambda/simplify/env/downwards_acc.cmi
 middle_end/flambda/simplify/env/downwards_acc.cmx : \
+    middle_end/flambda/basic/var_within_closure.cmx \
+    middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/simplify/env/simplify_envs.cmx \
     middle_end/flambda/types/flambda_type.cmx \
+    middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/simplify/env/continuation_uses_env.cmx \
     middle_end/flambda/simplify/env/downwards_acc.cmi
 middle_end/flambda/simplify/env/downwards_acc.cmi : \
+    middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
+    middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/simplify/env/simplify_envs.cmi \
     middle_end/flambda/types/flambda_type.cmi \
+    middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/simplify/env/continuation_uses_env_intf.cmo \
     middle_end/flambda/simplify/env/continuation_uses_env.cmi \
     middle_end/flambda/types/structures/code_age_relation.cmi
 middle_end/flambda/simplify/env/simplify_envs.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/simplify/env/simplify_envs_intf.cmo \
@@ -6424,7 +6438,6 @@ middle_end/flambda/simplify/env/simplify_envs.cmo : \
     middle_end/flambda/simplify/env/simplify_envs.cmi
 middle_end/flambda/simplify/env/simplify_envs.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/basic/var_within_closure.cmx \
     middle_end/flambda/naming/var_in_binding_pos.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/simplify/env/simplify_envs_intf.cmx \
@@ -6454,7 +6467,6 @@ middle_end/flambda/simplify/env/simplify_envs.cmi : \
     middle_end/flambda/simplify/env/simplify_envs_intf.cmo
 middle_end/flambda/simplify/env/simplify_envs_intf.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/basic/simple.cmi \
@@ -6479,7 +6491,6 @@ middle_end/flambda/simplify/env/simplify_envs_intf.cmo : \
     middle_end/flambda/simplify/basic/apply_cont_rewrite.cmi
 middle_end/flambda/simplify/env/simplify_envs_intf.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/basic/var_within_closure.cmx \
     middle_end/flambda/naming/var_in_binding_pos.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/basic/simple.cmx \
@@ -6503,20 +6514,33 @@ middle_end/flambda/simplify/env/simplify_envs_intf.cmx : \
     middle_end/flambda/terms/bound_symbols.cmx \
     middle_end/flambda/simplify/basic/apply_cont_rewrite.cmx
 middle_end/flambda/simplify/env/upwards_acc.cmo : \
+    middle_end/flambda/basic/var_within_closure.cmi \
+    middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/simplify/env/simplify_envs.cmi \
     middle_end/flambda/types/flambda_type.cmi \
+    middle_end/flambda/terms/flambda.cmi \
+    middle_end/flambda/cmx/exported_code.cmi \
     middle_end/flambda/simplify/env/downwards_acc.cmi \
     middle_end/flambda/types/structures/code_age_relation.cmi \
     middle_end/flambda/simplify/env/upwards_acc.cmi
 middle_end/flambda/simplify/env/upwards_acc.cmx : \
+    middle_end/flambda/basic/var_within_closure.cmx \
+    middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/simplify/env/simplify_envs.cmx \
     middle_end/flambda/types/flambda_type.cmx \
+    middle_end/flambda/terms/flambda.cmx \
+    middle_end/flambda/cmx/exported_code.cmx \
     middle_end/flambda/simplify/env/downwards_acc.cmx \
     middle_end/flambda/types/structures/code_age_relation.cmx \
     middle_end/flambda/simplify/env/upwards_acc.cmi
 middle_end/flambda/simplify/env/upwards_acc.cmi : \
+    middle_end/flambda/basic/var_within_closure.cmi \
+    middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/simplify/env/simplify_envs.cmi \
+    middle_end/flambda/terms/flambda.cmi \
+    middle_end/flambda/cmx/exported_code.cmi \
     middle_end/flambda/simplify/env/downwards_acc.cmi \
+    middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/types/structures/code_age_relation.cmi
  \
     middle_end/flambda/simplify/typing_helpers/continuation_handler_like_intf.cmo : \
@@ -8653,22 +8677,22 @@ middle_end/flambda/types/structures/lattice_ops_intf.cmx : \
 middle_end/flambda/types/structures/product.rec.cmo : \
     middle_end/flambda/basic/var_within_closure.cmi \
     utils/targetint.cmi \
+    middle_end/flambda/types/structures/product_intf.cmo \
     middle_end/flambda/types/basic/or_bottom.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     utils/misc.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/basic/closure_id.cmi \
     middle_end/flambda/types/structures/product.rec.cmi
 middle_end/flambda/types/structures/product.rec.cmx : \
     middle_end/flambda/basic/var_within_closure.cmx \
     utils/targetint.cmx \
+    middle_end/flambda/types/structures/product_intf.cmx \
     middle_end/flambda/types/basic/or_bottom.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     utils/misc.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
-    utils/identifiable.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
     middle_end/flambda/basic/closure_id.cmx \
     middle_end/flambda/types/structures/product.rec.cmi
@@ -8676,19 +8700,20 @@ middle_end/flambda/types/structures/product.rec.cmi : \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/types/structures/product_intf.cmo \
     utils/numbers.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/types/structures/product_intf.cmo : \
     middle_end/flambda/types/structures/type_structure_intf.cmo \
     utils/targetint.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
+    middle_end/flambda/cmx/ids_for_export.cmi \
     utils/identifiable.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi
 middle_end/flambda/types/structures/product_intf.cmx : \
     middle_end/flambda/types/structures/type_structure_intf.cmx \
     utils/targetint.cmx \
     middle_end/flambda/types/basic/or_bottom.cmx \
+    middle_end/flambda/cmx/ids_for_export.cmx \
     utils/identifiable.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx
 middle_end/flambda/types/structures/row_like.rec.cmo : \
@@ -8747,6 +8772,7 @@ middle_end/flambda/types/structures/set_of_closures_contents.cmo : \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
     utils/misc.cmi \
+    middle_end/flambda/cmx/ids_for_export.cmi \
     utils/identifiable.cmi \
     middle_end/flambda/basic/closure_id.cmi \
     middle_end/flambda/types/structures/set_of_closures_contents.cmi
@@ -8754,12 +8780,14 @@ middle_end/flambda/types/structures/set_of_closures_contents.cmx : \
     middle_end/flambda/basic/var_within_closure.cmx \
     middle_end/flambda/types/basic/or_unknown.cmx \
     utils/misc.cmx \
+    middle_end/flambda/cmx/ids_for_export.cmx \
     utils/identifiable.cmx \
     middle_end/flambda/basic/closure_id.cmx \
     middle_end/flambda/types/structures/set_of_closures_contents.cmi
 middle_end/flambda/types/structures/set_of_closures_contents.cmi : \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
+    middle_end/flambda/cmx/ids_for_export.cmi \
     utils/identifiable.cmi \
     middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/types/structures/type_structure_intf.cmo : \

--- a/middle_end/flambda/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion.ml
@@ -812,10 +812,16 @@ and close_let_rec t env ~defs ~body =
       generated_closures
       closure_vars
   in
+  let closure_vars =
+    List.map (fun (closure_id, _) ->
+        Closure_id.Map.find closure_id closure_vars)
+      (Flambda.Function_declarations.funs_in_order (
+          Flambda.Set_of_closures.function_decls set_of_closures)
+        |> Closure_id.Lmap.bindings)
+  in
   let body, handlers = close t env body in
   let leaving_scope_of =
-    Closure_id.Map.data closure_vars
-    |> List.map VB.var
+    List.map VB.var closure_vars
     |> Variable.Set.of_list
     |> Name_occurrences.create_variables' Name_mode.normal
   in

--- a/middle_end/flambda/naming/bindable_let_bound.ml
+++ b/middle_end/flambda/naming/bindable_let_bound.ml
@@ -145,14 +145,20 @@ let add_to_name_permutation t1 ~guaranteed_fresh:t2 perm =
   | Set_of_closures { name_mode = _; closure_vars = closure_vars1; },
       Set_of_closures { name_mode = _;
         closure_vars = closure_vars2; } ->
-    List.fold_left2
-      (fun perm var1 var2 ->
-        Name_permutation.add_fresh_variable perm
-          (Var_in_binding_pos.var var1)
-          ~guaranteed_fresh:(Var_in_binding_pos.var var2))
-      perm
-      closure_vars1
-      closure_vars2
+    if List.compare_lengths closure_vars1 closure_vars2 = 0
+    then
+      List.fold_left2
+        (fun perm var1 var2 ->
+          Name_permutation.add_fresh_variable perm
+            (Var_in_binding_pos.var var1)
+            ~guaranteed_fresh:(Var_in_binding_pos.var var2))
+        perm
+        closure_vars1
+        closure_vars2
+    else
+      Misc.fatal_errorf "Mismatching closure vars:@ %a@ and@ %a"
+        print t1
+        print t2
   | Symbols _, Symbols _ -> perm
   | (Singleton _ | Set_of_closures _ | Symbols _), _ ->
     Misc.fatal_errorf "Kind mismatch:@ %a@ and@ %a"

--- a/middle_end/flambda/naming/bindable_let_bound.mli
+++ b/middle_end/flambda/naming/bindable_let_bound.mli
@@ -26,7 +26,7 @@ type t = private
     (** The binding of a single variable, which is statically scoped. *)
   | Set_of_closures of {
       name_mode : Name_mode.t;
-      closure_vars : Var_in_binding_pos.t Closure_id.Map.t;
+      closure_vars : Var_in_binding_pos.t list;
     }
     (** The binding of one or more variables to the individual closures in a
         set of closures.  The variables are statically scoped. *)
@@ -41,13 +41,13 @@ include Contains_ids.S with type t := t
 
 val singleton : Var_in_binding_pos.t -> t
 
-val set_of_closures : closure_vars:Var_in_binding_pos.t Closure_id.Map.t -> t
+val set_of_closures : closure_vars:Var_in_binding_pos.t list -> t
 
 val symbols : Bound_symbols.t -> Symbol_scoping_rule.t -> t
 
 val must_be_singleton : t -> Var_in_binding_pos.t
 
-val must_be_set_of_closures : t -> Var_in_binding_pos.t Closure_id.Map.t
+val must_be_set_of_closures : t -> Var_in_binding_pos.t list
 
 val must_be_symbols : t -> symbols
 

--- a/middle_end/flambda/simplify/simplify_expr.rec.ml
+++ b/middle_end/flambda/simplify/simplify_expr.rec.ml
@@ -937,9 +937,7 @@ and simplify_direct_partial_application
   in
   let expr =
     let wrapper_var = VB.create wrapper_var Name_mode.normal in
-    let closure_vars =
-      Closure_id.Map.singleton wrapper_closure_id wrapper_var
-    in
+    let closure_vars = [wrapper_var]  in
     let pattern = Bindable_let_bound.set_of_closures ~closure_vars in
     Expr.create_pattern_let pattern
       (Named.create_set_of_closures wrapper_taking_remaining_args)

--- a/middle_end/flambda/simplify/simplify_expr.rec.ml
+++ b/middle_end/flambda/simplify/simplify_expr.rec.ml
@@ -937,7 +937,7 @@ and simplify_direct_partial_application
   in
   let expr =
     let wrapper_var = VB.create wrapper_var Name_mode.normal in
-    let closure_vars = [wrapper_var]  in
+    let closure_vars = [wrapper_var] in
     let pattern = Bindable_let_bound.set_of_closures ~closure_vars in
     Expr.create_pattern_let pattern
       (Named.create_set_of_closures wrapper_taking_remaining_args)

--- a/middle_end/flambda/terms/let_expr.rec.ml
+++ b/middle_end/flambda/terms/let_expr.rec.ml
@@ -280,11 +280,11 @@ let invariant env t =
     let env =
       match t.defining_expr, bindable_let_bound with
       | Set_of_closures _, Set_of_closures { closure_vars; _ } ->
-        Closure_id.Map.fold (fun _closure_id closure_var env ->
+        List.fold_left (fun env closure_var ->
             let closure_var = VB.var closure_var in
             E.add_variable env closure_var K.value)
-          closure_vars
           env
+          closure_vars
       | Set_of_closures _, Singleton _ ->
         Misc.fatal_errorf "Cannot bind a [Set_of_closures] to a \
             [Singleton]:@ %a"


### PR DESCRIPTION
This is necessary so that `Let_expr.pattern_match_pair` can operate on
expressions whose closure ids don't match.  The closure ids are no
longer necessary as keys since the right-hand side of the Let_expr is
now kept in order.