### PR TITLE
Fix inlining depth increment at Let_cont

### DIFF
--- a/middle_end/flambda/inlining/inlining_decision.ml
+++ b/middle_end/flambda/inlining/inlining_decision.ml
@@ -20,10 +20,6 @@ open! Flambda.Import
 
 module DE = Simplify_envs.Downwards_env
 
-(* CR mshinwell: We should track the inlining depth on closures (or maybe
-   code) in addition to on [Apply] nodes, as per conversation with
-   lwhite 2020-08-10. *)
-
 (* CR mshinwell: We need to emit [Warnings.Inlining_impossible] as
    required.
    When in fallback-inlining mode: if we want to follow Closure we should

--- a/middle_end/flambda/inlining/inlining_decision.ml
+++ b/middle_end/flambda/inlining/inlining_decision.ml
@@ -20,6 +20,10 @@ open! Flambda.Import
 
 module DE = Simplify_envs.Downwards_env
 
+(* CR mshinwell: We should track the inlining depth on closures (or maybe
+   code) in addition to on [Apply] nodes, as per conversation with
+   lwhite 2020-08-10. *)
+
 (* CR mshinwell: We need to emit [Warnings.Inlining_impossible] as
    required.
    When in fallback-inlining mode: if we want to follow Closure we should

--- a/middle_end/flambda/simplify/simplify_expr.rec.ml
+++ b/middle_end/flambda/simplify/simplify_expr.rec.ml
@@ -383,6 +383,9 @@ and simplify_non_recursive_let_cont_handler
            [prior_lifted_constants] back into [dacc] later. *)
         DA.get_and_clear_lifted_constants dacc
       in
+      let inlining_depth_increment_at_let_cont =
+        DE.get_inlining_depth_increment (DA.denv dacc)
+      in
       let body, handler, user_data, uacc =
         let body, (result, uenv', user_data), uacc =
           let scope = DE.get_continuation_scope_level (DA.denv dacc) in
@@ -496,6 +499,17 @@ and simplify_non_recursive_let_cont_handler
                          moving into a different scope.) *)
                       DE.set_at_unit_toplevel_state handler_env
                         at_unit_toplevel
+                    in
+                    let denv =
+                      (* In the case where the continuation is going to be
+                         inlined, [denv] is basically the use environment,
+                         which might have a deeper inlining depth increment
+                         (e.g. where an [Apply] was inlined, revealing the
+                         linear inlinable use of the continuation).  We need
+                         to make sure the handler is simplified using the
+                         depth at the [Let_cont]. *)
+                      DE.set_inlining_depth_increment denv
+                        inlining_depth_increment_at_let_cont
                     in
                     DA.with_denv dacc denv
                   in


### PR DESCRIPTION
The inlining depth increment in `DE` was going up far too fast, causing many inlinings to be rejected against `max_inlining_depth`.  This was happening due to a subtle misbehaviour at `Let_cont` bindings, as per the comment in this patch.

@lpw25 and I also discussed some improvements to the inlining depth tracking; I have left a CR for the moment, but we should attend to this relatively soon.