### PR TITLE
Expose the bare names of code ids, closure ids

### DIFF
--- a/middle_end/flambda/basic/closure_id.ml
+++ b/middle_end/flambda/basic/closure_id.ml
@@ -77,6 +77,9 @@ let get_compilation_unit t = t.compilation_unit
 let to_string t =
   t.name ^ "_" ^ (string_of_int t.name_stamp)
 
+let name t =
+  t.name
+
 let rename t =
   { t with
     name_stamp = get_next_stamp ();

--- a/middle_end/flambda/basic/closure_id.mli
+++ b/middle_end/flambda/basic/closure_id.mli
@@ -38,4 +38,6 @@ val get_compilation_unit : t -> Compilation_unit.t
 
 val to_string : t -> string
 
+val name : t -> string
+
 val rename : t -> t

--- a/middle_end/flambda/basic/code_id.mli
+++ b/middle_end/flambda/basic/code_id.mli
@@ -27,6 +27,8 @@ val create : name:string -> Compilation_unit.t -> t
 val get_compilation_unit : t -> Compilation_unit.t
 val in_compilation_unit : t -> Compilation_unit.t -> bool
 
+val name : t -> string
+
 (* The [rename] function, in addition to changing the stamp of the code ID,
    changes the compilation unit to the current one. *)
 val rename : t -> t


### PR DESCRIPTION
Since these are not guaranteed to be unique, they're not of general
interest, but it's important for round-tripping hand-written Flambda
code since these names don't get tagged.