### PR TITLE
Move Code to its own file and move fields from Function_declaration.t

### DIFF
--- a/.depend
+++ b/.depend
@@ -4328,6 +4328,11 @@ middle_end/flambda/basic/num_continuation_uses.cmo : \
 middle_end/flambda/basic/num_continuation_uses.cmx : \
     middle_end/flambda/basic/num_continuation_uses.cmi
 middle_end/flambda/basic/num_continuation_uses.cmi :
+middle_end/flambda/basic/or_deleted.cmo : \
+    middle_end/flambda/basic/or_deleted.cmi
+middle_end/flambda/basic/or_deleted.cmx : \
+    middle_end/flambda/basic/or_deleted.cmi
+middle_end/flambda/basic/or_deleted.cmi :
 middle_end/flambda/basic/or_variable.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/naming/name_permutation.cmi \
@@ -5041,6 +5046,7 @@ middle_end/flambda/inlining/inlining_decision.cmo : \
     middle_end/flambda/basic/inline_attribute.cmi \
     middle_end/flambda/terms/function_declaration.cmi \
     middle_end/flambda/terms/flambda.cmi \
+    middle_end/flambda/basic/code_id.cmi \
     utils/clflags.cmi \
     middle_end/flambda/inlining/inlining_decision.cmi
 middle_end/flambda/inlining/inlining_decision.cmx : \
@@ -5052,6 +5058,7 @@ middle_end/flambda/inlining/inlining_decision.cmx : \
     middle_end/flambda/basic/inline_attribute.cmx \
     middle_end/flambda/terms/function_declaration.cmx \
     middle_end/flambda/terms/flambda.cmx \
+    middle_end/flambda/basic/code_id.cmx \
     utils/clflags.cmx \
     middle_end/flambda/inlining/inlining_decision.cmi
 middle_end/flambda/inlining/inlining_decision.cmi : \
@@ -5070,6 +5077,7 @@ middle_end/flambda/inlining/inlining_transforms.cmo : \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
     middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_mode.cmi \
+    utils/misc.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/types/flambda_type.cmi \
     middle_end/flambda/basic/exn_continuation.cmi \
@@ -5087,6 +5095,7 @@ middle_end/flambda/inlining/inlining_transforms.cmx : \
     middle_end/flambda/compilenv_deps/rec_info.cmx \
     middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_mode.cmx \
+    utils/misc.cmx \
     middle_end/flambda/basic/kinded_parameter.cmx \
     middle_end/flambda/types/flambda_type.cmx \
     middle_end/flambda/basic/exn_continuation.cmx \
@@ -6773,6 +6782,41 @@ middle_end/flambda/terms/call_kind.cmi : \
     middle_end/flambda/cmx/contains_ids.cmo \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/basic/closure_id.cmi
+middle_end/flambda/terms/code.rec.cmo : \
+    middle_end/flambda/basic/recursive.cmi \
+    utils/printing_cache.cmi \
+    middle_end/flambda/basic/or_deleted.cmi \
+    middle_end/flambda/naming/name_occurrences.cmi \
+    middle_end/flambda/naming/name_mode.cmi \
+    utils/misc.cmi \
+    middle_end/flambda/basic/inline_attribute.cmi \
+    middle_end/flambda/cmx/ids_for_export.cmi \
+    middle_end/flambda/compilenv_deps/flambda_colours.cmi \
+    middle_end/flambda/types/kinds/flambda_arity.cmi \
+    middle_end/flambda/basic/code_id.cmi \
+    middle_end/flambda/terms/code.rec.cmi
+middle_end/flambda/terms/code.rec.cmx : \
+    middle_end/flambda/basic/recursive.cmx \
+    utils/printing_cache.cmx \
+    middle_end/flambda/basic/or_deleted.cmx \
+    middle_end/flambda/naming/name_occurrences.cmx \
+    middle_end/flambda/naming/name_mode.cmx \
+    utils/misc.cmx \
+    middle_end/flambda/basic/inline_attribute.cmx \
+    middle_end/flambda/cmx/ids_for_export.cmx \
+    middle_end/flambda/compilenv_deps/flambda_colours.cmx \
+    middle_end/flambda/types/kinds/flambda_arity.cmx \
+    middle_end/flambda/basic/code_id.cmx \
+    middle_end/flambda/terms/code.rec.cmi
+middle_end/flambda/terms/code.rec.cmi : \
+    middle_end/flambda/basic/recursive.cmi \
+    utils/printing_cache.cmi \
+    middle_end/flambda/basic/or_deleted.cmi \
+    middle_end/flambda/basic/inline_attribute.cmi \
+    middle_end/flambda/cmx/ids_for_export.cmi \
+    middle_end/flambda/types/kinds/flambda_arity.cmi \
+    middle_end/flambda/naming/contains_names.cmo \
+    middle_end/flambda/basic/code_id.cmi
 middle_end/flambda/terms/continuation_handler.rec.cmo : \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/basic/recursive.cmi \
@@ -6896,6 +6940,7 @@ middle_end/flambda/terms/flambda.cmo : \
     middle_end/flambda/basic/recursive.cmi \
     utils/printing_cache.cmi \
     middle_end/flambda/basic/or_variable.cmi \
+    middle_end/flambda/basic/or_deleted.cmi \
     utils/numbers.cmi \
     middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
@@ -6907,6 +6952,7 @@ middle_end/flambda/terms/flambda.cmo : \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/basic/invariant_env.cmi \
     middle_end/flambda/basic/invalid_term_semantics.cmi \
+    middle_end/flambda/basic/inline_attribute.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     utils/identifiable.cmi \
     middle_end/flambda/terms/function_declarations.cmi \
@@ -6947,6 +6993,7 @@ middle_end/flambda/terms/flambda.cmx : \
     middle_end/flambda/basic/recursive.cmx \
     utils/printing_cache.cmx \
     middle_end/flambda/basic/or_variable.cmx \
+    middle_end/flambda/basic/or_deleted.cmx \
     utils/numbers.cmx \
     middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
@@ -6958,6 +7005,7 @@ middle_end/flambda/terms/flambda.cmx : \
     middle_end/flambda/basic/kinded_parameter.cmx \
     middle_end/flambda/basic/invariant_env.cmx \
     middle_end/flambda/basic/invalid_term_semantics.cmx \
+    middle_end/flambda/basic/inline_attribute.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     utils/identifiable.cmx \
     middle_end/flambda/terms/function_declarations.cmx \
@@ -6994,14 +7042,18 @@ middle_end/flambda/terms/flambda.cmi : \
     middle_end/flambda/terms/switch_expr.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/terms/set_of_closures.cmi \
+    middle_end/flambda/basic/recursive.cmi \
     utils/printing_cache.cmi \
     middle_end/flambda/basic/or_variable.cmi \
+    middle_end/flambda/basic/or_deleted.cmi \
     utils/numbers.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/basic/name.cmi \
     middle_end/flambda/basic/mutability.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/basic/invalid_term_semantics.cmi \
+    middle_end/flambda/basic/inline_attribute.cmi \
+    middle_end/flambda/cmx/ids_for_export.cmi \
     utils/identifiable.cmi \
     middle_end/flambda/terms/function_declarations.cmi \
     middle_end/flambda/terms/function_declaration.cmi \
@@ -7100,37 +7152,27 @@ middle_end/flambda/terms/flambda_unit.cmi : \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/basic/continuation.cmi \
+    middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/terms/function_declaration.cmo : \
-    middle_end/flambda/basic/recursive.cmi \
     utils/printing_cache.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
-    utils/misc.cmi \
-    middle_end/flambda/basic/inline_attribute.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
-    middle_end/flambda/types/kinds/flambda_arity.cmi \
     lambda/debuginfo.cmi \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/terms/function_declaration.cmi
 middle_end/flambda/terms/function_declaration.cmx : \
-    middle_end/flambda/basic/recursive.cmx \
     utils/printing_cache.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
-    utils/misc.cmx \
-    middle_end/flambda/basic/inline_attribute.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
-    middle_end/flambda/types/kinds/flambda_arity.cmx \
     lambda/debuginfo.cmx \
     middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/terms/function_declaration.cmi
 middle_end/flambda/terms/function_declaration.cmi : \
-    middle_end/flambda/basic/recursive.cmi \
-    middle_end/flambda/basic/inline_attribute.cmi \
-    middle_end/flambda/types/kinds/flambda_arity.cmi \
     middle_end/flambda/basic/expr_std.cmo \
     lambda/debuginfo.cmi \
     middle_end/flambda/cmx/contains_ids.cmo \
@@ -7422,7 +7464,6 @@ middle_end/flambda/terms/static_const.rec.cmi : \
     utils/printing_cache.cmi \
     middle_end/flambda/basic/or_variable.cmi \
     utils/numbers.cmi \
-    middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/basic/mutability.cmi \
     utils/identifiable.cmi \
     middle_end/flambda/naming/contains_names.cmo \
@@ -7593,6 +7634,7 @@ middle_end/flambda/to_cmm/un_cps_closure.cmo : \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/cmx/exported_offsets.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
+    middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/basic/closure_id.cmi \
     middle_end/flambda/to_cmm/un_cps_closure.cmi
 middle_end/flambda/to_cmm/un_cps_closure.cmx : \
@@ -7607,6 +7649,7 @@ middle_end/flambda/to_cmm/un_cps_closure.cmx : \
     middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/cmx/exported_offsets.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
+    middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/basic/closure_id.cmx \
     middle_end/flambda/to_cmm/un_cps_closure.cmi
 middle_end/flambda/to_cmm/un_cps_closure.cmi : \
@@ -7841,7 +7884,6 @@ middle_end/flambda/types/flambda_type.cmo : \
     middle_end/flambda/types/structures/row_like_maps_to_intf.cmo \
     middle_end/flambda/compilenv_deps/reg_width_things.cmi \
     middle_end/flambda/basic/reg_width_const.cmi \
-    middle_end/flambda/basic/recursive.cmi \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
     middle_end/flambda/types/structures/product_intf.cmo \
     utils/printing_cache.cmi \
@@ -7860,7 +7902,6 @@ middle_end/flambda/types/flambda_type.cmo : \
     middle_end/flambda/types/basic/meet_or_join_op.cmi \
     middle_end/flambda/types/structures/lattice_ops_intf.cmo \
     middle_end/flambda/basic/kinded_parameter.cmi \
-    middle_end/flambda/basic/inline_attribute.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     utils/identifiable.cmi \
     middle_end/flambda/terms/flambda_primitive.cmi \
@@ -7904,7 +7945,6 @@ middle_end/flambda/types/flambda_type.cmx : \
     middle_end/flambda/types/structures/row_like_maps_to_intf.cmx \
     middle_end/flambda/compilenv_deps/reg_width_things.cmx \
     middle_end/flambda/basic/reg_width_const.cmx \
-    middle_end/flambda/basic/recursive.cmx \
     middle_end/flambda/compilenv_deps/rec_info.cmx \
     middle_end/flambda/types/structures/product_intf.cmx \
     utils/printing_cache.cmx \
@@ -7923,7 +7963,6 @@ middle_end/flambda/types/flambda_type.cmx : \
     middle_end/flambda/types/basic/meet_or_join_op.cmx \
     middle_end/flambda/types/structures/lattice_ops_intf.cmx \
     middle_end/flambda/basic/kinded_parameter.cmx \
-    middle_end/flambda/basic/inline_attribute.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     utils/identifiable.cmx \
     middle_end/flambda/terms/flambda_primitive.cmx \
@@ -7958,7 +7997,6 @@ middle_end/flambda/types/flambda_type.cmi : \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/basic/scope.cmi \
     middle_end/flambda/basic/reg_width_const.cmi \
-    middle_end/flambda/basic/recursive.cmi \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
     utils/printing_cache.cmi \
     middle_end/flambda/types/basic/or_unknown_or_bottom.cmi \
@@ -7971,7 +8009,6 @@ middle_end/flambda/types/flambda_type.cmi : \
     middle_end/flambda/basic/name.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/basic/invariant_env.cmi \
-    middle_end/flambda/basic/inline_attribute.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/terms/flambda_primitive.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
@@ -8110,16 +8147,13 @@ middle_end/flambda/types/type_grammar.rec.cmi : \
     lambda/tag.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/basic/reg_width_const.cmi \
-    middle_end/flambda/basic/recursive.cmi \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
     utils/printing_cache.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
     utils/numbers.cmi \
     middle_end/flambda/basic/name.cmi \
-    middle_end/flambda/basic/inline_attribute.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
-    middle_end/flambda/types/kinds/flambda_arity.cmi \
     lambda/debuginfo.cmi \
     middle_end/flambda/naming/contains_names.cmo \
     middle_end/flambda/cmx/contains_ids.cmo \
@@ -8589,43 +8623,34 @@ middle_end/flambda/types/structures/code_age_relation.cmi : \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/basic/code_id.cmi
 middle_end/flambda/types/structures/function_declaration_type.rec.cmo : \
-    middle_end/flambda/basic/recursive.cmi \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
     middle_end/flambda/types/basic/or_unknown_or_bottom.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/types/structures/lattice_ops_intf.cmo \
-    middle_end/flambda/basic/inline_attribute.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
-    middle_end/flambda/types/kinds/flambda_arity.cmi \
     lambda/debuginfo.cmi \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/types/structures/code_age_relation.cmi \
     middle_end/flambda/types/structures/function_declaration_type.rec.cmi
 middle_end/flambda/types/structures/function_declaration_type.rec.cmx : \
-    middle_end/flambda/basic/recursive.cmx \
     middle_end/flambda/compilenv_deps/rec_info.cmx \
     middle_end/flambda/types/basic/or_unknown_or_bottom.cmx \
     middle_end/flambda/types/basic/or_bottom.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/types/structures/lattice_ops_intf.cmx \
