### PR TITLE
Names for continuations

### DIFF
--- a/.depend
+++ b/.depend
@@ -4081,24 +4081,28 @@ middle_end/flambda/basic/coeffects.cmx : \
 middle_end/flambda/basic/coeffects.cmi :
 middle_end/flambda/basic/continuation.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
+    middle_end/flambda/compilenv_deps/table_by_int_id.cmi \
     middle_end/flambda/compilenv_deps/patricia_tree.cmi \
     utils/numbers.cmi \
-    utils/misc.cmi \
     utils/identifiable.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
+    middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/basic/continuation.cmi
 middle_end/flambda/basic/continuation.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
+    middle_end/flambda/compilenv_deps/table_by_int_id.cmx \
     middle_end/flambda/compilenv_deps/patricia_tree.cmx \
     utils/numbers.cmx \
-    utils/misc.cmx \
     utils/identifiable.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
+    middle_end/flambda/compilenv_deps/compilation_unit.cmx \
     middle_end/flambda/basic/continuation.cmi
 middle_end/flambda/basic/continuation.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
+    middle_end/flambda/compilenv_deps/table_by_int_id.cmi \
     utils/printing_cache.cmi \
-    utils/identifiable.cmi
+    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/compilation_unit.cmi
 middle_end/flambda/basic/continuation_counts.cmo : \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/basic/continuation_counts.cmi
@@ -4431,16 +4435,19 @@ middle_end/flambda/basic/symbol_scoping_rule.cmi :
 middle_end/flambda/basic/trap_action.cmo : \
     middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
+    middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/basic/trap_action.cmi
 middle_end/flambda/basic/trap_action.cmx : \
     middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
+    middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/basic/continuation.cmx \
     middle_end/flambda/basic/trap_action.cmi
 middle_end/flambda/basic/trap_action.cmi : \
+    middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/basic/expr_std.cmo \
     middle_end/flambda/basic/continuation.cmi
 middle_end/flambda/basic/var_within_closure.cmo : \
@@ -4546,6 +4553,7 @@ middle_end/flambda/cmx/flambda_cmx_format.cmo : \
     middle_end/flambda/types/flambda_type.cmi \
     middle_end/flambda/cmx/exported_offsets.cmi \
     middle_end/flambda/cmx/exported_code.cmi \
+    middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/cmx/flambda_cmx_format.cmi
@@ -4560,6 +4568,7 @@ middle_end/flambda/cmx/flambda_cmx_format.cmx : \
     middle_end/flambda/types/flambda_type.cmx \
     middle_end/flambda/cmx/exported_offsets.cmx \
     middle_end/flambda/cmx/exported_code.cmx \
+    middle_end/flambda/basic/continuation.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
     middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/cmx/flambda_cmx_format.cmi
@@ -4576,6 +4585,7 @@ middle_end/flambda/cmx/ids_for_export.cmo : \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/compilenv_deps/reg_width_things.cmi \
     middle_end/flambda/basic/name.cmi \
+    middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi
 middle_end/flambda/cmx/ids_for_export.cmx : \
@@ -4585,6 +4595,7 @@ middle_end/flambda/cmx/ids_for_export.cmx : \
     middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/compilenv_deps/reg_width_things.cmx \
     middle_end/flambda/basic/name.cmx \
+    middle_end/flambda/basic/continuation.cmx \
     middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/cmx/ids_for_export.cmi
 middle_end/flambda/cmx/ids_for_export.cmi : \
@@ -4594,6 +4605,7 @@ middle_end/flambda/cmx/ids_for_export.cmi : \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/compilenv_deps/reg_width_things.cmi \
     middle_end/flambda/basic/name.cmi \
+    middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/basic/code_id.cmi
 middle_end/flambda/from_lambda/closure_conversion.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \

