### PR TITLE
Have Let_expr.pattern_match_pair return a Result.t

### DIFF
--- a/middle_end/flambda/terms/continuation_params_and_handler.rec.ml
+++ b/middle_end/flambda/terms/continuation_params_and_handler.rec.ml
@@ -77,6 +77,8 @@ end
 let pattern_match_pair t1 t2 ~f =
   pattern_match t1 ~f:(fun params1 ~handler:_ ->
     pattern_match t2 ~f:(fun params2 ~handler:_ ->
+      (* CR lmaurer: Should this check be done by
+         [Name_abstraction.Make_list]? *)
       if List.compare_lengths params1 params2 = 0 then
         pattern_match_pair t1 t2 ~f:(
           fun params { handler = handler1; } { handler = handler2; } ->

--- a/middle_end/flambda/terms/continuation_params_and_handler.rec.ml
+++ b/middle_end/flambda/terms/continuation_params_and_handler.rec.ml
@@ -67,6 +67,11 @@ let pattern_match t ~f =
     f params ~handler)
 
 let pattern_match_pair t1 t2 ~f =
-  pattern_match_pair t1 t2 ~f:(
-    fun params { handler = handler1; } { handler = handler2; } ->
-      f params ~handler1 ~handler2)
+  pattern_match t1 ~f:(fun params1 ~handler:_ ->
+    pattern_match t2 ~f:(fun params2 ~handler:_ ->
+      if List.compare_lengths params1 params2 = 0 then
+        pattern_match_pair t1 t2 ~f:(
+          fun params { handler = handler1; } { handler = handler2; } ->
+            Ok (f params ~handler1 ~handler2))
+      else
+        Error "Parameter lists have different lengths"))

--- a/middle_end/flambda/terms/continuation_params_and_handler.rec.ml
+++ b/middle_end/flambda/terms/continuation_params_and_handler.rec.ml
@@ -66,6 +66,14 @@ let pattern_match t ~f =
   pattern_match t ~f:(fun params { handler; } ->
     f params ~handler)
 
+module Pattern_match_pair_error = struct
+  type t = Parameter_lists_have_different_lengths
+
+  let to_string = function
+    | Parameter_lists_have_different_lengths ->
+      "Parameter lists have different lengths"
+end
+
 let pattern_match_pair t1 t2 ~f =
   pattern_match t1 ~f:(fun params1 ~handler:_ ->
     pattern_match t2 ~f:(fun params2 ~handler:_ ->
@@ -74,4 +82,4 @@ let pattern_match_pair t1 t2 ~f =
           fun params { handler = handler1; } { handler = handler2; } ->
             Ok (f params ~handler1 ~handler2))
       else
-        Error "Parameter lists have different lengths"))
+        Error Pattern_match_pair_error.Parameter_lists_have_different_lengths))

--- a/middle_end/flambda/terms/continuation_params_and_handler.rec.mli
+++ b/middle_end/flambda/terms/continuation_params_and_handler.rec.mli
@@ -52,5 +52,5 @@ val pattern_match_pair
     -> handler1:Expr.t
     -> handler2:Expr.t
     -> 'a)