-    middle_end/flambda/basic/inline_attribute.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
-    middle_end/flambda/types/kinds/flambda_arity.cmx \
     lambda/debuginfo.cmx \
     middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/types/structures/code_age_relation.cmx \
     middle_end/flambda/types/structures/function_declaration_type.rec.cmi
 middle_end/flambda/types/structures/function_declaration_type.rec.cmi : \
     middle_end/flambda/types/structures/type_structure_intf.cmo \
-    middle_end/flambda/basic/recursive.cmi \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
     middle_end/flambda/types/basic/or_unknown_or_bottom.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
-    middle_end/flambda/basic/inline_attribute.cmi \
-    middle_end/flambda/types/kinds/flambda_arity.cmi \
     lambda/debuginfo.cmi \
     middle_end/flambda/basic/code_id.cmi
 middle_end/flambda/types/structures/lattice_ops.rec.cmo : \

--- a/Makefile
+++ b/Makefile
@@ -277,7 +277,8 @@ MIDDLE_END_FLAMBDA_BASIC=\
   middle_end/flambda/basic/closure_origin.cmo \
   middle_end/flambda/basic/apply_cont_rewrite_id.cmo \
   middle_end/flambda/basic/continuation_extra_params_and_args.cmo \
-  middle_end/flambda/basic/symbol_scoping_rule.cmo
+  middle_end/flambda/basic/symbol_scoping_rule.cmo \
+  middle_end/flambda/basic/or_deleted.cmo
 
 MIDDLE_END_FLAMBDA_NAMING=\
   middle_end/flambda/naming/contains_names.cmo \

--- a/middle_end/flambda/basic/or_deleted.ml
+++ b/middle_end/flambda/basic/or_deleted.ml
@@ -5,8 +5,8 @@
 (*                       Pierre Chambart, OCamlPro                        *)
 (*           Mark Shinwell and Leo White, Jane Street Europe              *)
 (*                                                                        *)
-(*   Copyright 2013--2019 OCamlPro SAS                                    *)
-(*   Copyright 2014--2019 Jane Street Group LLC                           *)
+(*   Copyright 2013--2020 OCamlPro SAS                                    *)
+(*   Copyright 2014--2020 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -14,43 +14,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** The Flambda representation of a single compilation unit's code. *)
-
 [@@@ocaml.warning "+a-30-40-41-42"]
 
-type t
-
-(** Perform well-formedness checks on the unit. *)
-val invariant : t -> unit
-
-(** Print a unit to a formatter. *)
-val print : Format.formatter -> t -> unit
-
-(** Create a unit. *)
-val create
-   : return_continuation:Continuation.t
-  -> exn_continuation:Continuation.t
-  -> body:Flambda.Expr.t
-  -> module_symbol:Symbol.t
-  -> t
-
-val return_continuation : t -> Continuation.t
-
-val exn_continuation : t -> Continuation.t
-
-val module_symbol : t -> Symbol.t
-
-(** All closure variables used in the given unit. *)
-val used_closure_vars : t -> Var_within_closure.Set.t
-
-val body : t -> Flambda.Expr.t
-
-val iter
-   : ?code:(id:Code_id.t
-     -> Flambda.Code.t
-     -> unit)
-  -> ?set_of_closures:(closure_symbols:Symbol.t Closure_id.Lmap.t option
-     -> Flambda.Set_of_closures.t
-     -> unit)
-  -> t
-  -> unit
+type 'a t =
+  | Present of 'a
+  | Deleted

--- a/middle_end/flambda/basic/or_deleted.mli
+++ b/middle_end/flambda/basic/or_deleted.mli
@@ -5,8 +5,8 @@
 (*                       Pierre Chambart, OCamlPro                        *)
 (*           Mark Shinwell and Leo White, Jane Street Europe              *)
 (*                                                                        *)
-(*   Copyright 2013--2019 OCamlPro SAS                                    *)
-(*   Copyright 2014--2019 Jane Street Group LLC                           *)
+(*   Copyright 2013--2020 OCamlPro SAS                                    *)
+(*   Copyright 2014--2020 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -14,43 +14,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** The Flambda representation of a single compilation unit's code. *)
-
 [@@@ocaml.warning "+a-30-40-41-42"]
 
-type t
-
-(** Perform well-formedness checks on the unit. *)
-val invariant : t -> unit
-
-(** Print a unit to a formatter. *)
-val print : Format.formatter -> t -> unit
-
-(** Create a unit. *)
-val create
-   : return_continuation:Continuation.t
-  -> exn_continuation:Continuation.t
-  -> body:Flambda.Expr.t
-  -> module_symbol:Symbol.t
-  -> t
-
-val return_continuation : t -> Continuation.t
-
-val exn_continuation : t -> Continuation.t
-
-val module_symbol : t -> Symbol.t
-
-(** All closure variables used in the given unit. *)
-val used_closure_vars : t -> Var_within_closure.Set.t
-
-val body : t -> Flambda.Expr.t
-
-val iter
-   : ?code:(id:Code_id.t
-     -> Flambda.Code.t
-     -> unit)
-  -> ?set_of_closures:(closure_symbols:Symbol.t Closure_id.Lmap.t option
-     -> Flambda.Set_of_closures.t
-     -> unit)
-  -> t
-  -> unit
+type 'a t =
+  | Present of 'a
+  | Deleted

--- a/middle_end/flambda/cmx/exported_code.ml
+++ b/middle_end/flambda/cmx/exported_code.ml
@@ -14,6 +14,7 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
+module C = Flambda.Code
 module P = Flambda.Function_params_and_body
 
 module Calling_convention = struct
@@ -52,7 +53,7 @@ end
 
 type t0 =
   | Present of {
-    params_and_body : P.t;
+    code : C.t;
     calling_convention : Calling_convention.t;
   }
   | Imported of { calling_convention : Calling_convention.t; }
@@ -61,13 +62,13 @@ type t = t0 Code_id.Map.t
 
 let print0 ppf t0 =
   match t0 with
-  | Present { params_and_body; calling_convention; } ->
+  | Present { code; calling_convention; } ->
     Format.fprintf ppf
       "@[<hov 1>(Present@ (\
-         @[<hov 1>(params_and_body@ %a)@]\
+         @[<hov 1>(codey@ %a)@]\
          @[<hov 1>(calling_convention@ %a)@]\
        ))@]"
-      P.print params_and_body
+      C.print code
       Calling_convention.print calling_convention
   | Imported { calling_convention; } ->
     Format.fprintf ppf
@@ -81,11 +82,15 @@ let empty = Code_id.Map.empty
 
 let add_code code t =
   let with_calling_convention =
-    Code_id.Map.map (fun params_and_body ->
-        let calling_convention =
-          Calling_convention.compute ~params_and_body
-        in
-        Present { params_and_body; calling_convention; })
+    Code_id.Map.mapi (fun code_id code ->
+        match C.params_and_body code with
+        | Present params_and_body ->
+          let calling_convention =
+            Calling_convention.compute ~params_and_body
+          in
+          Present { code; calling_convention; }
+        | Deleted ->
+          Misc.fatal_errorf "Deleted code %a" Code_id.print code_id)
       code
   in
   Code_id.Map.disjoint_union with_calling_convention t
@@ -94,7 +99,7 @@ let mark_as_imported t =
   let forget_params_and_body t0 =
     match t0 with
     | Imported _ -> t0
-    | Present { params_and_body = _; calling_convention; } ->
+    | Present { code = _; calling_convention; } ->
       Imported { calling_convention; }
   in
   Code_id.Map.map forget_params_and_body t
@@ -116,8 +121,8 @@ let merge t1 t2 =
       Misc.fatal_errorf "Cannot merge two definitions for code id %a"
         Code_id.print code_id
     | Imported { calling_convention = cc_imported; },
-      (Present { calling_convention = cc_present; params_and_body = _; } as t0)
-    | (Present { calling_convention = cc_present; params_and_body = _; } as t0),
+      (Present { calling_convention = cc_present; code = _; } as t0)
+    | (Present { calling_convention = cc_present; code = _; } as t0),
       Imported { calling_convention = cc_imported; } ->
       if Calling_convention.equal cc_present cc_imported then Some t0
       else
@@ -137,7 +142,7 @@ let find_code t code_id =
   match Code_id.Map.find code_id t with
   | exception Not_found ->
     Misc.fatal_errorf "Code ID %a not bound" Code_id.print code_id
-  | Present { params_and_body; calling_convention = _; } -> params_and_body
+  | Present { code; calling_convention = _; } -> code
   | Imported _ ->
     Misc.fatal_errorf "Actual code for Code ID %a is missing"
       Code_id.print code_id
@@ -155,7 +160,7 @@ let find_code_if_not_imported t code_id =
        instead so we can end up with missing code IDs during the reachability
        computation, and have to assume that it fits the above case. *)
     None
-  | Present { params_and_body; calling_convention = _; } -> Some params_and_body
+  | Present { code; calling_convention = _; } -> Some code
   | Imported _ ->
     None
 
@@ -163,7 +168,7 @@ let find_calling_convention t code_id =
   match Code_id.Map.find code_id t with
   | exception Not_found ->
     Misc.fatal_errorf "Code ID %a not bound" Code_id.print code_id
-  | Present { params_and_body = _; calling_convention; } -> calling_convention
+  | Present { code = _; calling_convention; } -> calling_convention
   | Imported { calling_convention; } -> calling_convention
 
 let remove_unreachable t ~reachable_names =
@@ -175,9 +180,8 @@ let all_ids_for_export t =
   Code_id.Map.fold (fun code_id code_data all_ids ->
       let all_ids = Ids_for_export.add_code_id all_ids code_id in
       match code_data with
-      | Present { params_and_body; calling_convention = _; } ->
-        Ids_for_export.union all_ids
-          (P.all_ids_for_export params_and_body)
+      | Present { code; calling_convention = _; } ->
+        Ids_for_export.union all_ids (C.all_ids_for_export code)
       | Imported { calling_convention = _; } -> all_ids)
     t
     Ids_for_export.empty
@@ -187,11 +191,11 @@ let import import_map t =
       let code_id = Ids_for_export.Import_map.code_id import_map code_id in
       let code_data =
         match code_data with
-        | Present { calling_convention; params_and_body; } ->
-          let params_and_body =
-            Flambda.Function_params_and_body.import import_map params_and_body
+        | Present { calling_convention; code; } ->
+          let code =
+            Flambda.Code.import import_map code
           in
-          Present { calling_convention; params_and_body; }
+          Present { calling_convention; code; }
         | Imported { calling_convention; } ->
           Imported { calling_convention; }
       in

--- a/middle_end/flambda/cmx/exported_code.ml
+++ b/middle_end/flambda/cmx/exported_code.ml
@@ -90,7 +90,7 @@ let add_code code t =
           in
           Some (Present { code; calling_convention; })
         | Deleted ->
-          (* CR maurerl for vlaviron: Okay to just ignore deleted code? *)
+          (* CR lmaurer for vlaviron: Okay to just ignore deleted code? *)
           None)
       code
   in

--- a/middle_end/flambda/cmx/exported_code.ml
+++ b/middle_end/flambda/cmx/exported_code.ml
@@ -82,15 +82,16 @@ let empty = Code_id.Map.empty
 
 let add_code code t =
   let with_calling_convention =
-    Code_id.Map.mapi (fun code_id code ->
+    Code_id.Map.filter_map ~f:(fun _code_id code ->
         match C.params_and_body code with
         | Present params_and_body ->
           let calling_convention =
             Calling_convention.compute ~params_and_body
           in
-          Present { code; calling_convention; }
+          Some (Present { code; calling_convention; })
         | Deleted ->
-          Misc.fatal_errorf "Deleted code %a" Code_id.print code_id)
+          (* CR maurerl for vlaviron: Okay to just ignore deleted code? *)
+          None)
       code
   in
   Code_id.Map.disjoint_union with_calling_convention t

--- a/middle_end/flambda/cmx/exported_code.ml
+++ b/middle_end/flambda/cmx/exported_code.ml
@@ -65,7 +65,7 @@ let print0 ppf t0 =
   | Present { code; calling_convention; } ->
     Format.fprintf ppf
       "@[<hov 1>(Present@ (\
-         @[<hov 1>(codey@ %a)@]\
+         @[<hov 1>(code@ %a)@]\
          @[<hov 1>(calling_convention@ %a)@]\
        ))@]"
       C.print code

--- a/middle_end/flambda/cmx/exported_code.mli
+++ b/middle_end/flambda/cmx/exported_code.mli
@@ -29,7 +29,7 @@ val print : Format.formatter -> t -> unit
 
 val empty : t
 
-val add_code : Flambda.Function_params_and_body.t Code_id.Map.t -> t -> t
+val add_code : Flambda.Code.t Code_id.Map.t -> t -> t
 
 val mark_as_imported : t -> t
 
@@ -37,12 +37,12 @@ val merge : t -> t -> t
 
 val mem : Code_id.t -> t -> bool
 
-val find_code : t -> Code_id.t -> Flambda.Function_params_and_body.t
+val find_code : t -> Code_id.t -> Flambda.Code.t
 
 val find_code_if_not_imported
    : t
   -> Code_id.t
-  -> Flambda.Function_params_and_body.t option
+  -> Flambda.Code.t option
 
 val find_calling_convention : t -> Code_id.t -> Calling_convention.t
 

--- a/middle_end/flambda/cmx/flambda_cmx.ml
+++ b/middle_end/flambda/cmx/flambda_cmx.ml
@@ -62,12 +62,12 @@ let compute_reachable_names_and_code ~module_symbol typing_env code =
       let fold_code_id names_to_add code_id =
         match Exported_code.find_code_if_not_imported code code_id with
         | None -> names_to_add
-        | Some params_and_body ->
-          let params_and_body_names =
-            Function_params_and_body.free_names params_and_body
+        | Some code ->
+          let code_names =
+            Code.free_names code
           in
           let names_to_consider =
-            Name_occurrences.with_only_names_and_code_ids params_and_body_names
+            Name_occurrences.with_only_names_and_code_ids code_names
           in
           let new_names =
             Name_occurrences.diff names_to_consider names_already_added

