### PR TITLE
Fix inlined debuginfo at single-use continuations

### DIFF
--- a/middle_end/flambda/simplify/env/simplify_envs.ml
+++ b/middle_end/flambda/simplify/env/simplify_envs.ml
@@ -478,6 +478,8 @@ end = struct
   let set_inlined_debuginfo t dbg =
     { t with inlined_debuginfo = dbg; }
 
+  let get_inlined_debuginfo t = t.inlined_debuginfo
+
   let add_inlined_debuginfo' t dbg =
     Debuginfo.concat t.inlined_debuginfo dbg
 

--- a/middle_end/flambda/simplify/env/simplify_envs_intf.ml
+++ b/middle_end/flambda/simplify/env/simplify_envs_intf.ml
@@ -177,6 +177,8 @@ module type Downwards_env = sig
 
   val add_inlined_debuginfo' : t -> Debuginfo.t -> Debuginfo.t
 
+  val get_inlined_debuginfo : t -> Debuginfo.t
+
   val round : t -> int
 
   (** Prevent function inlining from occurring in the given environment. *)

--- a/middle_end/flambda/simplify/simplify_expr.rec.ml
+++ b/middle_end/flambda/simplify/simplify_expr.rec.ml
@@ -386,6 +386,9 @@ and simplify_non_recursive_let_cont_handler
       let inlining_depth_increment_at_let_cont =
         DE.get_inlining_depth_increment (DA.denv dacc)
       in
+      let inlined_debuginfo_at_let_cont =
+        DE.get_inlined_debuginfo (DA.denv dacc)
+      in
       let body, handler, user_data, uacc =
         let body, (result, uenv', user_data), uacc =
           let scope = DE.get_continuation_scope_level (DA.denv dacc) in
@@ -510,6 +513,11 @@ and simplify_non_recursive_let_cont_handler
                          depth at the [Let_cont]. *)
                       DE.set_inlining_depth_increment denv
                         inlining_depth_increment_at_let_cont
+                    in
+                    let denv =
+                      (* Likewise, the inlined debuginfo may need restoring. *)
+                      DE.set_inlined_debuginfo denv
+                        inlined_debuginfo_at_let_cont
                     in
                     DA.with_denv dacc denv
                   in


### PR DESCRIPTION
Analogously to #236, the inlined debuginfo in `DE` also needs restoring.