-  -> 'a
+  -> ('a, string) Result.t
 

--- a/middle_end/flambda/terms/continuation_params_and_handler.rec.mli
+++ b/middle_end/flambda/terms/continuation_params_and_handler.rec.mli
@@ -43,6 +43,12 @@ val pattern_match
     -> 'a)
   -> 'a
 
+module Pattern_match_pair_error : sig
+  type t = Parameter_lists_have_different_lengths
+
+  val to_string : t -> string
+end
+
 (** Choose members of two bindings' alpha-equivalence classes using the same
     parameters. *)
 val pattern_match_pair
@@ -52,5 +58,5 @@ val pattern_match_pair
     -> handler1:Expr.t
     -> handler2:Expr.t
     -> 'a)
-  -> ('a, string) Result.t
+  -> ('a, Pattern_match_pair_error.t) Result.t
 

--- a/middle_end/flambda/terms/flambda.mli
+++ b/middle_end/flambda/terms/flambda.mli
@@ -241,11 +241,21 @@ end and Let_expr : sig
   end
 
   (** Look inside two [Let]s by choosing members of their alpha-equivalence
-      classes, using the same bound variables for both. *)
+      classes, using the same bound variables for both. If they are both
+      dynamic lets (that is, they both bind variables), this invokes [dynamic]
+      having freshened both bodies; if they are both static (that is, they
+      both bind symbols), this invokes [static] with the bodies unchanged, since
+      no renaming is necessary. *)
   val pattern_match_pair
      : t
     -> t
-    -> f:(Bindable_let_bound.t -> body1:Expr.t -> body2:Expr.t -> 'a)
+    -> dynamic:(Bindable_let_bound.t -> body1:Expr.t -> body2:Expr.t -> 'a)
+    -> static:(
+            bound_symbols1:Bindable_let_bound.symbols
+         -> bound_symbols2:Bindable_let_bound.symbols
+         -> body1:Expr.t
+         -> body2:Expr.t
+         -> 'a)
     -> ('a, Pattern_match_pair_error.t) Result.t
 end and Let_cont_expr : sig
   (** Values of type [t] represent alpha-equivalence classes of the definitions

--- a/middle_end/flambda/terms/flambda.mli
+++ b/middle_end/flambda/terms/flambda.mli
@@ -401,7 +401,7 @@ end and Continuation_params_and_handler : sig
       -> handler1:Expr.t
       -> handler2:Expr.t
       -> 'a)
-    -> 'a
+    -> ('a, string) Result.t
 
 end and Recursive_let_cont_handlers : sig
   (** The representation of the alpha-equivalence class of a group of possibly

--- a/middle_end/flambda/terms/flambda.mli
+++ b/middle_end/flambda/terms/flambda.mli
@@ -234,13 +234,19 @@ end and Let_expr : sig
     -> f:(Bindable_let_bound.t -> body:Expr.t -> 'a)
     -> 'a
 
+  module Pattern_match_pair_error : sig
+    type t = Mismatched_let_bindings
+
+    val to_string : t -> string
+  end
+
   (** Look inside two [Let]s by choosing members of their alpha-equivalence
       classes, using the same bound variables for both. *)
   val pattern_match_pair
      : t
     -> t
     -> f:(Bindable_let_bound.t -> body1:Expr.t -> body2:Expr.t -> 'a)
-    -> ('a, string) Result.t
+    -> ('a, Pattern_match_pair_error.t) Result.t
 end and Let_cont_expr : sig
   (** Values of type [t] represent alpha-equivalence classes of the definitions
       of continuations:
@@ -392,6 +398,12 @@ end and Continuation_params_and_handler : sig
       -> 'a)
     -> 'a
 
+  module Pattern_match_pair_error : sig
+    type t = Parameter_lists_have_different_lengths
+
+    val to_string : t -> string
+  end
+
   (** Choose members of two bindings' alpha-equivalence classes using the same
       parameters. *)
   val pattern_match_pair
@@ -401,7 +413,7 @@ end and Continuation_params_and_handler : sig
       -> handler1:Expr.t
       -> handler2:Expr.t
       -> 'a)
-    -> ('a, string) Result.t
+    -> ('a, Pattern_match_pair_error.t) Result.t
 
 end and Recursive_let_cont_handlers : sig
   (** The representation of the alpha-equivalence class of a group of possibly

--- a/middle_end/flambda/terms/flambda.mli
+++ b/middle_end/flambda/terms/flambda.mli
@@ -240,7 +240,7 @@ end and Let_expr : sig
      : t
     -> t
     -> f:(Bindable_let_bound.t -> body1:Expr.t -> body2:Expr.t -> 'a)
-    -> 'a
+    -> ('a, string) Result.t
 end and Let_cont_expr : sig
   (** Values of type [t] represent alpha-equivalence classes of the definitions
       of continuations:

--- a/middle_end/flambda/terms/let_expr.rec.ml
+++ b/middle_end/flambda/terms/let_expr.rec.ml
@@ -30,6 +30,13 @@ let pattern_match t ~f =
   A.pattern_match t.name_abstraction
     ~f:(fun bindable_let_bound body -> f bindable_let_bound ~body)
 
+module Pattern_match_pair_error = struct
+  type t = Mismatched_let_bindings
+
+  let to_string = function
+    | Mismatched_let_bindings -> "Mismatched let bindings"
+end
+
 let pattern_match_pair t1 t2 ~f =
   A.pattern_match t1.name_abstraction
     ~f:(fun bindable_let_bound1 _ ->
@@ -59,7 +66,7 @@ let pattern_match_pair t1 t2 ~f =
             in
             Ok ans
           else
-            Error "Mismatched let bindings"))
+            Error Pattern_match_pair_error.Mismatched_let_bindings))
 
 (* For printing "let symbol": *)
 

--- a/middle_end/flambda/terms/let_expr.rec.ml
+++ b/middle_end/flambda/terms/let_expr.rec.ml
@@ -63,8 +63,17 @@ let pattern_match_pair t1 t2 ~dynamic ~static =
             else Error Pattern_match_pair_error.Mismatched_let_bindings
           | Symbols bound_symbols1,
             Symbols bound_symbols2 ->
-            let ans = static ~bound_symbols1 ~bound_symbols2 ~body1 ~body2 in
-            Ok ans
+            let patterns1 =
+              bound_symbols1.bound_symbols |> Bound_symbols.to_list
+            in
+            let patterns2 =
+              bound_symbols2.bound_symbols |> Bound_symbols.to_list
+            in
+            if List.compare_lengths patterns1 patterns2 = 0
+            then
+              let ans = static ~bound_symbols1 ~bound_symbols2 ~body1 ~body2 in
+              Ok ans
+            else Error Pattern_match_pair_error.Mismatched_let_bindings
           | _, _ ->
             Error Pattern_match_pair_error.Mismatched_let_bindings))
 

--- a/middle_end/flambda/terms/let_expr.rec.ml
+++ b/middle_end/flambda/terms/let_expr.rec.ml
@@ -42,24 +42,7 @@ let pattern_match_pair t1 t2 ~dynamic ~static =
     ~f:(fun bindable_let_bound1 body1 ->
       A.pattern_match t2.name_abstraction
         ~f:(fun bindable_let_bound2 body2 ->
-          let case =
-            match bindable_let_bound1, bindable_let_bound2 with
-            | Bindable_let_bound.Singleton _,
-              Bindable_let_bound.Singleton _ ->
-              `Dynamic
-            | Set_of_closures { closure_vars = vars1; _ },
-              Set_of_closures { closure_vars = vars2; _ } ->
-              if List.compare_lengths vars1 vars2 = 0
-              then `Dynamic
-              else `Error
-            | Symbols bound_symbols1,
-              Symbols bound_symbols2 ->
-              `Static (bound_symbols1, bound_symbols2)
-            | _, _ ->
-              `Error
-          in
-          match case with
-          | `Dynamic ->
+          let dynamic_case () =
             let ans =
               A.pattern_match_pair
                 t1.name_abstraction
@@ -68,10 +51,21 @@ let pattern_match_pair t1 t2 ~dynamic ~static =
                   dynamic bindable_let_bound ~body1 ~body2)
             in
             Ok ans
-          | `Static (bound_symbols1, bound_symbols2) ->
+          in
+          match bindable_let_bound1, bindable_let_bound2 with
+          | Bindable_let_bound.Singleton _,
+            Bindable_let_bound.Singleton _ ->
+            dynamic_case ()
+          | Set_of_closures { closure_vars = vars1; _ },
+            Set_of_closures { closure_vars = vars2; _ } ->
+            if List.compare_lengths vars1 vars2 = 0
+            then dynamic_case ()
+            else Error Pattern_match_pair_error.Mismatched_let_bindings
+          | Symbols bound_symbols1,
+            Symbols bound_symbols2 ->
             let ans = static ~bound_symbols1 ~bound_symbols2 ~body1 ~body2 in
             Ok ans
-          | `Error ->
+          | _, _ ->
             Error Pattern_match_pair_error.Mismatched_let_bindings))
 
 (* For printing "let symbol": *)

--- a/middle_end/flambda/terms/let_expr.rec.mli
+++ b/middle_end/flambda/terms/let_expr.rec.mli
@@ -41,11 +41,21 @@ module Pattern_match_pair_error : sig
 end
 
 (** Look inside two [Let]s by choosing members of their alpha-equivalence
-    classes, using the same bound variables for both. *)
+    classes, using the same bound variables for both. If they are both
+    dynamic lets (that is, they both bind variables), this invokes [dynamic]
+    having freshened both bodies; if they are both static (that is, they
+    both bind symbols), this invokes [static] with the bodies unchanged, since
+    no renaming is necessary. *)
 val pattern_match_pair
    : t
   -> t
-  -> f:(Bindable_let_bound.t -> body1:Expr.t -> body2:Expr.t -> 'a)
+  -> dynamic:(Bindable_let_bound.t -> body1:Expr.t -> body2:Expr.t -> 'a)
+  -> static:(
+          bound_symbols1:Bindable_let_bound.symbols
+       -> bound_symbols2:Bindable_let_bound.symbols
+       -> body1:Expr.t
+       -> body2:Expr.t
+       -> 'a)
   -> ('a, Pattern_match_pair_error.t) Result.t
 
 val create : Bindable_let_bound.t -> defining_expr:Named.t -> body:Expr.t -> t

--- a/middle_end/flambda/terms/let_expr.rec.mli
+++ b/middle_end/flambda/terms/let_expr.rec.mli
@@ -40,6 +40,6 @@ val pattern_match_pair
    : t
   -> t
   -> f:(Bindable_let_bound.t -> body1:Expr.t -> body2:Expr.t -> 'a)
-  -> 'a
+  -> ('a, string) Result.t
 
 val create : Bindable_let_bound.t -> defining_expr:Named.t -> body:Expr.t -> t

--- a/middle_end/flambda/terms/let_expr.rec.mli
+++ b/middle_end/flambda/terms/let_expr.rec.mli
@@ -34,12 +34,18 @@ val pattern_match
   -> f:(Bindable_let_bound.t -> body:Expr.t -> 'a)
   -> 'a
 
+module Pattern_match_pair_error : sig
+  type t = Mismatched_let_bindings
+
+  val to_string : t -> string
+end
+
 (** Look inside two [Let]s by choosing members of their alpha-equivalence
     classes, using the same bound variables for both. *)
 val pattern_match_pair
    : t
   -> t
   -> f:(Bindable_let_bound.t -> body1:Expr.t -> body2:Expr.t -> 'a)
-  -> ('a, string) Result.t
+  -> ('a, Pattern_match_pair_error.t) Result.t
 
 val create : Bindable_let_bound.t -> defining_expr:Named.t -> body:Expr.t -> t


### PR DESCRIPTION
It doesn't make much sense for `pattern_match_pair` to cause fatal
errors, since it's called on terms that aren't known a priori to match
at all.