--- a/middle_end/flambda/inlining/inlining_cost.ml
+++ b/middle_end/flambda/inlining/inlining_cost.ml
@@ -426,11 +426,14 @@ let smaller' denv expr ~than:threshold =
       let funs = Function_declarations.funs func_decls in
       Closure_id.Map.iter (fun _ func_decl ->
           let code_id = Function_declaration.code_id func_decl in
-          let params_and_body = DE.find_code denv code_id in
-          Function_params_and_body.pattern_match params_and_body
-            ~f:(fun ~return_continuation:_ _exn_continuation _params
-                    ~body ~my_closure:_ ->
-              expr_size denv body))
+          let code = DE.find_code denv code_id in
+          match Code.params_and_body code with
+          | Present params_and_body ->
+            Function_params_and_body.pattern_match params_and_body
+              ~f:(fun ~return_continuation:_ _exn_continuation _params
+                      ~body ~my_closure:_ ->
+                expr_size denv body)
+          | Deleted -> ())
         funs
     | Prim (prim, _dbg) ->
       size := !size + prim_size prim

--- a/middle_end/flambda/inlining/inlining_decision.ml
+++ b/middle_end/flambda/inlining/inlining_decision.ml
@@ -50,7 +50,7 @@ let make_decision_for_function_declaration denv ?params_and_body function_decl
   (* At present, we follow Closure, taking inlining decisions without
      first examining call sites. *)
   let code_id = Function_declaration.code_id function_decl in
-  let code = DE.find_code denv (Function_declaration.code_id function_decl) in
+  let code = DE.find_code denv code_id in
   match Code.inline code with
   | Never_inline -> Never_inline_attribute
   | Always_inline -> Inline
@@ -60,13 +60,8 @@ let make_decision_for_function_declaration denv ?params_and_body function_decl
       let params_and_body =
         match params_and_body with
         | None ->
-          begin
-            match Code.params_and_body code with
-            | Present params_and_body ->
-              params_and_body
-            | Deleted ->
-              Misc.fatal_errorf "Code id %a is deleted" Code_id.print code_id
-          end
+          Code.params_and_body_must_be_present code
+            ~error_context:"Inlining decision"
         | Some params_and_body -> params_and_body
       in
       Function_params_and_body.pattern_match params_and_body

--- a/middle_end/flambda/inlining/inlining_transforms.ml
+++ b/middle_end/flambda/inlining/inlining_transforms.ml
@@ -29,12 +29,7 @@ let inline dacc ~callee ~args function_decl
   let denv = DA.denv dacc in
   let code = DE.find_code denv (I.code_id function_decl) in
   let params_and_body =
