### PR TITLE
Fix for bug introduced in #217

### DIFF
--- a/middle_end/flambda/lifting/lift_inconstants.ml
+++ b/middle_end/flambda/lifting/lift_inconstants.ml
@@ -350,7 +350,6 @@ let allowed_for_toplevel_lifting static_const =
 
 type reify_primitive_at_toplevel_result =
   | Lift of {
-    dacc : DA.t;
     symbol : Symbol.t;
     static_const : Flambda.Static_const.t;
   }
@@ -377,8 +376,6 @@ let reify_primitive_at_toplevel dacc bound_var ty =
     then
       Cannot_reify
     else begin
-      (* CR mshinwell: This should attempt to share the constant (see
-         first function in this file for the code). *)
       match DA.find_shareable_constant dacc static_const with
       | Some symbol -> Shared symbol
       | None ->
@@ -387,8 +384,7 @@ let reify_primitive_at_toplevel dacc bound_var ty =
             (Linkage_name.create
                (Variable.unique_name (Var_in_binding_pos.var bound_var)))
         in
-        let dacc = DA.consider_constant_for_sharing dacc symbol static_const in
-        Lift { dacc; symbol; static_const; }
+        Lift { symbol; static_const; }
     end
   | Lift_set_of_closures _ | Simple _ | Cannot_reify | Invalid ->
     Cannot_reify

--- a/middle_end/flambda/lifting/lift_inconstants.mli
+++ b/middle_end/flambda/lifting/lift_inconstants.mli
@@ -29,7 +29,6 @@ val lift_via_reification_of_continuation_param_types
 
 type reify_primitive_at_toplevel_result =
   | Lift of {
-    dacc : Downwards_acc.t;
     symbol : Symbol.t;
     static_const : Flambda.Static_const.t;
   }

--- a/middle_end/flambda/simplify/simplify_named.rec.ml
+++ b/middle_end/flambda/simplify/simplify_named.rec.ml
@@ -26,8 +26,8 @@ type simplify_named_result =
   | Reified of {
       definition : Named.t;
       bound_symbol : Bound_symbols.t;
+      symbol : Symbol.t;
       static_const : Static_const.t;
-      dacc : DA.t;
     }
   | Shared of Symbol.t
 
@@ -88,13 +88,13 @@ let simplify_named0 dacc (bindable_let_bound : Bindable_let_bound.t)
       | Cannot_reify ->
         bindings_result [bindable_let_bound, defining_expr] dacc
       | Shared symbol -> Shared symbol
-      | Lift { dacc; symbol; static_const; } ->
+      | Lift { symbol; static_const; } ->
         let named = Named.create_simple (Simple.symbol symbol) in
         Reified
           { definition = named;
             bound_symbol = Singleton symbol;
+            symbol;
             static_const;
-            dacc;
           }
     end
     else

--- a/middle_end/flambda/simplify/simplify_named.rec.mli
+++ b/middle_end/flambda/simplify/simplify_named.rec.mli
@@ -26,8 +26,8 @@ type simplify_named_result = private
   | Reified of {
       definition : Named.t;
       bound_symbol : Bound_symbols.t;
+      symbol : Symbol.t;
       static_const :  Static_const.t;
-      dacc : Downwards_acc.t;
     }
   | Shared of Symbol.t
 


### PR DESCRIPTION
This should now use the correct `dacc` in two cases in `Simplify_let` (as per a bug that @lthls found a while back in a previous version of the code, and which regressed again in #217).