### PR TITLE
Stop boolean NOT from producing Invalid

### DIFF
--- a/flambdatest/mlexamples/from_core_char_test.ml
+++ b/flambdatest/mlexamples/from_core_char_test.ml
@@ -1,0 +1,28 @@
+type ('a, 'b) result = Ok of 'a | Error of 'b
+
+external string_length : string -> int = "%string_length"
+external string_get : string -> int -> char = "%string_safe_get"
+external ( && ) : bool -> bool -> bool = "%sequand"
+external ( = ) : 'a -> 'a -> bool = "%equal"
+external not : bool -> bool = "%boolnot"
+
+let[@inline always] char_of_string s =
+  match string_length s with
+  | 1 -> string_get s 0
+  | _ -> assert false
+
+let[@inline always] result_is_error r =
+  match r with
+  | Ok _ -> false
+  | Error _ -> true
+
+let[@inline always] result_try_with f =
+  try Ok (f ()) with
+  | exn -> Error exn
+
+let[@inline always] test () =
+  char_of_string "c" = 'c'
+  && result_is_error (result_try_with (fun () -> char_of_string ""))
+
+let top () =
+  if not (test ()) then assert false

--- a/middle_end/flambda/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda/simplify/simplify_unary_primitive.ml
@@ -366,6 +366,11 @@ let simplify_boolean_not dacc ~original_term ~arg:_ ~arg_ty ~result_var =
   let denv = DA.denv dacc in
   let typing_env = DE.typing_env denv in
   let proof = T.prove_equals_tagged_immediates typing_env arg_ty in
+  let result_unknown () =
+    let ty = T.unknown K.value in
+    let env_extension = TEE.one_equation result ty in
+    Reachable.reachable original_term, env_extension, dacc
+  in
   let result_invalid () =
     let ty = T.bottom K.value in
     let env_extension = TEE.one_equation result ty in
@@ -379,7 +384,7 @@ let simplify_boolean_not dacc ~original_term ~arg:_ ~arg_ty ~result_var =
             || Target_imm.equal imm Target_imm.one)
         imms
     in
-    if not imms_ok then result_invalid ()
+    if not imms_ok then result_unknown ()
     else
       let imms =
         Target_imm.Set.map (fun imm ->


### PR DESCRIPTION
In the example in this PR we end up applying `Boolean_not` to something whose type holds the set of all possible tags, which was producing an `Invalid`.  I think we probably want this change anyway, but I wonder if we should be more precise here, since it is clear what the possible tags are.  @lthls Let's discuss when you are back.