-    match Code.params_and_body code with
-    | Present params_and_body ->
-      params_and_body
-    | Deleted ->
-      Misc.fatal_errorf "Attempt to inline deleted function %a"
-        Simple.print callee
+    Code.params_and_body_must_be_present code ~error_context:"Inlining"
   in
   Function_params_and_body.pattern_match params_and_body
     ~f:(fun ~return_continuation exn_continuation params ~body ~my_closure ->

--- a/middle_end/flambda/inlining/inlining_transforms.ml
+++ b/middle_end/flambda/inlining/inlining_transforms.ml
@@ -27,7 +27,15 @@ let inline dacc ~callee ~args function_decl
       ~apply_return_continuation ~apply_exn_continuation
       ~apply_inlining_depth ~unroll_to dbg =
   let denv = DA.denv dacc in
-  let params_and_body = DE.find_code denv (I.code_id function_decl) in
+  let code = DE.find_code denv (I.code_id function_decl) in
+  let params_and_body =
+    match Code.params_and_body code with
+    | Present params_and_body ->
+      params_and_body
+    | Deleted ->
+      Misc.fatal_errorf "Attempt to inline deleted function %a"
+        Simple.print callee
+  in
   Function_params_and_body.pattern_match params_and_body
     ~f:(fun ~return_continuation exn_continuation params ~body ~my_closure ->
           let denv =
@@ -90,7 +98,7 @@ let inline dacc ~callee ~args function_decl
                   let pop_wrapper_handler =
                     let kinded_params =
                       List.map (fun k -> (Variable.create "wrapper_return", k))
-                        (I.result_arity function_decl)
+                        (Code.result_arity code)
                     in
                     let trap_action =
                       Trap_action.Pop { exn_handler = wrapper; raise_kind = None; }

--- a/middle_end/flambda/lifting/lift_inconstants.ml
+++ b/middle_end/flambda/lifting/lift_inconstants.ml
@@ -72,13 +72,7 @@ let lift_set_of_closures_discovered_via_reified_continuation_param_types dacc
     let function_decls =
       Closure_id.Lmap.map (fun inlinable ->
         Function_declaration.create ~code_id:(I.code_id inlinable)
-          ~params_arity:(I.param_arity inlinable)
-          ~result_arity:(I.result_arity inlinable)
-          ~stub:(I.stub inlinable)
           ~dbg:(I.dbg inlinable)
-          ~inline:(I.inline inlinable)
-          ~is_a_functor:(I.is_a_functor inlinable)
-          ~recursive:(I.recursive inlinable)
           ~is_tupled:(I.is_tupled inlinable))
         function_decls
       |> Function_declarations.create

--- a/middle_end/flambda/simplify/env/simplify_envs_intf.ml
+++ b/middle_end/flambda/simplify/env/simplify_envs_intf.ml
@@ -157,14 +157,13 @@ module type Downwards_env = sig
 
   val define_code
      : t
-    -> ?newer_version_of:Code_id.t
     -> code_id:Code_id.t
-    -> params_and_body:Function_params_and_body.t
+    -> code:Code.t
     -> t
 
   val mem_code : t -> Code_id.t -> bool
 
-  val find_code : t -> Code_id.t -> Function_params_and_body.t
+  val find_code : t -> Code_id.t -> Code.t
 
   val with_code : from:t -> t -> t
 

--- a/middle_end/flambda/simplify/env/upwards_acc.mli
+++ b/middle_end/flambda/simplify/env/upwards_acc.mli
@@ -60,7 +60,7 @@ val with_uenv : t -> Simplify_envs.Upwards_env.t -> t
 
 val remember_code_for_cmx
     : t
-  -> Flambda.Function_params_and_body.t Code_id.Map.t
+  -> Flambda.Code.t Code_id.Map.t
   -> t
 
 val all_code : t -> Exported_code.t

--- a/middle_end/flambda/simplify/simplify_common.ml
+++ b/middle_end/flambda/simplify/simplify_common.ml
@@ -300,9 +300,7 @@ let create_let_symbol0 uacc code_age_relation (bound_symbols : Bound_symbols.t)
       Expr.create_let_symbol bound_symbols Syntactic static_consts body
     in
     let uacc =
-      Static_const.Group.pieces_of_code' static_consts
-      |> List.map (fun code -> Code.code_id code, code)
-      |> Code_id.Map.of_list
+      Static_const.Group.pieces_of_code_by_code_id static_consts
       |> UA.remember_code_for_cmx uacc
     in
     expr, uacc
@@ -353,9 +351,7 @@ let create_let_symbol uacc (scoping_rule : Symbol_scoping_rule.t)
       Expr.create_let_symbol bound_symbols scoping_rule static_consts body
     in
     let uacc =
-      Static_const.Group.pieces_of_code' defining_exprs
-      |> List.map (fun code -> Code.code_id code, code)
-      |> Code_id.Map.of_list
+      Static_const.Group.pieces_of_code_by_code_id defining_exprs
       |> UA.remember_code_for_cmx uacc
     in
     expr, uacc

--- a/middle_end/flambda/simplify/simplify_common.ml
+++ b/middle_end/flambda/simplify/simplify_common.ml
@@ -286,14 +286,13 @@ let create_let_symbol0 uacc code_age_relation (bound_symbols : Bound_symbols.t)
             ~all_code_ids_still_existing:all_code_ids_free_names_after)
         code_ids_only_used_in_newer_version_of
     in
-    let module Code = Static_const.Code in
     let static_consts =
       ListLabels.map (Static_const.Group.to_list static_consts)
         ~f:(fun static_const : Static_const.t ->
           match Static_const.to_code static_const with
           | Some code
             when Code_id.Set.mem (Code.code_id code) code_ids_to_make_deleted ->
-            Code (Static_const.Code.make_deleted code)
+            Code (Code.make_deleted code)
           | Some _ | None -> static_const)
       |> Static_const.Group.create
     in
@@ -301,7 +300,9 @@ let create_let_symbol0 uacc code_age_relation (bound_symbols : Bound_symbols.t)
       Expr.create_let_symbol bound_symbols Syntactic static_consts body
     in
     let uacc =
-      Static_const.Group.pieces_of_code static_consts
+      Static_const.Group.pieces_of_code' static_consts
+      |> List.map (fun code -> Code.code_id code, code)
+      |> Code_id.Map.of_list
       |> UA.remember_code_for_cmx uacc
     in
     expr, uacc
@@ -352,7 +353,9 @@ let create_let_symbol uacc (scoping_rule : Symbol_scoping_rule.t)
       Expr.create_let_symbol bound_symbols scoping_rule static_consts body
     in
     let uacc =
-      Static_const.Group.pieces_of_code defining_exprs
+      Static_const.Group.pieces_of_code' defining_exprs
+      |> List.map (fun code -> Code.code_id code, code)
+      |> Code_id.Map.of_list
       |> UA.remember_code_for_cmx uacc
     in
     expr, uacc

--- a/middle_end/flambda/simplify/simplify_expr.rec.ml
+++ b/middle_end/flambda/simplify/simplify_expr.rec.ml
@@ -1097,11 +1097,12 @@ and simplify_direct_function_call
       let args = Apply.args apply in
       let provided_num_args = List.length args in
       let callee's_code = DE.find_code (DA.denv dacc) callee's_code_id in
-      (* Because of tupled functions, a function declaration's params_arity
-         may not match that of the underlying function_params_and_body.
+      (* A function declaration with [is_tupled = true] may effectively have
+         an arity that does not match that of the underlying code.
          Since direct calls adopt the calling convention of the code's body
          (whereas indirect_unknown_arity calls use the convention of the
-         function_declaration), we here need the arity of the callee's body *)
+         function_declaration), we here always use the arity from the callee's
+         code. *)
       let param_arity = Code.params_arity callee's_code in
       let num_params = List.length param_arity in
       if provided_num_args = num_params then

--- a/middle_end/flambda/simplify/simplify_expr.rec.ml
+++ b/middle_end/flambda/simplify/simplify_expr.rec.ml
@@ -732,9 +732,9 @@ and simplify_direct_tuple_application
     -> 'a k -> Expr.t * 'a * UA.t
 = fun dacc apply code_id k ->
   let dbg = Apply.dbg apply in
-  let callee's_params_and_body = DE.find_code (DA.denv dacc) code_id in
+  let callee's_code = DE.find_code (DA.denv dacc) code_id in
   let param_arity =
-    Function_params_and_body.params_arity callee's_params_and_body
+    Code.params_arity callee's_code
   in
   let n = List.length param_arity in
   (* Split the tuple argument from other potential
@@ -979,16 +979,20 @@ and simplify_direct_partial_application
         ~name:(Closure_id.to_string callee's_closure_id ^ "_partial")
         (Compilation_unit.get_current_exn ())
     in
-    let function_decl =
-      Function_declaration.create ~code_id
+    let code =
+      Code.create
+        code_id
+        ~params_and_body:(Present params_and_body)
+        ~newer_version_of:None
         ~params_arity:(KP.List.arity remaining_params)
         ~result_arity
         ~stub:true
-        ~dbg
         ~inline:Default_inline
         ~is_a_functor:false
         ~recursive
-        ~is_tupled:false
+    in
+    let function_decl =
+      Function_declaration.create ~code_id ~is_tupled:false ~dbg 
     in
     let function_decls =
       Function_declarations.create
@@ -997,27 +1001,25 @@ and simplify_direct_partial_application
     let closure_elements =
       Var_within_closure.Map.of_list applied_args_with_closure_vars
     in
-    let dummy_code =
+    let defining_expr =
+      Lifted_constant.create_code code_id (Code code)
+    in
+    let dummy_defining_expr =
       (* We should not add the real piece of code in the lifted constant.
          A new piece of code will always be generated when the [Let] we
          generate below is simplified.  As such we can simply add a lifted
          constant identifying deleted code.  This will ensure, if for some
          reason the constant makes it to Cmm stage, that code size is not
          increased unnecessarily. *)
-      Lifted_constant.create_code code_id
-        (Code (Static_const.Code.deleted code_id))
-    in
-    let code =
-      Lifted_constant.create_code code_id
-        (Code (Static_const.Code.create code_id
-          ~params_and_body:(Present params_and_body)
-          ~newer_version_of:None))
+      Lifted_constant.create_code code_id (Code (Code.make_deleted code))
     in
     let dacc =
-      DA.add_lifted_constant dacc dummy_code
-      |> DA.map_denv ~f:(fun denv -> DE.add_lifted_constant denv code)
+      DA.add_lifted_constant dacc dummy_defining_expr
+      |> DA.map_denv ~f:(fun denv -> DE.add_lifted_constant denv defining_expr)
     in
-    Set_of_closures.create function_decls ~closure_elements, dacc, dummy_code
+    Set_of_closures.create function_decls ~closure_elements,
+    dacc,
+    dummy_defining_expr
   in
   let apply_cont =
     Apply_cont.create apply_continuation
@@ -1100,7 +1102,7 @@ and simplify_direct_function_call
          Since direct calls adopt the calling convention of the code's body
          (whereas indirect_unknown_arity calls use the convention of the
          function_declaration), we here need the arity of the callee's body *)
-      let param_arity = Function_params_and_body.params_arity callee's_code in
+      let param_arity = Code.params_arity callee's_code in
       let num_params = List.length param_arity in
       if provided_num_args = num_params then
         simplify_direct_full_application dacc apply function_decl_opt
@@ -1274,11 +1276,12 @@ and simplify_function_call
         | Some newer -> Rec_info.merge rec_info ~newer
       in
       let callee's_code_id_from_type = I.code_id inlinable in
+      let callee's_code = DE.find_code denv callee's_code_id_from_type in
       let must_be_detupled = call_must_be_detupled (I.is_tupled inlinable) in
       simplify_direct_function_call dacc apply ~callee's_code_id_from_type
         ~callee's_code_id_from_call_kind ~callee's_closure_id ~arg_types
-        ~result_arity:(I.result_arity inlinable)
-        ~recursive:(I.recursive inlinable)
+        ~result_arity:(Code.result_arity callee's_code)
+        ~recursive:(Code.recursive callee's_code)
         ~must_be_detupled
         (Some (inlinable, function_decl_rec_info)) k
     | Ok (Non_inlinable non_inlinable) ->
@@ -1291,11 +1294,14 @@ and simplify_function_call
         | Indirect_known_arity _ -> None
       in
       let must_be_detupled = call_must_be_detupled (N.is_tupled non_inlinable) in
+      let callee's_code_from_type =
+        DE.find_code denv callee's_code_id_from_type
+      in
       simplify_direct_function_call dacc apply ~callee's_code_id_from_type
         ~callee's_code_id_from_call_kind
         ~callee's_closure_id ~arg_types
-        ~result_arity:(N.result_arity non_inlinable)
-        ~recursive:(N.recursive non_inlinable)
+        ~result_arity:(Code.result_arity callee's_code_from_type)
+        ~recursive:(Code.recursive callee's_code_from_type)
         ~must_be_detupled
         None k
     | Bottom ->

--- a/middle_end/flambda/simplify/simplify_import.ml
+++ b/middle_end/flambda/simplify/simplify_import.ml
@@ -18,6 +18,7 @@
 
 module Apply = Flambda.Apply
 module Apply_cont = Flambda.Apply_cont
+module Code = Flambda.Code
 module Continuation_handler = Flambda.Continuation_handler
 module Continuation_handlers = Flambda.Continuation_handlers
 module Continuation_params_and_handler = Flambda.Continuation_params_and_handler

--- a/middle_end/flambda/simplify/simplify_import.mli
+++ b/middle_end/flambda/simplify/simplify_import.mli
@@ -18,6 +18,7 @@
 
 module Apply = Flambda.Apply
 module Apply_cont = Flambda.Apply_cont
+module Code = Flambda.Code
 module Continuation_handler = Flambda.Continuation_handler
 module Continuation_handlers = Flambda.Continuation_handlers
 module Continuation_params_and_handler = Flambda.Continuation_params_and_handler

--- a/middle_end/flambda/simplify/simplify_set_of_closures.rec.ml
+++ b/middle_end/flambda/simplify/simplify_set_of_closures.rec.ml
@@ -409,7 +409,10 @@ let simplify_function context ~used_closure_vars ~shareable_constants
     let code =
       code
       |> Code.with_code_id new_code_id
-      |> Code.with_newer_version_of (Some old_code_id)
+      (* CR lmaurer: Setting newer_version_of seems obviously correct here,
+         but it causes errors about deleted code. We should either fix those
+         errors or explain here why we can't set newer_version_of. *)
+      (* |> Code.with_newer_version_of (Some old_code_id) *)
       |> Code.with_params_and_body (Present params_and_body)
     in
     let function_decl = FD.update_code_id function_decl new_code_id in

--- a/middle_end/flambda/simplify/simplify_set_of_closures.rec.ml
+++ b/middle_end/flambda/simplify/simplify_set_of_closures.rec.ml
@@ -409,10 +409,7 @@ let simplify_function context ~used_closure_vars ~shareable_constants
     let code =
       code
       |> Code.with_code_id new_code_id
-      (* CR lmaurer: Setting newer_version_of seems obviously correct here,
-         but it causes errors about deleted code. We should either fix those
-         errors or explain here why we can't set newer_version_of. *)
-      (* |> Code.with_newer_version_of (Some old_code_id) *)
+      |> Code.with_newer_version_of (Some old_code_id)
       |> Code.with_params_and_body (Present params_and_body)
     in
     let function_decl = FD.update_code_id function_decl new_code_id in

--- a/middle_end/flambda/simplify/simplify_set_of_closures.rec.ml
+++ b/middle_end/flambda/simplify/simplify_set_of_closures.rec.ml
@@ -31,21 +31,12 @@ let function_decl_type denv function_decl ?code_id ?params_and_body rec_info =
   if Inlining_decision.Function_declaration_decision.can_inline decision then
     T.create_inlinable_function_declaration
       ~code_id
-      ~param_arity:(FD.params_arity function_decl)
-      ~result_arity:(FD.result_arity function_decl)
-      ~stub:(FD.stub function_decl)
       ~dbg:(FD.dbg function_decl)
-      ~inline:(FD.inline function_decl)
-      ~is_a_functor:(FD.is_a_functor function_decl)
-      ~recursive:(FD.recursive function_decl)
       ~is_tupled:(FD.is_tupled function_decl)
       ~rec_info
   else
     T.create_non_inlinable_function_declaration
       ~code_id
-      ~param_arity:(FD.params_arity function_decl)
-      ~result_arity:(FD.result_arity function_decl)
-      ~recursive:(FD.recursive function_decl)
       ~is_tupled:(FD.is_tupled function_decl)
 
 module Context_for_multiple_sets_of_closures : sig
@@ -69,8 +60,6 @@ module Context_for_multiple_sets_of_closures : sig
 
   val old_to_new_code_ids_all_sets : t -> Code_id.t Code_id.Map.t
 
-  val new_to_old_code_ids_all_sets : t -> Code_id.t Code_id.Map.t
-
   val closure_bound_names_inside_functions_all_sets
      : t
     -> Name_in_binding_pos.t Closure_id.Map.t list
@@ -87,9 +76,6 @@ end = struct
   let dacc_inside_functions t = t.dacc_inside_functions
 
   let old_to_new_code_ids_all_sets t = t.old_to_new_code_ids_all_sets
-
-  let new_to_old_code_ids_all_sets t =
-    Code_id.invert_map (old_to_new_code_ids_all_sets t)
 
   let closure_bound_names_inside_functions_all_sets t =
     t.closure_bound_names_inside_functions_all_sets
@@ -234,9 +220,12 @@ end = struct
 
   let bind_existing_code_to_new_code_ids denv ~old_to_new_code_ids_all_sets =
     Code_id.Map.fold (fun old_code_id new_code_id denv ->
-        let params_and_body = DE.find_code denv old_code_id in
-        DE.define_code denv ~code_id:new_code_id ~newer_version_of:old_code_id
-          ~params_and_body)
+        let code =
+          DE.find_code denv old_code_id
+          |> Code.with_newer_version_of (Some old_code_id)
+          |> Code.with_code_id new_code_id
+        in
+        DE.define_code denv ~code_id:new_code_id ~code)
       old_to_new_code_ids_all_sets
       denv
 
@@ -331,7 +320,7 @@ let dacc_inside_function context ~used_closure_vars ~shareable_constants
 type simplify_function_result = {
   function_decl : FD.t;
   new_code_id : Code_id.t;
-  params_and_body : Function_params_and_body.t;
+  code : Code.t;
   function_type : T.Function_declaration_type.t;
   dacc_after_body : DA.t;
   uacc_after_upwards_traversal : UA.t;
@@ -343,8 +332,15 @@ let simplify_function context ~used_closure_vars ~shareable_constants
   let name = Closure_id.to_string closure_id in
   Profile.record_call ~accumulate:true name (fun () ->
     let code_id = FD.code_id function_decl in
-    let params_and_body =
+    let code =
       DE.find_code (DA.denv (C.dacc_prior_to_sets context)) code_id
+    in
+    let params_and_body =
+      match Code.params_and_body code with
+      | Deleted ->
+        Misc.fatal_errorf "Simplifying deleted code %a" Code_id.print code_id
+      | Present params_and_body ->
+        params_and_body
     in
     let params_and_body, dacc_after_body, uacc_after_upwards_traversal =
       Function_params_and_body.pattern_match params_and_body
@@ -379,7 +375,7 @@ let simplify_function context ~used_closure_vars ~shareable_constants
           match
             Simplify_toplevel.simplify_toplevel dacc body
               ~return_continuation
-              ~return_arity:(FD.result_arity function_decl)
+              ~return_arity:(Code.result_arity code)
               exn_continuation
               ~return_cont_scope:Scope.initial
               ~exn_cont_scope:(Scope.next Scope.initial)
@@ -414,6 +410,11 @@ let simplify_function context ~used_closure_vars ~shareable_constants
     let new_code_id =
       Code_id.Map.find old_code_id (C.old_to_new_code_ids_all_sets context)
     in
+    let code =
+      code
+      |> Code.with_code_id new_code_id
+      |> Code.with_params_and_body (Present params_and_body)
+    in
     let function_decl = FD.update_code_id function_decl new_code_id in
     let function_type =
       (* We need to use [dacc_after_body] to ensure that all [code_ids] in
@@ -423,7 +424,7 @@ let simplify_function context ~used_closure_vars ~shareable_constants
     in
     { function_decl;
       new_code_id;
-      params_and_body;
+      code;
       function_type;
       dacc_after_body;
       uacc_after_upwards_traversal;
@@ -431,7 +432,7 @@ let simplify_function context ~used_closure_vars ~shareable_constants
 
 type simplify_set_of_closures0_result = {
   set_of_closures : Flambda.Set_of_closures.t;
-  code : Flambda.Function_params_and_body.t Code_id.Lmap.t;
+  code : Code.t Code_id.Lmap.t;
   dacc : Downwards_acc.t;
 }
 
@@ -454,7 +455,7 @@ let simplify_set_of_closures0 dacc context set_of_closures
            (result_function_decls_in_set, code, fun_types,
             code_age_relation, used_closure_vars, shareable_constants,
             lifted_consts_prev_functions) ->
-        let { function_decl; new_code_id; params_and_body; function_type;
+        let { function_decl; new_code_id; code = new_code; function_type;
               dacc_after_body; uacc_after_upwards_traversal; } =
           simplify_function context ~used_closure_vars ~shareable_constants
             closure_id function_decl
@@ -476,7 +477,7 @@ let simplify_set_of_closures0 dacc context set_of_closures
         let result_function_decls_in_set =
           (closure_id, function_decl) :: result_function_decls_in_set
         in
-        let code = (new_code_id, params_and_body) :: code in
+        let code = (new_code_id, new_code) :: code in
         let fun_types = Closure_id.Map.add closure_id function_type fun_types in
         let lifted_consts_prev_functions =
           LCS.union lifted_consts_this_function lifted_consts_prev_functions
@@ -628,15 +629,7 @@ let simplify_and_lift_set_of_closures dacc ~closure_bound_vars_inverse
   let dacc =
     ListLabels.fold_left (Code_id.Lmap.bindings code)
       ~init:dacc
-      ~f:(fun dacc (code_id, params_and_body) ->
-        let newer_version_of =
-          Code_id.Map.find code_id (C.new_to_old_code_ids_all_sets context)
-        in
-        let code =
-          SC.Code.create code_id
-            ~params_and_body:(Present params_and_body)
-            ~newer_version_of:(Some newer_version_of)
-        in
+      ~f:(fun dacc (code_id, code) ->
         let lifted_constant = LC.create_code code_id (Code code) in
         DA.add_lifted_constant dacc lifted_constant
         |> DA.map_denv ~f:(fun denv ->
@@ -701,16 +694,10 @@ let simplify_non_lifted_set_of_closures0 dacc bound_vars ~closure_bound_vars
     Reachable.reachable (Named.create_set_of_closures set_of_closures)
   in
   let lifted_constants =
-    let newer_versions_of = C.new_to_old_code_ids_all_sets context in
-    Code_id.Lmap.fold (fun code_id params_and_body lifted_constants ->
-        let newer_version_of =
-          Some (Code_id.Map.find code_id newer_versions_of)
-        in
+    Code_id.Lmap.fold (fun code_id code lifted_constants ->
         let lifted_constant =
           LC.create_code code_id
-            (Code (Static_const.Code.create code_id
-              ~params_and_body:(Present params_and_body)
-              ~newer_version_of))
+            (Code code)
         in
         lifted_constant :: lifted_constants)
       code
@@ -848,23 +835,10 @@ let simplify_lifted_set_of_closures0 context ~closure_symbols
   let dacc =
     DA.map_denv dacc ~f:(fun denv ->
       (* CR mshinwell: factor out *)
-      Code_id.Lmap.fold (fun code_id params_and_body denv ->
-          let newer_version_of =
-            Code_id.Map.find code_id (C.new_to_old_code_ids_all_sets context)
-          in
-          DE.define_code ~newer_version_of denv ~code_id ~params_and_body)
+      Code_id.Lmap.fold (fun code_id code denv ->
+          DE.define_code denv ~code_id ~code)
         code
         denv)
-  in
-  let code =
-    Code_id.Lmap.mapi (fun code_id params_and_body ->
-        let newer_version_of =
-          Code_id.Map.find_opt code_id (C.new_to_old_code_ids_all_sets context)
-        in
-        SC.Code.create code_id
-          ~params_and_body:(Present params_and_body)
-          ~newer_version_of)
-      code
   in
   let code_patterns =
     Code_id.Lmap.keys code

--- a/middle_end/flambda/simplify/simplify_set_of_closures.rec.ml
+++ b/middle_end/flambda/simplify/simplify_set_of_closures.rec.ml
@@ -336,11 +336,7 @@ let simplify_function context ~used_closure_vars ~shareable_constants
       DE.find_code (DA.denv (C.dacc_prior_to_sets context)) code_id
     in
     let params_and_body =
-      match Code.params_and_body code with
-      | Deleted ->
-        Misc.fatal_errorf "Simplifying deleted code %a" Code_id.print code_id
-      | Present params_and_body ->
-        params_and_body
+      Code.params_and_body_must_be_present code ~error_context:"Simplifying"
     in
     let params_and_body, dacc_after_body, uacc_after_upwards_traversal =
       Function_params_and_body.pattern_match params_and_body
@@ -413,6 +409,7 @@ let simplify_function context ~used_closure_vars ~shareable_constants
     let code =
       code
       |> Code.with_code_id new_code_id
+      |> Code.with_newer_version_of (Some old_code_id)
       |> Code.with_params_and_body (Present params_and_body)
     in
     let function_decl = FD.update_code_id function_decl new_code_id in

--- a/middle_end/flambda/simplify/simplify_static_const.rec.ml
+++ b/middle_end/flambda/simplify/simplify_static_const.rec.ml
@@ -188,12 +188,11 @@ let simplify_static_consts dacc (bound_symbols : Bound_symbols.t)
       ~init:([], [], dacc)
       ~code:(fun (bound_symbols, static_consts, dacc) code_id code ->
         let dacc =
-          match SC.Code.params_and_body code with
-          | None -> dacc
-          | Some params_and_body ->
-            let newer_version_of = code.newer_version_of in
+          match Code.params_and_body code with
+          | Deleted -> dacc
+          | Present _ ->
             DA.map_denv dacc ~f:(fun denv ->
-              DE.define_code denv ?newer_version_of ~code_id ~params_and_body)
+              DE.define_code denv ~code_id ~code)
         in
         (Bound_symbols.Pattern.code code_id) :: bound_symbols,
           (SC.Code code) :: static_consts,

--- a/middle_end/flambda/terms/code.rec.ml
+++ b/middle_end/flambda/terms/code.rec.ml
@@ -37,6 +37,11 @@ let params_and_body_opt { params_and_body; _ } =
   | Deleted -> None
   | Present params_and_body -> Some params_and_body
 
+let params_and_body_must_be_present ~error_context { params_and_body; _ } =
+  match params_and_body with
+  | Deleted -> Misc.fatal_errorf "%s: params and body are deleted" error_context
+  | Present params_and_body -> params_and_body
+
 let newer_version_of { newer_version_of; _ } = newer_version_of
 
 let params_arity { params_arity; _ } = params_arity

--- a/middle_end/flambda/terms/code.rec.ml
+++ b/middle_end/flambda/terms/code.rec.ml
@@ -1,0 +1,239 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Pierre Chambart, OCamlPro                        *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2013--2020 OCamlPro SAS                                    *)
+(*   Copyright 2014--2020 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+type t = {
+  code_id : Code_id.t;
+  params_and_body : Function_params_and_body.t Or_deleted.t;
+  newer_version_of : Code_id.t option;
+  params_arity : Flambda_arity.t;
+  result_arity : Flambda_arity.t;
+  stub : bool;
+  inline : Inline_attribute.t;
+  is_a_functor : bool;
+  recursive : Recursive.t;
+}
+
+let code_id { code_id; _ } = code_id
+
+let params_and_body { params_and_body; _ } = params_and_body
+
+let params_and_body_opt { params_and_body; _ } =
+  match params_and_body with
+  | Deleted -> None
+  | Present params_and_body -> Some params_and_body
+
+let newer_version_of { newer_version_of; _ } = newer_version_of
+
+let params_arity { params_arity; _ } = params_arity
+
+let result_arity { result_arity; _ } = result_arity
+
+let stub { stub; _ } = stub
+
+let inline { inline; _ } = inline
+
+let is_a_functor { is_a_functor; _ } = is_a_functor
+
+let recursive { recursive; _ } = recursive
+
+let create
+      code_id
+      ~params_and_body
+      ~newer_version_of
+      ~params_arity
+      ~result_arity
+      ~stub
+      ~(inline:Inline_attribute.t)
+      ~is_a_functor
+      ~recursive =
+  begin match stub, inline with
+  | true, (Never_inline | Default_inline)
+  | false, (Never_inline | Default_inline | Always_inline | Unroll _) -> ()
+  | true, (Always_inline | Unroll _) ->
+    Misc.fatal_error "Stubs may not be annotated as [Always_inline] or [Unroll]"
+  end;
+  { code_id;
+    params_and_body;
+    newer_version_of;
+    params_arity;
+    result_arity;
+    stub;
+    inline;
+    is_a_functor;
+    recursive;
+  }
+
+let with_code_id code_id t = { t with code_id }
+
+let with_params_and_body params_and_body t = { t with params_and_body }
+
+let with_newer_version_of newer_version_of t = { t with newer_version_of }
+
+let print_params_and_body_with_cache ~cache ppf params_and_body =
+  match params_and_body with
+  | Or_deleted.Deleted -> Format.fprintf ppf "Deleted"
+  | Or_deleted.Present params_and_body ->
+    Function_params_and_body.print_with_cache ~cache ppf
+      params_and_body
+
+let print_with_cache ~cache ppf
+      { code_id = _; params_and_body; newer_version_of; stub; inline;
+        is_a_functor; params_arity; result_arity; recursive; } =
+  let module C = Flambda_colours in
+  Format.fprintf ppf "@[<hov 1>(\
+      @[<hov 1>@<0>%s(newer_version_of@ %a)@<0>%s@]@ \
+      @[<hov 1>@<0>%s(stub@ %b)@<0>%s@]@ \
+      @[<hov 1>@<0>%s(inline@ %a)@<0>%s@]@ \
+      @[<hov 1>@<0>%s(is_a_functor@ %b)@<0>%s@]@ \
+      @[<hov 1>@<0>%s(params_arity@ @<0>%s%a@<0>%s)@<0>%s@]@ \
+      @[<hov 1>@<0>%s(result_arity@ @<0>%s%a@<0>%s)@<0>%s@]@ \
+      @[<hov 1>@<0>%s(recursive@ %a)@<0>%s@]@ \
+      %a\
+      )@]"
+    (if Option.is_none newer_version_of then Flambda_colours.elide ()
+     else Flambda_colours.normal ())
+    (Misc.Stdlib.Option.print_compact Code_id.print) newer_version_of
+    (Flambda_colours.normal ())
+    (if not stub then Flambda_colours.elide () else C.normal ())
+    stub
+    (Flambda_colours.normal ())
+    (if Inline_attribute.is_default inline
+     then Flambda_colours.elide ()
+     else C.normal ())
+    Inline_attribute.print inline
+    (Flambda_colours.normal ())
+    (if not is_a_functor then Flambda_colours.elide () else C.normal ())
+    is_a_functor
+    (Flambda_colours.normal ())
+    (if Flambda_arity.is_singleton_value params_arity
+     then Flambda_colours.elide ()
+     else Flambda_colours.normal ())
+    (Flambda_colours.normal ())
+    Flambda_arity.print params_arity
+    (if Flambda_arity.is_singleton_value params_arity
+     then Flambda_colours.elide ()
+     else Flambda_colours.normal ())
+    (Flambda_colours.normal ())
+    (if Flambda_arity.is_singleton_value result_arity
+     then Flambda_colours.elide ()
+     else Flambda_colours.normal ())
+    (Flambda_colours.normal ())
+    Flambda_arity.print result_arity
+    (if Flambda_arity.is_singleton_value result_arity
+     then Flambda_colours.elide ()
+     else Flambda_colours.normal ())
+    (Flambda_colours.normal ())
+    (match recursive with
+     | Non_recursive -> Flambda_colours.elide ()
+     | Recursive -> Flambda_colours.normal ())
+    Recursive.print recursive
+    (Flambda_colours.normal ())
+    (print_params_and_body_with_cache ~cache) params_and_body
+
+let print ppf code =
+  print_with_cache ~cache:(Printing_cache.create ()) ppf code
+
+let compare { code_id = code_id1; _ } { code_id = code_id2; _ } =
+  Code_id.compare code_id1 code_id2
+
+let free_names { code_id = _; params_and_body; newer_version_of;
+                 params_arity = _; result_arity = _; stub = _; inline = _;
+                 is_a_functor = _; recursive = _; } =
+  (* [code_id] is only in [t] for the use of [compare]; it doesn't
+     count as a free name. *)
+  let from_newer_version_of =
+    match newer_version_of with
+    | None -> Name_occurrences.empty
+    | Some older ->
+      Name_occurrences.add_newer_version_of_code_id
+        Name_occurrences.empty older Name_mode.normal
+  in
+  let from_params_and_body =
+    match params_and_body with
+    | Deleted -> Name_occurrences.empty
+    | Present params_and_body ->
+      Function_params_and_body.free_names params_and_body
+  in
+  Name_occurrences.union from_newer_version_of from_params_and_body
+
+let apply_name_permutation
+      ({ code_id = _; params_and_body; newer_version_of = _; params_arity = _;
+         result_arity = _; stub = _; inline = _; is_a_functor = _;
+         recursive = _; } as t)
+      perm =
+  let params_and_body' : Function_params_and_body.t Or_deleted.t =
+    match params_and_body with
+    | Deleted -> Deleted
+    | Present params_and_body_inner ->
+      let params_and_body_inner' =
+        Function_params_and_body.apply_name_permutation
+          params_and_body_inner perm
+      in
+      if params_and_body_inner == params_and_body_inner' then
+        params_and_body
+      else
+        Present params_and_body_inner'
+  in
+  if params_and_body == params_and_body' then t
+  else
+    { t with params_and_body = params_and_body'; }
+
+let all_ids_for_export { code_id; params_and_body; newer_version_of;
+                         params_arity = _; result_arity = _; stub = _;
+                         inline = _; is_a_functor = _; recursive = _;} =
+  let newer_version_of_ids =
+    match newer_version_of with
+    | None -> Ids_for_export.empty
+    | Some older ->
+      Ids_for_export.add_code_id Ids_for_export.empty older
+  in
+  let params_and_body_ids =
+    match params_and_body with
+    | Deleted -> Ids_for_export.empty
+    | Present params_and_body ->
+      Function_params_and_body.all_ids_for_export params_and_body
+  in
+  Ids_for_export.add_code_id
+    (Ids_for_export.union newer_version_of_ids params_and_body_ids)
+    code_id
+
+let import import_map
+      ({ code_id; params_and_body; newer_version_of; params_arity = _;
+         result_arity = _; stub = _; inline = _; is_a_functor = _;
+         recursive = _; } as t) =
+  let code_id = Ids_for_export.Import_map.code_id import_map code_id in
+  let params_and_body : Function_params_and_body.t Or_deleted.t =
+    match params_and_body with
+    | Deleted -> Deleted
+    | Present params_and_body ->
+      let params_and_body =
+        Function_params_and_body.import import_map params_and_body
+      in
+      Present params_and_body
+  in
+  let newer_version_of =
+    match newer_version_of with
+    | None -> None
+    | Some older ->
+      let older = Ids_for_export.Import_map.code_id import_map older in
+      Some older
+  in
+  { t with code_id; params_and_body; newer_version_of; }
+
+let make_deleted t =
+  { t with params_and_body = Deleted; }

--- a/middle_end/flambda/terms/code.rec.mli
+++ b/middle_end/flambda/terms/code.rec.mli
@@ -28,6 +28,11 @@ val params_and_body : t -> Function_params_and_body.t Or_deleted.t
 
 val params_and_body_opt : t -> Function_params_and_body.t option
 
+val params_and_body_must_be_present
+   : error_context:string
+  -> t
+  -> Function_params_and_body.t
+
 val newer_version_of : t -> Code_id.t option
 
 val params_arity : t -> Flambda_arity.t

--- a/middle_end/flambda/terms/code.rec.mli
+++ b/middle_end/flambda/terms/code.rec.mli
@@ -1,0 +1,79 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Pierre Chambart, OCamlPro                        *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2013--2020 OCamlPro SAS                                    *)
+(*   Copyright 2014--2020 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+(** A piece of code, comprising of the parameters and body of a function,
+    together with a field indicating whether the piece of code is a newer
+    version of one that existed previously (and may still exist), for
+    example after a round of simplification. *)
+type t
+
+val code_id : t -> Code_id.t
+
+val params_and_body : t -> Function_params_and_body.t Or_deleted.t
+
+val params_and_body_opt : t -> Function_params_and_body.t option
+
+val newer_version_of : t -> Code_id.t option
+
+val params_arity : t -> Flambda_arity.t
+
+val result_arity : t -> Flambda_arity.t
+
+val stub : t -> bool
+
+val inline : t -> Inline_attribute.t
+
+val is_a_functor : t -> bool
+
+val recursive : t -> Recursive.t
+
+val create
+   : Code_id.t  (** needed for [compare], although useful otherwise too *)
+  -> params_and_body:Function_params_and_body.t Or_deleted.t
+  -> newer_version_of:Code_id.t option
+  -> params_arity:Flambda_arity.t
+  -> result_arity:Flambda_arity.t
+  -> stub:bool
+  -> inline:Inline_attribute.t
+  -> is_a_functor:bool
+  -> recursive:Recursive.t
+  -> t
+
+val with_code_id : Code_id.t -> t -> t
+
+val with_params_and_body : Function_params_and_body.t Or_deleted.t -> t -> t
+
+val with_newer_version_of : Code_id.t option -> t -> t
+
+val make_deleted : t -> t
+
+include Contains_names.S with type t := t
+
+val print_with_cache : cache:Printing_cache.t -> Format.formatter -> t -> unit
+
+val print : Format.formatter -> t -> unit
+
+val all_ids_for_export : t -> Ids_for_export.t
+
+val import : Ids_for_export.Import_map.t -> t -> t
+
+val compare : t -> t -> int
+
+(* CR mshinwell: Somewhere there should be an invariant check that
+   code has no free names. *)
+

--- a/middle_end/flambda/terms/dune
+++ b/middle_end/flambda/terms/dune
@@ -3,6 +3,8 @@
   (deps
     rec_modules
     template/flambda.templ.ml
+    code.rec.ml
+    code.rec.mli
     continuation_handler.rec.ml
     continuation_handler.rec.mli
     continuation_handlers.rec.ml

--- a/middle_end/flambda/terms/expr.rec.ml
+++ b/middle_end/flambda/terms/expr.rec.ml
@@ -378,11 +378,18 @@ let create_let_cont let_cont = create (Let_cont let_cont)
 let create_apply apply = create (Apply apply)
 let create_apply_cont apply_cont = create (Apply_cont apply_cont)
 
-let create_invalid () =
-  if !Clflags.treat_invalid_code_as_unreachable then
-    create (Invalid Treat_as_unreachable)
-  else
-    create (Invalid Halt_and_catch_fire)
+let create_invalid ?semantics () =
+  let semantics : Invalid_term_semantics.t =
+    match semantics with
+    | Some semantics ->
+      semantics
+    | None -> 
+      if !Clflags.treat_invalid_code_as_unreachable then
+        Treat_as_unreachable
+      else
+        Halt_and_catch_fire
+  in
+  create (Invalid semantics)
 
 type switch_creation_result =
   | Have_deleted_comparison_but_not_branch

--- a/middle_end/flambda/terms/expr.rec.mli
+++ b/middle_end/flambda/terms/expr.rec.mli
@@ -111,7 +111,7 @@ val create_if_then_else
   -> t
 
 (** Create an expression indicating type-incorrect or unreachable code. *)
-val create_invalid : unit -> t
+val create_invalid : ?semantics:Invalid_term_semantics.t -> unit -> t
 
 (** [bind [var1, expr1; ...; varN, exprN] body] binds using
     [Immutable] [Let] expressions the given [(var, expr)] pairs around the

--- a/middle_end/flambda/terms/flambda.mli
+++ b/middle_end/flambda/terms/flambda.mli
@@ -128,7 +128,7 @@ module rec Expr : sig
     -> t
 
   (** Create an expression indicating type-incorrect or unreachable code. *)
-  val create_invalid : unit -> t
+  val create_invalid : ?semantics:Invalid_term_semantics.t -> unit -> t
 
   (** [bind [var1, expr1; ...; varN, exprN] body] binds using
       [Immutable] [Let] expressions the given [(var, expr)] pairs around the
@@ -539,39 +539,6 @@ end and Static_const : sig
     include Identifiable.S with type t := t
   end
 
-  (** A piece of code, comprising of the parameters and body of a function,
-      together with a field indicating whether the piece of code is a newer
-      version of one that existed previously (and may still exist), for
-      example after a round of simplification. *)
-  module Code : sig
-    type t = private {
-      code_id : Code_id.t;
-      params_and_body : Function_params_and_body.t or_deleted;
-      newer_version_of : Code_id.t option;
-    }
-    and 'a or_deleted =
-      | Present of 'a
-      | Deleted
-
-    val print : Format.formatter -> t -> unit
-
-    val free_names : t -> Name_occurrences.t
-
-    val create
-       : Code_id.t
-      -> params_and_body:Function_params_and_body.t or_deleted
-      -> newer_version_of:Code_id.t option
-      -> t
-
-    (** A piece of code that is [Deleted] with no [newer_version_of]. *)
-    val deleted : Code_id.t -> t
-
-    val code_id : t -> Code_id.t
-    val params_and_body : t -> Function_params_and_body.t option
-
-    val make_deleted : t -> t
-  end
-
   (* CR mshinwell: Somewhere there should be an invariant check that
     code has no free names. *)
 
@@ -654,6 +621,60 @@ end and Static_const : sig
 
     val is_fully_static : t -> bool
   end
+end and Code : sig
+
+  (** A piece of code, comprising of the parameters and body of a function,
+      together with a field indicating whether the piece of code is a newer
+      version of one that existed previously (and may still exist), for
+      example after a round of simplification. *)
+  type t
+
+  val code_id : t -> Code_id.t
+
+  val params_and_body : t -> Function_params_and_body.t Or_deleted.t
+
+  val newer_version_of : t -> Code_id.t option
+
+  val params_arity : t -> Flambda_arity.t
+
+  val result_arity : t -> Flambda_arity.t
+
+  val stub : t -> bool
+
+  val inline : t -> Inline_attribute.t
+
+  val is_a_functor : t -> bool
+
+  val recursive : t -> Recursive.t
+
+  val create
+     : Code_id.t
+    -> params_and_body:Function_params_and_body.t Or_deleted.t
+    -> newer_version_of:Code_id.t option
+    -> params_arity:Flambda_arity.t
+    -> result_arity:Flambda_arity.t
+    -> stub:bool
+    -> inline:Inline_attribute.t
+    -> is_a_functor:bool
+    -> recursive:Recursive.t
+    -> t
+
+  val with_code_id : Code_id.t -> t -> t
+
+  val with_params_and_body : Function_params_and_body.t Or_deleted.t -> t -> t
+
+  val with_newer_version_of : Code_id.t option -> t -> t
+
+  val print : Format.formatter -> t -> unit
+
+  val free_names : t -> Name_occurrences.t
+
+  val all_ids_for_export : t -> Ids_for_export.t
+
+  val import : Ids_for_export.Import_map.t -> t -> t
+
+  val make_deleted : t -> t
+
 end
 
 module Function_declaration = Function_declaration
@@ -667,6 +688,7 @@ module Set_of_closures = Set_of_closures
 module Import : sig
   module Apply = Apply
   module Apply_cont = Apply_cont
+  module Code = Code
   module Continuation_handler = Continuation_handler
   module Continuation_handlers = Continuation_handlers
   module Continuation_params_and_handler = Continuation_params_and_handler

--- a/middle_end/flambda/terms/flambda.mli
+++ b/middle_end/flambda/terms/flambda.mli
@@ -619,6 +619,8 @@ end and Static_const : sig
 
     val pieces_of_code' : t -> Code.t list
 
+    val pieces_of_code_by_code_id : t -> Code.t Code_id.Map.t
+
     val is_fully_static : t -> bool
   end
 end and Code : sig
@@ -632,6 +634,11 @@ end and Code : sig
   val code_id : t -> Code_id.t
 
   val params_and_body : t -> Function_params_and_body.t Or_deleted.t
+
+  val params_and_body_must_be_present
+     : error_context:string
+    -> t
+    -> Function_params_and_body.t
 
   val newer_version_of : t -> Code_id.t option
 

--- a/middle_end/flambda/terms/function_declaration.ml
+++ b/middle_end/flambda/terms/function_declaration.ml
@@ -18,104 +18,30 @@
 
 type t = {
   code_id : Code_id.t;
-  params_arity : Flambda_arity.t;
-  result_arity : Flambda_arity.t;
-  stub : bool;
   dbg : Debuginfo.t;
-  inline : Inline_attribute.t;
-  is_a_functor : bool;
-  recursive : Recursive.t;
   is_tupled : bool;
 }
 
-let invariant _env t =
-  (* check arity of tupled functions *)
-  if t.is_tupled then begin
-    match t.params_arity with
-    | [Value] -> ()
-    | _ ->
-      Misc.fatal_errorf "tupled functions must take a single value as argument"
-  end
+let invariant _env _t = ()
 
-let create ~code_id ~params_arity ~result_arity ~stub ~dbg
-      ~(inline : Inline_attribute.t)
-      ~is_a_functor ~recursive ~is_tupled : t =
-  begin match stub, inline with
-  | true, (Never_inline | Default_inline)
-  | false, (Never_inline | Default_inline | Always_inline | Unroll _) -> ()
-  | true, (Always_inline | Unroll _) ->
-    Misc.fatal_error "Stubs may not be annotated as [Always_inline] or [Unroll]"
-  end;
+let create ~code_id ~dbg ~is_tupled =
   { code_id;
-    params_arity;
-    result_arity;
-    stub;
     dbg;
-    inline;
-    is_a_functor;
-    recursive;
     is_tupled;
   }
 
 let print_with_cache ~cache:_ ppf
       { code_id;
-        params_arity;
-        result_arity;
-        stub;
         dbg;
-        inline;
-        is_a_functor;
-        recursive;
         is_tupled;
       } =
-  let module C = Flambda_colours in
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(code_id@ %a)@]@ \
-      @[<hov 1>@<0>%s(stub@ %b)@<0>%s@]@ \
       @[<hov 1>@<0>%s(dbg@ %a)@<0>%s@]@ \
-      @[<hov 1>@<0>%s(inline@ %a)@<0>%s@]@ \
-      @[<hov 1>@<0>%s(is_a_functor@ %b)@<0>%s@]@ \
-      @[<hov 1>@<0>%s(params_arity@ @<0>%s%a@<0>%s)@<0>%s@]@ \
-      @[<hov 1>@<0>%s(result_arity@ @<0>%s%a@<0>%s)@<0>%s@]@ \
-      @[<hov 1>@<0>%s(recursive@ %a)@<0>%s@] \
-      @[<hov 1>@<0>%s(is_tupled@ %b)@<0>%s@])"
+      @[<hov 1>@<0>%s(is_tupled @ %b)@<0>%s@])@]"
     Code_id.print code_id
-    (if not stub then Flambda_colours.elide () else C.normal ())
-    stub
-    (Flambda_colours.normal ())
     (Flambda_colours.debuginfo ())
     Debuginfo.print_compact dbg
-    (Flambda_colours.normal ())
-    (if Inline_attribute.is_default inline
-     then Flambda_colours.elide ()
-     else C.normal ())
-    Inline_attribute.print inline
-    (Flambda_colours.normal ())
-    (if not is_a_functor then Flambda_colours.elide () else C.normal ())
-    is_a_functor
-    (Flambda_colours.normal ())
-    (if Flambda_arity.is_singleton_value params_arity
-     then Flambda_colours.elide ()
-     else Flambda_colours.normal ())
-    (Flambda_colours.normal ())
-    Flambda_arity.print params_arity
-    (if Flambda_arity.is_singleton_value params_arity
-     then Flambda_colours.elide ()
-     else Flambda_colours.normal ())
-    (Flambda_colours.normal ())
-    (if Flambda_arity.is_singleton_value result_arity
-     then Flambda_colours.elide ()
-     else Flambda_colours.normal ())
-    (Flambda_colours.normal ())
-    Flambda_arity.print result_arity
-    (if Flambda_arity.is_singleton_value result_arity
-     then Flambda_colours.elide ()
-     else Flambda_colours.normal ())
-    (Flambda_colours.normal ())
-    (match recursive with
-     | Non_recursive -> Flambda_colours.elide ()
-     | Recursive -> Flambda_colours.normal ())
-    Recursive.print recursive
     (Flambda_colours.normal ())
     (if is_tupled
      then Flambda_colours.normal ()
@@ -126,24 +52,12 @@ let print_with_cache ~cache:_ ppf
 let print ppf t = print_with_cache ~cache:(Printing_cache.create ()) ppf t
 
 let code_id t = t.code_id
-let params_arity t = t.params_arity
-let result_arity t = t.result_arity
-let stub t = t.stub
 let dbg t = t.dbg
-let inline t = t.inline
-let is_a_functor t = t.is_a_functor
-let recursive t = t.recursive
 let is_tupled t = t.is_tupled
 
 let free_names
       { code_id;
-        params_arity = _;
-        result_arity = _;
-        stub = _;
         dbg = _;
-        inline = _;
-        is_a_functor = _;
-        recursive = _;
         is_tupled = _;
       } =
   Name_occurrences.add_code_id Name_occurrences.empty code_id Name_mode.normal
@@ -152,37 +66,19 @@ let apply_name_permutation t _perm = t
 
 let all_ids_for_export
       { code_id;
-        params_arity = _;
-        result_arity = _;
-        stub = _;
         dbg = _;
-        inline = _;
-        is_a_functor = _;
-        recursive = _;
         is_tupled = _;
       } =
   Ids_for_export.add_code_id Ids_for_export.empty code_id
 
 let import import_map
       { code_id;
-        params_arity;
-        result_arity;
-        stub;
         dbg;
-        inline;
-        is_a_functor;
-        recursive;
         is_tupled;
       } =
   let code_id = Ids_for_export.Import_map.code_id import_map code_id in
   { code_id;
-    params_arity;
-    result_arity;
-    stub;
     dbg;
-    inline;
-    is_a_functor;
-    recursive;
     is_tupled;
   }
 

--- a/middle_end/flambda/terms/function_declaration.mli
+++ b/middle_end/flambda/terms/function_declaration.mli
@@ -26,13 +26,7 @@ include Contains_ids.S with type t := t
 (** Create a function declaration. *)
 val create
    : code_id:Code_id.t
-  -> params_arity:Flambda_arity.t
-  -> result_arity:Flambda_arity.t
-  -> stub:bool
   -> dbg:Debuginfo.t
-  -> inline:Inline_attribute.t
-  -> is_a_functor:bool
-  -> recursive:Recursive.t
   -> is_tupled:bool
   -> t
 
@@ -40,29 +34,8 @@ val create
     [Define_symbol]). *)
 val code_id : t -> Code_id.t
 
-(* CR mshinwell: Be consistent: "param_arity" or "params_arity" throughout. *)
-val params_arity : t -> Flambda_arity.t
-
-(** The arity of the return continuation of the function.  This provides the
-    number of results that the function produces and their kinds. *)
-(* CR mshinwell: Be consistent everywhere as regards "result" vs "return"
-   arity. *)
-val result_arity : t -> Flambda_arity.t
-
-(** A stub function is a generated function used to prepare arguments or
-    return values to allow indirect calls to functions with a special
-    calling convention.  For instance indirect calls to tuplified functions
-    must go through a stub.  Stubs will be unconditionally inlined. *)
-val stub : t -> bool
-
 (** Debug info for the function declaration. *)
 val dbg : t -> Debuginfo.t
-
-(** Inlining requirements from the source code. *)
-val inline : t -> Inline_attribute.t
-
-(** Whether the function is known definitively to be a functor. *)
-val is_a_functor : t -> bool
 
 (** Whether the function is a tuplified function *)
 val is_tupled : t -> bool
@@ -70,10 +43,6 @@ val is_tupled : t -> bool
 (** Return a function declaration that is like the supplied one except
     that it has a new code ID. *)
 val update_code_id : t -> Code_id.t -> t
-
-(** Whether the function is recursive, in the sense of the syntactic analysis
-    conducted during closure conversion. *)
-val recursive : t -> Recursive.t
 
 val compare : t -> t -> int
 

--- a/middle_end/flambda/terms/let_expr.rec.ml
+++ b/middle_end/flambda/terms/let_expr.rec.ml
@@ -38,7 +38,7 @@ let pattern_match_pair t1 t2 ~f =
 (* For printing "let symbol": *)
 
 type flattened_for_printing_descr =
-  | Code of Code_id.t * Static_const.Code.t
+  | Code of Code_id.t * Code.t
   | Set_of_closures of Symbol.t Closure_id.Lmap.t * Set_of_closures.t
   | Block_like of Symbol.t * Static_const.t
 
@@ -129,7 +129,7 @@ let print_flattened_descr_lhs ppf descr =
 (* CR mshinwell: Use [print_with_cache]? *)
 let print_flattened_descr_rhs ppf descr =
   match descr with
-  | Code (_, code) -> Static_const.Code.print ppf code
+  | Code (_, code) -> Code.print ppf code
   | Set_of_closures (_, set) -> Set_of_closures.print ppf set
   | Block_like (_, static_const) -> Static_const.print ppf static_const
 

--- a/middle_end/flambda/terms/rec_modules
+++ b/middle_end/flambda/terms/rec_modules
@@ -1,3 +1,4 @@
+code.rec.ml
 continuation_handler.rec.ml
 continuation_handlers.rec.ml
 continuation_params_and_handler.rec.ml

--- a/middle_end/flambda/terms/static_const.rec.ml
+++ b/middle_end/flambda/terms/static_const.rec.ml
@@ -595,6 +595,14 @@ module Group = struct
 
   let pieces_of_code' t = List.filter_map to_code t
 
+  let pieces_of_code_by_code_id t =
+    List.filter_map (fun const ->
+      match const with
+      | Code code -> Some (Code.code_id code, code)
+      | _ -> None
+    ) t
+    |> Code_id.Map.of_list
+
   let is_fully_static t = List.for_all is_fully_static t
 
   let concat t1 t2 = t1 @ t2

--- a/middle_end/flambda/terms/static_const.rec.ml
+++ b/middle_end/flambda/terms/static_const.rec.ml
@@ -108,144 +108,6 @@ module Field_of_block = struct
 *)
 end
 
-module Code = struct
-  type t = {
-    code_id : Code_id.t;
-    params_and_body : Function_params_and_body.t or_deleted;
-    newer_version_of : Code_id.t option;
-  }
-  and 'a or_deleted =
-    | Present of 'a
-    | Deleted
-
-  let print_params_and_body_with_cache ~cache ppf params_and_body =
-    match params_and_body with
-    | Deleted -> Format.fprintf ppf "Deleted"
-    | Present params_and_body ->
-      Function_params_and_body.print_with_cache ~cache ppf
-        params_and_body
-
-  let print_with_cache ~cache ppf
-        { code_id = _; params_and_body; newer_version_of; } =
-    Format.fprintf ppf "@[<hov 1>(\
-        @[<hov 1>@<0>%s(newer_version_of@ %a)@<0>%s@]@ \
-        %a\
-        )@]"
-      (if Option.is_none newer_version_of then Flambda_colours.elide ()
-       else Flambda_colours.normal ())
-      (Misc.Stdlib.Option.print_compact Code_id.print) newer_version_of
-      (Flambda_colours.normal ())
-      (print_params_and_body_with_cache ~cache) params_and_body
-
-  let print ppf code =
-    print_with_cache ~cache:(Printing_cache.create ()) ppf code
-
-  let create code_id ~params_and_body ~newer_version_of =
-    { code_id;
-      params_and_body;
-      newer_version_of;
-    }
-
-  let compare { code_id = code_id1; _ } { code_id = code_id2; _ } =
-    Code_id.compare code_id1 code_id2
-
-  let free_names { code_id = _; params_and_body; newer_version_of; } =
-    (* [code_id] is only in [t] for the use of [compare]; it doesn't
-       count as a free name. *)
-    let from_newer_version_of =
-      match newer_version_of with
-      | None -> Name_occurrences.empty
-      | Some older ->
-        Name_occurrences.add_newer_version_of_code_id
-          Name_occurrences.empty older Name_mode.normal
-    in
-    let from_params_and_body =
-      match params_and_body with
-      | Deleted -> Name_occurrences.empty
-      | Present params_and_body ->
-        Function_params_and_body.free_names params_and_body
-    in
-    Name_occurrences.union from_newer_version_of from_params_and_body
-
-  let apply_name_permutation
-        ({ code_id; params_and_body; newer_version_of; } as t) perm =
-    let params_and_body' =
-      match params_and_body with
-      | Deleted -> Deleted
-      | Present params_and_body_inner ->
-        let params_and_body_inner' =
-          Function_params_and_body.apply_name_permutation
-            params_and_body_inner perm
-        in
-        if params_and_body_inner == params_and_body_inner' then
-          params_and_body
-        else
-          Present params_and_body_inner'
-    in
-    if params_and_body == params_and_body' then t
-    else
-      { code_id;
-        params_and_body = params_and_body';
-        newer_version_of;
-      }
-
-  let all_ids_for_export { code_id; params_and_body; newer_version_of; } =
-    let newer_version_of_ids =
-      match newer_version_of with
-      | None -> Ids_for_export.empty
-      | Some older ->
-        Ids_for_export.add_code_id Ids_for_export.empty older
-    in
-    let params_and_body_ids =
-      match params_and_body with
-      | Deleted -> Ids_for_export.empty
-      | Present params_and_body ->
-        Function_params_and_body.all_ids_for_export params_and_body
-    in
-    Ids_for_export.add_code_id
-      (Ids_for_export.union newer_version_of_ids params_and_body_ids)
-      code_id
-
-  let import import_map { code_id; params_and_body; newer_version_of; } =
-    let code_id = Ids_for_export.Import_map.code_id import_map code_id in
-    let params_and_body =
-      match params_and_body with
-      | Deleted -> Deleted
-      | Present params_and_body ->
-        let params_and_body =
-          Function_params_and_body.import import_map params_and_body
-        in
-        Present params_and_body
-    in
-    let newer_version_of =
-      match newer_version_of with
-      | None -> None
-      | Some older ->
-        let older = Ids_for_export.Import_map.code_id import_map older in
-        Some older
-    in
-    { code_id; params_and_body; newer_version_of; }
-
-  let deleted code_id =
-    { code_id;
-      params_and_body = Deleted;
-      newer_version_of = None;
-    }
-
-  let code_id t = t.code_id
-
-  let params_and_body t =
-    match t.params_and_body with
-    | Present params_and_body -> Some params_and_body
-    | Deleted -> None
-
-  let make_deleted { code_id; params_and_body = _; newer_version_of; } =
-    { code_id;
-      params_and_body = Deleted;
-      newer_version_of;
-    }
-end
-
 type t =
   | Code of Code.t
   | Set_of_closures of Set_of_closures.t
@@ -637,7 +499,7 @@ let match_against_bound_symbols_pattern t (pat : Bound_symbols.Pattern.t)
       ~block_like:block_like_callback =
   match t, pat with
   | Code code, Code code_id ->
-    if not (Code_id.equal code.code_id code_id) then begin
+    if not (Code_id.equal (Code.code_id code) code_id) then begin
       Misc.fatal_errorf "Mismatch on declared code IDs:@ %a@ =@ %a"
         Bound_symbols.Pattern.print pat
         print t
@@ -728,7 +590,7 @@ module Group = struct
     List.filter_map to_code t
     |> List.filter_map (fun code ->
       Option.map (fun params_and_body -> Code.code_id code, params_and_body)
-        (Code.params_and_body code))
+        (Code.params_and_body_opt code))
     |> Code_id.Map.of_list
 
   let pieces_of_code' t = List.filter_map to_code t

--- a/middle_end/flambda/terms/static_const.rec.mli
+++ b/middle_end/flambda/terms/static_const.rec.mli
@@ -108,5 +108,7 @@ module Group : sig
 
   val pieces_of_code' : t -> Code.t list
 
+  val pieces_of_code_by_code_id : t -> Code.t Code_id.Map.t
+
   val is_fully_static : t -> bool
 end

--- a/middle_end/flambda/terms/static_const.rec.mli
+++ b/middle_end/flambda/terms/static_const.rec.mli
@@ -32,43 +32,6 @@ module Field_of_block : sig
   include Identifiable.S with type t := t
 end
 
-(** A piece of code, comprising of the parameters and body of a function,
-    together with a field indicating whether the piece of code is a newer
-    version of one that existed previously (and may still exist), for
-    example after a round of simplification. *)
-module Code : sig
-  type t = private {
-    code_id : Code_id.t;
-    params_and_body : Function_params_and_body.t or_deleted;
-    newer_version_of : Code_id.t option;
-  }
-  and 'a or_deleted =
-    | Present of 'a
-    | Deleted
-
-  val print : Format.formatter -> t -> unit
-
-  val free_names : t -> Name_occurrences.t
-
-  val create
-     : Code_id.t  (** needed for [compare], although useful otherwise too *)
-    -> params_and_body:Function_params_and_body.t or_deleted
-    -> newer_version_of:Code_id.t option
-    -> t
-
-  (** A piece of code that is [Deleted] with no [newer_version_of]. *)
-  (* CR mshinwell: rename to [create_deleted] *)
-  val deleted : Code_id.t -> t
-
-  val code_id : t -> Code_id.t
-  val params_and_body : t -> Function_params_and_body.t option
-
-  val make_deleted : t -> t
-end
-
-(* CR mshinwell: Somewhere there should be an invariant check that
-   code has no free names. *)
-
 (** The static structure of a symbol, possibly with holes, ready to be filled
     with values computed at runtime. *)
 type t =

--- a/middle_end/flambda/terms/template/flambda.templ.ml
+++ b/middle_end/flambda/terms/template/flambda.templ.ml
@@ -48,6 +48,7 @@ module Set_of_closures = Set_of_closures
 module Import = struct
   module Apply = Apply
   module Apply_cont = Apply_cont
+  module Code = Code
   module Continuation_handler = Continuation_handler
   module Continuation_handlers = Continuation_handlers
   module Continuation_params_and_handler = Continuation_params_and_handler

--- a/middle_end/flambda/to_cmm/un_cps.ml
+++ b/middle_end/flambda/to_cmm/un_cps.ml
@@ -1346,13 +1346,12 @@ and fill_slot decls elts env acc offset slot =
     let code_symbol = Code_id.code_symbol code_id in
     let code_name = Linkage_name.to_string (Symbol.linkage_name code_symbol) in
     let arity =
-      if Function_declaration.is_tupled decl then begin
-        let info = Env.get_function_info env code_id in
-        let l = Exported_code.Calling_convention.params_arity info in
+      let info = Env.get_function_info env code_id in
+      let l = Exported_code.Calling_convention.params_arity info in
+      if Function_declaration.is_tupled decl then
         ~- (List.length l)
-      end else begin
-        List.length (Function_declaration.params_arity decl)
-      end
+      else
+        List.length l
     in
     (* We build here the **reverse** list of fields for the closure *)
     if arity = 1 || arity = 0 then begin

--- a/middle_end/flambda/to_cmm/un_cps.ml
+++ b/middle_end/flambda/to_cmm/un_cps.ml
@@ -1345,14 +1345,7 @@ and fill_slot decls elts env acc offset slot =
     let code_id = Function_declaration.code_id decl in
     let code_symbol = Code_id.code_symbol code_id in
     let code_name = Linkage_name.to_string (Symbol.linkage_name code_symbol) in
-    let arity =
-      let info = Env.get_function_info env code_id in
-      let l = Exported_code.Calling_convention.params_arity info in
-      if Function_declaration.is_tupled decl then
-        ~- (List.length l)
-      else
-        List.length l
-    in
+    let arity = Env.get_func_decl_params_arity env decl in
     (* We build here the **reverse** list of fields for the closure *)
     if arity = 1 || arity = 0 then begin
       let acc =

--- a/middle_end/flambda/to_cmm/un_cps_closure.ml
+++ b/middle_end/flambda/to_cmm/un_cps_closure.ml
@@ -349,8 +349,8 @@ module Greedy = struct
               let is_tupled = Function_declaration.is_tupled def in
               let code_id = Function_declaration.code_id def in
               let code = Code_id.Map.find code_id code_map in
-              let parity = Code.params_arity code in
-              let arity = List.length parity in
+              let params_arity = Code.params_arity code in
+              let arity = List.length params_arity in
               let size = if arity = 1 && not is_tupled then 2 else 3 in
               let s = create_slot size (Closure c) in
               s, add_closure_slot state c s
@@ -558,6 +558,7 @@ let compute_code_map unit =
 let compute_offsets env unit =
   let state = ref (Greedy.create_initial_state env) in
   let used_closure_vars = Flambda_unit.used_closure_vars unit in
+  (* CR lmaurer for gbury: Can this double traversal be avoided somehow? *)
   let code_map = compute_code_map unit in
   let aux ~closure_symbols:_ s =
     state := Greedy.create_slots_for_set !state code_map used_closure_vars s

--- a/middle_end/flambda/to_cmm/un_cps_closure.ml
+++ b/middle_end/flambda/to_cmm/un_cps_closure.ml
@@ -339,7 +339,7 @@ module Greedy = struct
 
   (* Create slots (and create the cross-referencing). *)
 
-  let rec create_closure_slots set state = function
+  let rec create_closure_slots set state code_map = function
     | [] -> state
     | (c, def) :: r ->
         let s, state =
@@ -347,14 +347,16 @@ module Greedy = struct
           | Some s -> s, state
           | None ->
               let is_tupled = Function_declaration.is_tupled def in
-              let parity = Function_declaration.params_arity def in
+              let code_id = Function_declaration.code_id def in
+              let code = Code_id.Map.find code_id code_map in
+              let parity = Code.params_arity code in
               let arity = List.length parity in
               let size = if arity = 1 && not is_tupled then 2 else 3 in
               let s = create_slot size (Closure c) in
               s, add_closure_slot state c s
         in
         let () = add_unallocated_slot_to_set s set in
-        create_closure_slots set state r
+        create_closure_slots set state code_map r
 
   let rec create_env_var_slots set state = function
     | [] -> state
@@ -369,14 +371,14 @@ module Greedy = struct
         let () = add_unallocated_slot_to_set s set in
         create_env_var_slots set state r
 
-  let create_slots_for_set state used_closure_vars set_id =
+  let create_slots_for_set state code_map used_closure_vars set_id =
     let set = make_set set_id in
     let state = add_set_to_state state set in
     (* Fill closure slots *)
     let function_decls = Set_of_closures.function_decls set_id in
     let closure_map = Function_declarations.funs function_decls in
     let closures = Closure_id.Map.bindings closure_map in
-    let state = create_closure_slots set state closures in
+    let state = create_closure_slots set state code_map closures in
     (* Fill env var slots *)
     let env_map =
       Var_within_closure.Map.filter (fun clos_var _bound_to ->
@@ -545,13 +547,22 @@ module Greedy = struct
 
 end
 
+let compute_code_map unit =
+  let map = ref Code_id.Map.empty in
+  let aux ~id code =
+    map := Code_id.Map.add id code !map
+  in
+  Flambda_unit.iter unit ~code:aux;
+  !map
+
 let compute_offsets env unit =
   let state = ref (Greedy.create_initial_state env) in
   let used_closure_vars = Flambda_unit.used_closure_vars unit in
+  let code_map = compute_code_map unit in
   let aux ~closure_symbols:_ s =
-    state := Greedy.create_slots_for_set !state used_closure_vars s
+    state := Greedy.create_slots_for_set !state code_map used_closure_vars s
   in
-  Flambda_unit.iter_sets_of_closures unit ~f:aux;
+  Flambda_unit.iter unit ~set_of_closures:aux;
   Greedy.finalize !state
 
 

--- a/middle_end/flambda/to_cmm/un_cps_env.ml
+++ b/middle_end/flambda/to_cmm/un_cps_env.ml
@@ -183,6 +183,15 @@ let exn_cont env = env.k_exn
 let get_function_info env code_id =
   Exported_code.find_calling_convention env.functions_info code_id
 
+let get_func_decl_params_arity t func_decl =
+  let code_id = Function_declaration.code_id func_decl in
+  let info = get_function_info t code_id in
+  let l = Exported_code.Calling_convention.params_arity info in
+  if Function_declaration.is_tupled func_decl then
+    ~- (List.length l)
+  else
+    List.length l
+
 (* Variables *)
 
 let gen_variable v =

--- a/middle_end/flambda/to_cmm/un_cps_env.mli
+++ b/middle_end/flambda/to_cmm/un_cps_env.mli
@@ -74,6 +74,11 @@ val exn_cont : t -> Continuation.t
 val get_function_info : t -> Code_id.t -> Exported_code.Calling_convention.t
 (** Retrieve known information on the given function *)
 
+val get_func_decl_params_arity : t -> Function_declaration.t -> int
+(** Retrieve the parameter arity of the function declaration (taking into
+    account both the function's own arity and the [is_tupled] flag on the
+    declaration) *)
+
 
 (** {2 Variable bindings} *)
 

--- a/middle_end/flambda/to_cmm/un_cps_static.ml
+++ b/middle_end/flambda/to_cmm/un_cps_static.ml
@@ -220,13 +220,12 @@ and fill_static_slot s symbs decls elts env acc offset updates slot =
       let code_name = Linkage_name.to_string (Symbol.linkage_name code_symbol) in
       let acc = List.rev (C.define_symbol ~global:true external_name) @ acc in
       let arity =
-        if Function_declaration.is_tupled decl then begin
-          let info = Env.get_function_info env code_id in
-          let l = Exported_code.Calling_convention.params_arity info in
+        let info = Env.get_function_info env code_id in
+        let l = Exported_code.Calling_convention.params_arity info in
+        if Function_declaration.is_tupled decl then
           ~- (List.length l)
-        end else begin
-          List.length (Function_declaration.params_arity decl)
-        end
+        else
+          List.length l
       in
       let tagged_arity = arity * 2 + 1 in
       (* We build here the **reverse** list of fields for the closure *)
@@ -251,17 +250,17 @@ and fill_static_up_to j acc i =
   if i = j then acc
   else fill_static_up_to j (C.cint 1n :: acc) (i + 1)
 
-let update_env_for_code env (code : SC.Code.t) =
+let update_env_for_code env (code : Code.t) =
   (* Check scope of the code ID *)
-  let code_id = SC.Code.code_id code in
+  let code_id = Code.code_id code in
   let env =
-    match code.newer_version_of with
+    match Code.newer_version_of code with
     | None -> env
     | Some code_id ->
       Env.check_scope ~allow_deleted:true env
         (Code_id_or_symbol.Code_id code_id)
   in
-  match code.params_and_body with
+  match Code.params_and_body code with
   | Deleted ->
     Env.mark_code_id_as_deleted env code_id
   | Present _ ->
@@ -276,10 +275,10 @@ let add_function env r ~params_and_body code_id p =
   let fundecl, r = params_and_body env r fun_name p in
   R.add_function r fundecl
 
-let add_functions env ~params_and_body r (code : SC.Code.t) =
-  match code.params_and_body with
+let add_functions env ~params_and_body r (code : Code.t) =
+  match Code.params_and_body code with
   | Deleted -> r
-  | Present p -> add_function env r ~params_and_body (SC.Code.code_id code) p
+  | Present p -> add_function env r ~params_and_body (Code.code_id code) p
 
 let preallocate_set_of_closures (r, updates, env) ~closure_symbols
       set_of_closures =
@@ -314,7 +313,7 @@ let static_const0 env r ~updates ~params_and_body
       let updates = static_block_updates (C.symbol name) env updates 0 fields in
       env, R.set_data r block, updates
   | Code code_id, Code code ->
-      if not (Code_id.equal code_id (Static_const.Code.code_id code)) then begin
+      if not (Code_id.equal code_id (Code.code_id code)) then begin
         Misc.fatal_errorf "Code ID mismatch:@ %a@ =@ %a"
           Bound_symbols.Pattern.print bound_symbols
           Static_const.print static_const

--- a/middle_end/flambda/to_cmm/un_cps_static.ml
+++ b/middle_end/flambda/to_cmm/un_cps_static.ml
@@ -219,14 +219,7 @@ and fill_static_slot s symbs decls elts env acc offset updates slot =
       let code_symbol = Code_id.code_symbol code_id in
       let code_name = Linkage_name.to_string (Symbol.linkage_name code_symbol) in
       let acc = List.rev (C.define_symbol ~global:true external_name) @ acc in
-      let arity =
-        let info = Env.get_function_info env code_id in
-        let l = Exported_code.Calling_convention.params_arity info in
-        if Function_declaration.is_tupled decl then
-          ~- (List.length l)
-        else
-          List.length l
-      in
+      let arity = Env.get_func_decl_params_arity env decl in
       let tagged_arity = arity * 2 + 1 in
       (* We build here the **reverse** list of fields for the closure *)
       if arity = 1 || arity = 0 then begin

--- a/middle_end/flambda/types/flambda_type.mli
+++ b/middle_end/flambda/types/flambda_type.mli
@@ -206,13 +206,7 @@ module Function_declaration_type : sig
     type t
 
     val code_id : t -> Code_id.t
-    val param_arity : t -> Flambda_arity.t
-    val result_arity : t -> Flambda_arity.t
-    val stub : t -> bool
     val dbg : t -> Debuginfo.t
-    val inline : t -> Inline_attribute.t
-    val is_a_functor : t -> bool
-    val recursive : t -> Recursive.t
     val rec_info : t -> Rec_info.t
     val is_tupled : t -> bool
   end
@@ -221,9 +215,6 @@ module Function_declaration_type : sig
     type t
 
     val code_id : t -> Code_id.t
-    val param_arity : t -> Flambda_arity.t
-    val result_arity : t -> Flambda_arity.t
-    val recursive : t -> Recursive.t
     val is_tupled : t -> bool
   end
 
@@ -374,13 +365,7 @@ val mutable_string : size:int -> t
 (** Create a description of a function declaration whose code is known. *)
 val create_inlinable_function_declaration
    : code_id:Code_id.t
-  -> param_arity:Flambda_arity.t
-  -> result_arity:Flambda_arity.t
-  -> stub:bool
   -> dbg:Debuginfo.t
-  -> inline:Inline_attribute.t
-  -> is_a_functor:bool
-  -> recursive:Recursive.t
   -> rec_info:Rec_info.t
   -> is_tupled:bool
   -> Function_declaration_type.t
@@ -389,9 +374,6 @@ val create_inlinable_function_declaration
     Such declarations cannot be inlined, but can be direct called. *)
 val create_non_inlinable_function_declaration
    : code_id:Code_id.t
-  -> param_arity:Flambda_arity.t
-  -> result_arity:Flambda_arity.t
-  -> recursive:Recursive.t
   -> is_tupled:bool
   -> Function_declaration_type.t
 

--- a/middle_end/flambda/types/structures/function_declaration_type.rec.mli
+++ b/middle_end/flambda/types/structures/function_declaration_type.rec.mli
@@ -21,25 +21,13 @@ module Inlinable : sig
 
   val create
      : code_id:Code_id.t
-    -> param_arity:Flambda_arity.t
-    -> result_arity:Flambda_arity.t
-    -> stub:bool
     -> dbg:Debuginfo.t
-    -> inline:Inline_attribute.t
-    -> is_a_functor:bool
-    -> recursive:Recursive.t
     -> rec_info:Rec_info.t
     -> is_tupled:bool
     -> t
 
   val code_id : t -> Code_id.t
-  val param_arity : t -> Flambda_arity.t
-  val result_arity : t -> Flambda_arity.t
-  val stub : t -> bool
   val dbg : t -> Debuginfo.t
-  val inline : t -> Inline_attribute.t
-  val is_a_functor : t -> bool
-  val recursive : t -> Recursive.t
   val rec_info : t -> Rec_info.t
   val is_tupled : t -> bool
 end
@@ -49,16 +37,10 @@ module Non_inlinable : sig
 
   val create
      : code_id:Code_id.t
-    -> param_arity:Flambda_arity.t
-    -> result_arity:Flambda_arity.t
-    -> recursive:Recursive.t
     -> is_tupled:bool
     -> t
 
   val code_id : t -> Code_id.t
-  val param_arity : t -> Flambda_arity.t
-  val result_arity : t -> Flambda_arity.t
-  val recursive : t -> Recursive.t
   val is_tupled : t -> bool
 end
 

--- a/middle_end/flambda/types/type_grammar.rec.ml
+++ b/middle_end/flambda/types/type_grammar.rec.ml
@@ -575,18 +575,15 @@ let any_boxed_int32 () = box_int32 (any_naked_int32 ())
 let any_boxed_int64 () = box_int64 (any_naked_int64 ())
 let any_boxed_nativeint () = box_nativeint (any_naked_nativeint ())
 
-let create_inlinable_function_declaration ~code_id ~param_arity ~result_arity
-      ~stub ~dbg ~inline ~is_a_functor ~recursive ~rec_info ~is_tupled
+let create_inlinable_function_declaration ~code_id ~dbg ~rec_info ~is_tupled
       : Function_declaration_type.t =
   Ok (Inlinable (
-    Function_declaration_type.Inlinable.create ~code_id ~param_arity
-      ~result_arity ~stub ~dbg ~inline ~is_a_functor ~recursive ~rec_info ~is_tupled))
+    Function_declaration_type.Inlinable.create ~code_id ~dbg ~rec_info ~is_tupled))
 
-let create_non_inlinable_function_declaration ~code_id ~param_arity
-      ~result_arity ~recursive ~is_tupled : Function_declaration_type.t =
+let create_non_inlinable_function_declaration ~code_id ~is_tupled
+      : Function_declaration_type.t =
   Ok (Non_inlinable (
-    Function_declaration_type.Non_inlinable.create ~code_id ~param_arity
-      ~result_arity ~recursive ~is_tupled))
+    Function_declaration_type.Non_inlinable.create ~code_id ~is_tupled))
 
 let exactly_this_closure closure_id ~all_function_decls_in_set:function_decls
       ~all_closures_in_set:closure_types

--- a/middle_end/flambda/types/type_grammar.rec.mli
+++ b/middle_end/flambda/types/type_grammar.rec.mli
@@ -159,22 +159,13 @@ val kind_for_const : Reg_width_const.t -> Flambda_kind.t
 
 val create_inlinable_function_declaration
    : code_id:Code_id.t
-  -> param_arity:Flambda_arity.t
-  -> result_arity:Flambda_arity.t
-  -> stub:bool
   -> dbg:Debuginfo.t
-  -> inline:Inline_attribute.t
-  -> is_a_functor:bool
-  -> recursive:Recursive.t
   -> rec_info:Rec_info.t
   -> is_tupled:bool
   -> Function_declaration_type.t
 
 val create_non_inlinable_function_declaration
    : code_id:Code_id.t
-  -> param_arity:Flambda_arity.t
-  -> result_arity:Flambda_arity.t
-  -> recursive:Recursive.t
   -> is_tupled:bool
   -> Function_declaration_type.t
 


### PR DESCRIPTION
This moves most of the things in `Function_declaration.t` into `Code.t`,
including arity information, the inlining policy, etc. This makes more
sense in general, since these things don't change from one closure to
another, and closures are the things that use function declarations. It
will also be easier to write Flambda module by hand this way, since we'd
like to declare the arities and such in the `let code` binding rather
than having to repeat them at each closure.

The one way in which the properties can differ between closures is that
a closure may represent a tupled form of the function. Therefore we
retain the `is_tupled` flag on the function declaration.