--- a/middle_end/flambda/basic/continuation.ml
+++ b/middle_end/flambda/basic/continuation.ml
@@ -136,7 +136,9 @@ include Identifiable.Make (struct
 
   let print ppf t =
     Format.fprintf ppf "@<0>%s" (Flambda_colours.continuation ());
-    Format.fprintf ppf "%s%d" (name t) (name_stamp t);
+    if String.equal (name t) "k"
+    then Format.fprintf ppf "k%d" (name_stamp t)
+    else Format.fprintf ppf "%s/%d" (name t) (name_stamp t);
     Format.fprintf ppf "@<0>%s" (Flambda_colours.normal ())
 
   let output chan t =

--- a/middle_end/flambda/basic/continuation.ml
+++ b/middle_end/flambda/basic/continuation.ml
@@ -80,10 +80,12 @@ module Data = struct
   let equal t1 t2 =
     if t1 == t2 then true
     else
-      let { compilation_unit = compilation_unit1; name_stamp = name_stamp1; _
+      let { compilation_unit = compilation_unit1; name_stamp = name_stamp1;
+            name = _; sort = _
           } = t1
       in
-      let { compilation_unit = compilation_unit2; name_stamp = name_stamp2; _
+      let { compilation_unit = compilation_unit2; name_stamp = name_stamp2;
+            name = _; sort = _
           } = t2
       in
       Int.equal name_stamp1 name_stamp2
@@ -122,8 +124,6 @@ include Identifiable.Make (struct
   type nonrec t = t
 
   let compare t1 t2 =
-    (* The [id] uniquely determines the [sort], so there's no need to look
-       at the latter. *)
     Id.compare t1 t2
 
   let equal t1 t2 =

--- a/middle_end/flambda/basic/continuation.ml
+++ b/middle_end/flambda/basic/continuation.ml
@@ -100,6 +100,8 @@ let grand_table_of_continuations = ref (Table.create ())
 
 let initialise () = grand_table_of_continuations := Table.create ()
 
+(* CR mshinwell: Document why this uses [next_raise_count].  Does it need
+   to?  It would be better if it didn't. *)
 let create ?sort ?name () : t =
   let sort = Option.value sort ~default:Sort.Normal in
   let name = Option.value name ~default:"k" in

--- a/middle_end/flambda/basic/continuation.ml
+++ b/middle_end/flambda/basic/continuation.ml
@@ -90,8 +90,6 @@ module Data = struct
         && Compilation_unit.equal compilation_unit1 compilation_unit2
 end
 
-(* There is no need to store the compilation unit, since in a .cmx file,
-   no values of type [t] occur that are not under [Name_abstraction] binders. *)
 type t = Id.t
 type exported = Data.t
 

--- a/middle_end/flambda/basic/continuation.ml
+++ b/middle_end/flambda/basic/continuation.ml
@@ -16,6 +16,10 @@
 
 [@@@ocaml.warning "+a-30-40-41-42"]
 
+module Id = Table_by_int_id.Id
+
+let continuation_flags = 0
+
 let raise_count = ref 0
 
 let next_raise_count () =
@@ -37,50 +41,84 @@ module Sort = struct
     | Toplevel_return
     | Exn
 
-  let to_int t =
+  let to_string t =
     match t with
-    | Normal -> 0
-    | Return -> 1
-    | Define_root_symbol -> 2
-    | Toplevel_return -> 3
-    | Exn -> 4
+    | Normal -> "Normal"
+    | Return -> "Return"
+    | Define_root_symbol -> "Define_root_symbol"
+    | Toplevel_return -> "Toplevel_return"
+    | Exn -> "Exn"
 
-  let of_int t =
-    match t with
-    | 0 -> Normal
-    | 1 -> Return
-    | 2 -> Define_root_symbol
-    | 3 -> Toplevel_return
-    | 4 -> Exn
-    | _ -> assert false
-
-  let num_bits_needed = 3
+  let print ppf t = Format.pp_print_string ppf (to_string t)
 end
 
-let max_num_continuations = (-1) lsr Sort.num_bits_needed
-let () = assert (max_num_continuations > 0)
+module Data = struct
+  type t = {
+    compilation_unit : Compilation_unit.t;
+    name : string;
+    name_stamp : int;
+    sort : Sort.t;
+  }
 
-let sort_shift = Sys.int_size - Sort.num_bits_needed
+  let flags = continuation_flags
+
+  let print ppf { compilation_unit; name; name_stamp; sort; } =
+    Format.fprintf ppf "@[<hov 1>(\
+        @[<hov 1>(compilation_unit@ %a)@]@ \
+        @[<hov 1>(name@ %s)@]@ \
+        @[<hov 1>(name_stamp@ %d)@]@ \
+        @[<hov 1>(sort@ %a)@]\
+        )@]"
+      Compilation_unit.print compilation_unit
+      name
+      name_stamp
+      Sort.print sort
+
+  let hash { compilation_unit; name = _; name_stamp; sort = _; } =
+    Hashtbl.hash (Compilation_unit.hash compilation_unit, name_stamp)
+
+  let equal t1 t2 =
+    if t1 == t2 then true
+    else
+      let { compilation_unit = compilation_unit1; name_stamp = name_stamp1; _
+          } = t1
+      in
+      let { compilation_unit = compilation_unit2; name_stamp = name_stamp2; _
+          } = t2
+      in
+      Int.equal name_stamp1 name_stamp2
+        && Compilation_unit.equal compilation_unit1 compilation_unit2
+end
 
 (* There is no need to store the compilation unit, since in a .cmx file,
    no values of type [t] occur that are not under [Name_abstraction] binders. *)
-type t = int
+type t = Id.t
+type exported = Data.t
 
-let create ?sort () : t =
+module Table = Table_by_int_id.Make(Data)
+let grand_table_of_continuations = ref (Table.create ())
+
+let initialise () = grand_table_of_continuations := Table.create ()
+
+let create ?sort ?name () : t =
   let sort = Option.value sort ~default:Sort.Normal in
-  let id = next_raise_count () in
-  if id < max_num_continuations then
-    ((Sort.to_int sort) lsl sort_shift) lor id
-  else
-    Misc.fatal_error "Use a machine with a wider word size to compile"
+  let name = Option.value name ~default:"k" in
+  let compilation_unit = Compilation_unit.get_current_exn () in
+  let name_stamp = next_raise_count () in
+  let data : Data.t = { compilation_unit; name; name_stamp; sort } in
+  Table.add !grand_table_of_continuations data
 
-(* CR mshinwell: Document why this uses [next_raise_count].  Does it need
-   to?  It would be better if it didn't. *)
+let find_data t = Table.find !grand_table_of_continuations t
 
-let dummy = create ~sort:Normal ()
+let rename t =
+  let { Data.name; sort; name_stamp = _; compilation_unit = _ } = find_data t in
+  create ~sort ~name ()
 
-let to_int t = t land max_num_continuations
-let sort t = Sort.of_int (t lsr sort_shift)
+let name t = (find_data t).name
+
+let name_stamp t = (find_data t).name_stamp
+
+let sort t = (find_data t).sort
 
 include Identifiable.Make (struct
   type nonrec t = t
@@ -88,7 +126,7 @@ include Identifiable.Make (struct
   let compare t1 t2 =
     (* The [id] uniquely determines the [sort], so there's no need to look
        at the latter. *)
-    Int.compare t1 t2
+    Id.compare t1 t2
 
   let equal t1 t2 =
     t1 == t2
@@ -98,7 +136,7 @@ include Identifiable.Make (struct
 
   let print ppf t =
     Format.fprintf ppf "@<0>%s" (Flambda_colours.continuation ());
-    Format.fprintf ppf "k%d" (to_int t);
+    Format.fprintf ppf "%s%d" (name t) (name_stamp t);
     Format.fprintf ppf "@<0>%s" (Flambda_colours.normal ())
 
   let output chan t =
@@ -111,6 +149,13 @@ module Map = Patricia_tree.Make_map (struct let print = print end) (Set)
 module Tbl = Identifiable.Make_tbl (Numbers.Int) (Map)
 
 let print_with_cache ~cache:_ ppf t = print ppf t
+
+let export t = find_data t
+
+let import data = Table.add !grand_table_of_continuations data
+
+let map_compilation_unit f (data : Data.t) =
+  { data with compilation_unit = f data.compilation_unit }
 
 module With_args = struct
   type nonrec t = t * Variable.t list

--- a/middle_end/flambda/basic/continuation.mli
+++ b/middle_end/flambda/basic/continuation.mli
@@ -18,7 +18,8 @@
 
 (** The names of continuations. *)
 
-type t = private int
+type t = private Table_by_int_id.Id.t
+type exported
 
 include Identifiable.S with type t := t
 
@@ -31,19 +32,30 @@ module Sort : sig
     | Exn
 end
 
-val dummy : t
+val create : ?sort:Sort.t -> ?name:string -> unit -> t
 
-val create : ?sort:Sort.t -> unit -> t
+val rename : t -> t
+
+val name : t -> string
+
+val name_stamp : t -> int
 
 val print_with_cache : cache:Printing_cache.t -> Format.formatter -> t -> unit
-
-val to_int : t -> int
 
 val sort : t -> Sort.t
 
 val is_exn : t -> bool
 
+val export : t -> exported
+
+val import : exported -> t
+
+val map_compilation_unit :
+      (Compilation_unit.t -> Compilation_unit.t) -> exported -> exported
+
 module With_args : sig
   type nonrec t = t * Variable.t list
   include Identifiable.S with type t := t
 end
+
+val initialise : unit -> unit

--- a/middle_end/flambda/basic/exn_continuation.ml
+++ b/middle_end/flambda/basic/exn_continuation.ml
@@ -119,20 +119,20 @@ let with_exn_handler t exn_handler =
 let without_extra_args t =
   { t with extra_args = []; }
 
-let all_ids_for_export t =
+let all_ids_for_export { exn_handler; extra_args; } =
   List.fold_left (fun ids (arg, _kind) ->
       Ids_for_export.add_simple ids arg)
-    (Ids_for_export.add_continuation Ids_for_export.empty t.exn_handler)
-    t.extra_args
+    (Ids_for_export.add_continuation Ids_for_export.empty exn_handler)
+    extra_args
 
-let import import_map t =
+let import import_map { exn_handler; extra_args; } =
   let exn_handler =
-    Ids_for_export.Import_map.continuation import_map t.exn_handler
+    Ids_for_export.Import_map.continuation import_map exn_handler
   in
   let extra_args =
     List.map (fun (arg, kind) ->
         let arg = Ids_for_export.Import_map.simple import_map arg in
         (arg, kind))
-      t.extra_args
+      extra_args
   in
   { exn_handler; extra_args; }

--- a/middle_end/flambda/basic/exn_continuation.ml
+++ b/middle_end/flambda/basic/exn_continuation.ml
@@ -122,14 +122,17 @@ let without_extra_args t =
 let all_ids_for_export t =
   List.fold_left (fun ids (arg, _kind) ->
       Ids_for_export.add_simple ids arg)
-    Ids_for_export.empty
+    (Ids_for_export.add_continuation Ids_for_export.empty t.exn_handler)
     t.extra_args
 
 let import import_map t =
+  let exn_handler =
+    Ids_for_export.Import_map.continuation import_map t.exn_handler
+  in
   let extra_args =
     List.map (fun (arg, kind) ->
         let arg = Ids_for_export.Import_map.simple import_map arg in
         (arg, kind))
       t.extra_args
   in
-  { t with extra_args; }
+  { exn_handler; extra_args; }

--- a/middle_end/flambda/basic/trap_action.mli
+++ b/middle_end/flambda/basic/trap_action.mli
@@ -47,6 +47,14 @@ module Option : sig
   type nonrec t = t option
 
   val print : Format.formatter -> t -> unit
+
+  val all_ids_for_export : t -> Ids_for_export.t
+
+  val import : Ids_for_export.Import_map.t -> t -> t
 end
 
 val compare : t -> t -> int
+
+val all_ids_for_export : t -> Ids_for_export.t
+
+val import : Ids_for_export.Import_map.t -> t -> t

--- a/middle_end/flambda/cmx/flambda_cmx_format.ml
+++ b/middle_end/flambda/cmx/flambda_cmx_format.ml
@@ -80,8 +80,9 @@ let create ~final_typing_env ~all_code ~exported_offsets ~used_closure_vars =
       Code_id.Map.empty
   in
   let continuations =
-    Continuation.Set.fold (fun symbol symbols ->
-        Continuation.Map.add symbol (Continuation.export symbol) symbols)
+    Continuation.Set.fold (fun continuation continuations ->
+        Continuation.Map.add continuation (Continuation.export continuation)
+          continuations)
       exported_ids.continuations
       Continuation.Map.empty
   in

--- a/middle_end/flambda/cmx/flambda_cmx_format.ml
+++ b/middle_end/flambda/cmx/flambda_cmx_format.ml
@@ -27,6 +27,7 @@ type table_data = {
   simples : Simple.exported Simple.Map.t;
   consts : Const.exported Const.Map.t;
   code_ids : Code_id.exported Code_id.Map.t;
+  continuations : Continuation.exported Continuation.Map.t;
 }
 
 type t0 = {
@@ -78,12 +79,19 @@ let create ~final_typing_env ~all_code ~exported_offsets ~used_closure_vars =
       exported_ids.code_ids
       Code_id.Map.empty
   in
+  let continuations =
+    Continuation.Set.fold (fun symbol symbols ->
+        Continuation.Map.add symbol (Continuation.export symbol) symbols)
+      exported_ids.continuations
+      Continuation.Map.empty
+  in
   let table_data =
     { symbols;
       variables;
       simples;
       consts;
       code_ids;
+      continuations;
     }
   in
   [{ original_compilation_unit = Compilation_unit.get_current_exn ();
@@ -101,6 +109,9 @@ let import_typing_env_and_code0 t =
   let variables = Variable.Map.map Variable.import t.table_data.variables in
   let consts = Const.Map.map Const.import t.table_data.consts in
   let code_ids = Code_id.Map.map Code_id.import t.table_data.code_ids in
+  let continuations =
+    Continuation.Map.map Continuation.import t.table_data.continuations
+  in
   let used_closure_vars = t.used_closure_vars in
   (* Build a simple to simple converter from this *)
   let import_map =
@@ -110,6 +121,7 @@ let import_typing_env_and_code0 t =
       ~simples:Simple.Map.empty
       ~consts
       ~code_ids
+      ~continuations
       ~used_closure_vars
   in
   let map_simple = Ids_for_export.Import_map.simple import_map in
@@ -124,6 +136,7 @@ let import_typing_env_and_code0 t =
       ~simples
       ~consts
       ~code_ids
+      ~continuations
       ~used_closure_vars
   in
   let typing_env =
@@ -191,12 +204,17 @@ let update_for_pack0 ~pack_units ~pack t =
     Code_id.Map.map (Code_id.map_compilation_unit update_cu)
       t.table_data.code_ids
   in
+  let continuations =
+    Continuation.Map.map (Continuation.map_compilation_unit update_cu)
+      t.table_data.continuations
+  in
   let table_data =
     { symbols;
       variables;
       simples;
       consts;
       code_ids;
+      continuations;
     }
   in
   { t with table_data; }

--- a/middle_end/flambda/cmx/ids_for_export.ml
+++ b/middle_end/flambda/cmx/ids_for_export.ml
@@ -21,6 +21,7 @@ type t = {
   simples : Simple.Set.t;
   consts : Const.Set.t;
   code_ids : Code_id.Set.t;
+  continuations : Continuation.Set.t;
 }
 
 let empty = {
@@ -29,6 +30,7 @@ let empty = {
   simples = Simple.Set.empty;
   consts = Const.Set.empty;
   code_ids = Code_id.Set.empty;
+  continuations = Continuation.Set.empty;
 }
 
 let create
@@ -37,12 +39,14 @@ let create
     ?(simples = Simple.Set.empty)
     ?(consts = Const.Set.empty)
     ?(code_ids = Code_id.Set.empty)
+    ?(continuations = Continuation.Set.empty)
     () =
   { symbols;
     variables;
     simples;
     consts;
     code_ids;
+    continuations;
   }
 
 let singleton_code_id code_id =
@@ -79,6 +83,9 @@ let add_simple t simple =
 let add_code_id t code_id =
   { t with code_ids = Code_id.Set.add code_id t.code_ids }
 
+let add_continuation t continuation =
+  { t with continuations = Continuation.Set.add continuation t.continuations }
+
 let from_simple simple =
   let simples =
     match Simple.rec_info simple with
@@ -109,6 +116,7 @@ let union t1 t2 =
     simples = Simple.Set.union t1.simples t2.simples;
     consts = Const.Set.union t1.consts t2.consts;
     code_ids = Code_id.Set.union t1.code_ids t2.code_ids;
+    continuations = Continuation.Set.union t1.continuations t2.continuations;
   }
 
 let rec union_list ts =
@@ -123,6 +131,7 @@ module Import_map = struct
     simples : Simple.t Simple.Map.t;
     consts : Const.t Const.Map.t;
     code_ids : Code_id.t Code_id.Map.t;
+    continuations : Continuation.t Continuation.Map.t;
     used_closure_vars : Var_within_closure.Set.t;
     (* CR vlaviron: [used_closure_vars] is here because we need to rewrite the
        types to remove occurrences of unused closure variables, as otherwise
@@ -136,12 +145,20 @@ module Import_map = struct
        are really missing at this point). *)
   }
 
-  let create ~symbols ~variables ~simples ~consts ~code_ids ~used_closure_vars =
+  let create
+      ~symbols
+      ~variables
+      ~simples
+      ~consts
+      ~code_ids
+      ~continuations
+      ~used_closure_vars =
     { symbols;
       variables;
       simples;
       consts;
       code_ids;
+      continuations;
       used_closure_vars;
     }
 
@@ -163,6 +180,11 @@ module Import_map = struct
   let code_id t orig =
     match Code_id.Map.find orig t.code_ids with
     | code_id -> code_id
+    | exception Not_found -> orig
+
+  let continuation t orig =
+    match Continuation.Map.find orig t.continuations with
+    | continuation -> continuation
     | exception Not_found -> orig
 
   let name t name =

--- a/middle_end/flambda/cmx/ids_for_export.mli
+++ b/middle_end/flambda/cmx/ids_for_export.mli
@@ -19,6 +19,7 @@ type t = {
   simples : Simple.Set.t;
   consts : Reg_width_things.Const.Set.t;
   code_ids : Code_id.Set.t;
+  continuations : Continuation.Set.t;
 }
 
 val empty : t
@@ -29,6 +30,7 @@ val create
   -> ?simples: Simple.Set.t
   -> ?consts: Reg_width_things.Const.Set.t
   -> ?code_ids: Code_id.Set.t
+  -> ?continuations: Continuation.Set.t
   -> unit
   -> t
 
@@ -50,6 +52,8 @@ val add_simple : t -> Simple.t -> t
 
 val add_code_id : t -> Code_id.t -> t
 
+val add_continuation : t -> Continuation.t -> t
+
 val union : t -> t -> t
 
 val union_list : t list -> t
@@ -63,6 +67,7 @@ module Import_map : sig
     -> simples : Simple.t Simple.Map.t
     -> consts : Reg_width_things.Const.t Reg_width_things.Const.Map.t
     -> code_ids : Code_id.t Code_id.Map.t
+    -> continuations : Continuation.t Continuation.Map.t
     -> used_closure_vars : Var_within_closure.Set.t
     -> t
 
@@ -72,6 +77,7 @@ module Import_map : sig
   val name : t -> Name.t -> Name.t
   val simple : t -> Simple.t -> Simple.t
   val code_id : t -> Code_id.t -> Code_id.t
+  val continuation : t -> Continuation.t -> Continuation.t
   val closure_var_is_used : t -> Var_within_closure.t -> bool
 end
 

--- a/middle_end/flambda/naming/bindable_continuation.ml
+++ b/middle_end/flambda/naming/bindable_continuation.ml
@@ -22,11 +22,11 @@ let free_names t = Name_occurrences.singleton_continuation t
 
 let apply_name_permutation t perm = Name_permutation.apply_continuation perm t
 
-let all_ids_for_export _t = Ids_for_export.empty
+let all_ids_for_export t =
+  Ids_for_export.add_continuation Ids_for_export.empty t
 
-let import _import_map t = t
-
-let rename t = create ~sort:(sort t) ()
+let import import_map t =
+  Ids_for_export.Import_map.continuation import_map t
 
 let add_to_name_permutation t ~guaranteed_fresh perm =
   Name_permutation.add_fresh_continuation perm t ~guaranteed_fresh

--- a/middle_end/flambda/naming/bindable_exn_continuation.ml
+++ b/middle_end/flambda/naming/bindable_exn_continuation.ml
@@ -32,5 +32,5 @@ let add_occurrence_in_terms t occs =
   Name_occurrences.add_continuation occs (exn_handler t)
 
 let rename t =
-  create ~exn_handler:(Continuation.create ~sort:Exn ())
-    ~extra_args:(extra_args t)
+  let exn_handler = Continuation.rename (exn_handler t) in
+  create ~exn_handler ~extra_args:(extra_args t)

--- a/middle_end/flambda/terms/apply_cont_expr.ml
+++ b/middle_end/flambda/terms/apply_cont_expr.ml
@@ -246,13 +246,17 @@ let apply_name_permutation ({ k; args; trap_action; dbg; } as t) perm =
   if k == k' && args == args' && trap_action == trap_action' then t
   else { k = k'; args = args'; trap_action = trap_action'; dbg; }
 
-let all_ids_for_export { k = _; args; trap_action = _; dbg = _; } =
+let all_ids_for_export { k; args; trap_action; dbg = _; } =
   List.fold_left (fun ids arg -> Ids_for_export.add_simple ids arg)
-    Ids_for_export.empty
+    (Ids_for_export.add_continuation 
+      (Trap_action.Option.all_ids_for_export trap_action)
+      k)
     args
 
 let import import_map { k; args; trap_action; dbg; } =
+  let k = Ids_for_export.Import_map.continuation import_map k in
   let args = List.map (Ids_for_export.Import_map.simple import_map) args in
+  let trap_action = Trap_action.Option.import import_map trap_action in
   { k; args; trap_action; dbg; }
 
 let update_continuation t continuation =

--- a/middle_end/flambda/terms/continuation_handlers.rec.ml
+++ b/middle_end/flambda/terms/continuation_handlers.rec.ml
@@ -55,11 +55,11 @@ let all_ids_for_export t =
     Ids_for_export.empty
 
 let import import_map t =
-  Continuation.Map.of_list
-    (List.map (fun (k, handler) ->
+  Continuation.Map.of_seq
+    (Seq.map (fun (k, handler) ->
         Ids_for_export.Import_map.continuation import_map k,
         Continuation_handler.import import_map handler)
-      (Continuation.Map.bindings t))
+      (Continuation.Map.to_seq t))
 
 let domain t = Continuation.Map.keys t
 

--- a/middle_end/flambda/terms/continuation_handlers.rec.ml
+++ b/middle_end/flambda/terms/continuation_handlers.rec.ml
@@ -55,11 +55,12 @@ let all_ids_for_export t =
     Ids_for_export.empty
 
 let import import_map t =
-  Continuation.Map.of_seq
-    (Seq.map (fun (k, handler) ->
-        Ids_for_export.Import_map.continuation import_map k,
-        Continuation_handler.import import_map handler)
-      (Continuation.Map.to_seq t))
+  Continuation.Map.fold (fun k handler t ->
+      let k = Ids_for_export.Import_map.continuation import_map k in
+      let handler = Continuation_handler.import import_map handler in
+      Continuation.Map.add k handler t)
+    t 
+    Continuation.Map.empty
 
 let domain t = Continuation.Map.keys t
 

--- a/middle_end/flambda/terms/continuation_handlers.rec.ml
+++ b/middle_end/flambda/terms/continuation_handlers.rec.ml
@@ -46,14 +46,20 @@ let apply_name_permutation t perm =
     Continuation.Map.empty
 
 let all_ids_for_export t =
-  Continuation.Map.fold (fun _k handler ids ->
+  Continuation.Map.fold (fun k handler ids ->
       Ids_for_export.union ids
-        (Continuation_handler.all_ids_for_export handler))
+        (Ids_for_export.add_continuation
+          (Continuation_handler.all_ids_for_export handler)
+          k))
     t
     Ids_for_export.empty
 
 let import import_map t =
-  Continuation.Map.map (Continuation_handler.import import_map) t
+  Continuation.Map.of_list
+    (List.map (fun (k, handler) ->
+        Ids_for_export.Import_map.continuation import_map k,
+        Continuation_handler.import import_map handler)
+      (Continuation.Map.bindings t))
 
 let domain t = Continuation.Map.keys t
 


### PR DESCRIPTION
It's helpful for hand-written Flambda to have names for continuations
(beyond just kn for integer n), and this lets us round-trip those names.