### PR TITLE
Propagate value-subkind info on parameters

### DIFF
--- a/middle_end/flambda/basic/exn_continuation.ml
+++ b/middle_end/flambda/basic/exn_continuation.ml
@@ -18,7 +18,7 @@
 
 type t = {
   exn_handler : Continuation.t;
-  extra_args : (Simple.t * Flambda_kind.t) list;
+  extra_args : (Simple.t * Flambda_kind.With_subkind.t) list;
 }
 
 include Identifiable.Make (struct
@@ -27,7 +27,7 @@ include Identifiable.Make (struct
   let print_simple_and_kind ppf (simple, kind) =
     Format.fprintf ppf "@[<h>(%a@ \u{2237}@ %a)@]"
       Simple.print simple
-      Flambda_kind.print kind
+      Flambda_kind.With_subkind.print kind
 
   let print ppf { exn_handler; extra_args; } =
     match extra_args with
@@ -53,7 +53,7 @@ include Identifiable.Make (struct
   let compare_simple_and_kind (simple1, kind1) (simple2, kind2) =
     let c = Simple.compare simple1 simple2 in
     if c <> 0 then c
-    else Flambda_kind.compare kind1 kind2
+    else Flambda_kind.With_subkind.compare kind1 kind2
 
   let compare
         { exn_handler = exn_handler1; extra_args = extra_args1; }
@@ -111,7 +111,10 @@ let apply_name_permutation ({ exn_handler; extra_args; } as t) perm =
 
 let arity t =
   let extra_args = List.map (fun (_simple, kind) -> kind) t.extra_args in
-  Flambda_kind.value :: extra_args
+  let exn_bucket_kind =
+    Flambda_kind.With_subkind.create Flambda_kind.value Anything
+  in
+  exn_bucket_kind :: extra_args
 
 let with_exn_handler t exn_handler =
   { t with exn_handler; }

--- a/middle_end/flambda/basic/exn_continuation.mli
+++ b/middle_end/flambda/basic/exn_continuation.mli
@@ -30,18 +30,18 @@ include Contains_ids.S with type t := t
 (** Create an exception continuation. *)
 val create
    : exn_handler:Continuation.t
-  -> extra_args:(Simple.t * Flambda_kind.t) list
+  -> extra_args:(Simple.t * Flambda_kind.With_subkind.t) list
   -> t
 
 (** The exception handler itself. *)
 val exn_handler : t -> Continuation.t
 
 (** Any extra arguments together with their kinds. *)
-val extra_args : t -> (Simple.t * Flambda_kind.t) list
+val extra_args : t -> (Simple.t * Flambda_kind.With_subkind.t) list
 
 (** The arity of the given exception continuation, taking into account both
     the exception bucket argument and any [extra_args]. *)
-val arity : t -> Flambda_arity.t
+val arity : t -> Flambda_arity.With_subkinds.t
 
 val with_exn_handler : t -> Continuation.t -> t
 

--- a/middle_end/flambda/basic/invariant_env.ml
+++ b/middle_end/flambda/basic/invariant_env.ml
@@ -107,7 +107,8 @@ type t = {
   uses_of_var_within_closures_seen : Var_within_closure.Set.t ref;
   names : Flambda_kind.t Name.Map.t;
   continuations :
-    (Flambda_arity.t * continuation_kind (* * Continuation_stack.t *))
+    (Flambda_arity.With_subkinds.t
+      * continuation_kind (* * Continuation_stack.t *))
       Continuation.Map.t;
 (*
   continuation_stack : Continuation_stack.t;
@@ -165,7 +166,7 @@ let add_variables t vars_and_kinds =
 let add_kinded_parameters t kinded_params =
   List.fold_left (fun t kinded_param ->
       add_name t (Kinded_parameter.name kinded_param)
-        (Kinded_parameter.kind kinded_param))
+        (Flambda_kind.With_subkind.kind (Kinded_parameter.kind kinded_param)))
     t
     kinded_params
 
@@ -362,7 +363,8 @@ let prepare_for_function_body t ~parameters_with_kinds ~my_closure
   in
   let continuations =
     Continuation.Map.add exception_cont
-      ([Flambda_kind.value], Exn_handler (*, continuation_stack *))
+      ([Flambda_kind.With_subkind.any_value],
+       Exn_handler (*, continuation_stack *))
       continuations
   in
   let names = Name.symbols_only_map t.names in

--- a/middle_end/flambda/basic/invariant_env.mli
+++ b/middle_end/flambda/basic/invariant_env.mli
@@ -43,7 +43,7 @@ val prepare_for_function_body
   -> parameters_with_kinds:(Variable.t * Flambda_kind.t) list
   -> my_closure:Variable.t
   -> return_cont:Continuation.t
-  -> return_cont_arity:Flambda_arity.t
+  -> return_cont_arity:Flambda_arity.With_subkinds.t
   -> exception_cont:Continuation.t
   -> t
 
@@ -58,7 +58,7 @@ val add_symbol : t -> Symbol.t -> Flambda_kind.t -> t
 val add_continuation
    : t
   -> Continuation.t
-  -> Flambda_arity.t
+  -> Flambda_arity.With_subkinds.t
   -> continuation_kind
 (*
   -> Continuation_stack.t
@@ -123,9 +123,10 @@ val check_symbol_is_bound : t -> Symbol.t -> unit
 val find_continuation_opt
    : t
   -> Continuation.t
-  -> (Flambda_arity.t * continuation_kind (* * Continuation_stack.t *)) option
+  -> (Flambda_arity.With_subkinds.t
+       * continuation_kind (* * Continuation_stack.t *)) option
 
-val continuation_arity : t -> Continuation.t -> Flambda_arity.t
+val continuation_arity : t -> Continuation.t -> Flambda_arity.With_subkinds.t
 
 val kind_of_simple : t -> Simple.t -> Flambda_kind.t
 

--- a/middle_end/flambda/basic/kinded_parameter.ml
+++ b/middle_end/flambda/basic/kinded_parameter.ml
@@ -18,30 +18,30 @@
 
 type t = {
   param : Variable.t;
-  kind : Flambda_kind.t;
+  kind : Flambda_kind.With_subkind.t;
 }
 
 include Identifiable.Make (struct
   type nonrec t = t
 
-  let compare 
+  let compare
         { param = param1; kind = kind1; }
         { param = param2; kind = kind2; } =
     let c = Variable.compare param1 param2 in
     if c <> 0 then c
-    else Flambda_kind.compare kind1 kind2
+    else Flambda_kind.With_subkind.compare kind1 kind2
 
   let equal t1 t2 = compare t1 t2 = 0
 
   let hash { param; kind; } =
-    Hashtbl.hash (Variable.hash param, Flambda_kind.hash kind)
+    Hashtbl.hash (Variable.hash param, Flambda_kind.With_subkind.hash kind)
 
   let print ppf { param; kind; } =
     Format.fprintf ppf "@[(@<0>%s%a@<0>%s @<1>\u{2237} %a)@]"
       (Flambda_colours.parameter ())
       Variable.print param
       (Flambda_colours.normal ())
-      Flambda_kind.print kind
+      Flambda_kind.With_subkind.print kind
 
   let output chan t =
     print (Format.formatter_of_out_channel chan) t
@@ -63,12 +63,8 @@ let with_kind t kind = { t with kind; }
 
 let rename t = { t with param = Variable.rename t.param; }
 
-let map_var t ~f = { t with param = f t.param; }
-
-let map_kind t ~f = { t with kind = f t.kind; }
-
 let equal_kinds t1 t2 =
-  Flambda_kind.equal t1.kind t2.kind
+  Flambda_kind.With_subkind.equal t1.kind t2.kind
 
 let free_names ({ param = _; kind = _; } as t) =
   Name_occurrences.singleton_variable (var t) Name_mode.normal
@@ -123,7 +119,9 @@ module List = struct
 
   let rename t = List.map (fun t -> rename t) t
 
-  let arity t = List.map (fun t -> kind t) t
+  let arity t = List.map (fun t -> Flambda_kind.With_subkind.kind (kind t)) t
+
+  let arity_with_subkinds t = List.map (fun t -> kind t) t
 
   let equal t1 t2 =
     List.compare_lengths t1 t2 = 0

--- a/middle_end/flambda/basic/kinded_parameter.mli
+++ b/middle_end/flambda/basic/kinded_parameter.mli
@@ -24,7 +24,7 @@ type t
 include Bindable.S with type t := t
 
 (** Create a kinded parameter. *)
-val create : Variable.t -> Flambda_kind.t -> t
+val create : Variable.t -> Flambda_kind.With_subkind.t -> t
 
 (** The underlying variable. *)
 val var : t -> Variable.t
@@ -35,20 +35,15 @@ val name : t -> Name.t
 val simple : t -> Simple.t
 
 (** The kind of the given parameter. *)
-val kind : t -> Flambda_kind.t
+val kind : t -> Flambda_kind.With_subkind.t
 
 (** Replace the kind of the given parameter. *)
-val with_kind : t -> Flambda_kind.t -> t
+val with_kind : t -> Flambda_kind.With_subkind.t -> t
 
 (* CR mshinwell: We should use [Name.t] underneath *)
 
-(** Map the underlying variable of the given parameter. *)
-val map_var : t -> f:(Variable.t -> Variable.t) -> t
-
-(** Map the kind of the given parameter. *)
-val map_kind : t -> f:(Flambda_kind.t -> Flambda_kind.t) -> t
-
-(** Returns [true] iff the provided kinded parameters have the same kind. *)
+(** Returns [true] iff the provided kinded parameters have the same kind
+    and subkind. *)
 val equal_kinds : t -> t -> bool
 
 val rename : t -> t
@@ -58,7 +53,7 @@ module List : sig
 
   include Contains_names.S with type t := t
 
-  val create : (Variable.t * Flambda_kind.t) list -> t
+  val create : (Variable.t * Flambda_kind.With_subkind.t) list -> t
 
   (** As for [Variable.List.vars]. *)
   val vars : t -> Variable.t list
@@ -80,6 +75,8 @@ module List : sig
   val rename : t -> t
 
   val arity : t -> Flambda_arity.t
+
+  val arity_with_subkinds : t -> Flambda_arity.With_subkinds.t
 
   val print : Format.formatter -> t -> unit
 

--- a/middle_end/flambda/cmx/exported_code.ml
+++ b/middle_end/flambda/cmx/exported_code.ml
@@ -45,7 +45,7 @@ module Calling_convention = struct
     let f ~return_continuation:_ _exn_continuation params ~body ~my_closure =
       let free_vars = Flambda.Expr.free_names body in
       let needs_closure_arg = Name_occurrences.mem_var free_vars my_closure in
-      let params_arity = List.map Kinded_parameter.kind params in
+      let params_arity = Kinded_parameter.List.arity params in
       { needs_closure_arg; params_arity; }
     in
     P.pattern_match params_and_body ~f

--- a/middle_end/flambda/compilenv_deps/flambda_colours.ml
+++ b/middle_end/flambda/compilenv_deps/flambda_colours.ml
@@ -27,6 +27,7 @@ let tagged_immediate () = C.fg_256 70
 let constructor () = C.fg_256 69
 
 let kind () = C.fg_256 37
+let subkind () = C.fg_256 39
 
 let top_or_bottom_type () = C.fg_256 37
 

--- a/middle_end/flambda/compilenv_deps/flambda_colours.mli
+++ b/middle_end/flambda/compilenv_deps/flambda_colours.mli
@@ -25,6 +25,7 @@ val tagged_immediate : unit -> string
 val constructor : unit -> string
 
 val kind : unit -> string
+val subkind : unit -> string
 
 val top_or_bottom_type : unit -> string
 

--- a/middle_end/flambda/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion.ml
@@ -316,6 +316,9 @@ let close_c_call t ~let_bound_var (prim : Primitive.description)
     if not needs_wrapper then call
     else
       let after_call =
+        let return_kind =
+          Flambda_kind.With_subkind.create return_kind Anything
+        in
         let params = [Kinded_parameter.create handler_param return_kind] in
         let params_and_handler =
           Continuation_params_and_handler.create params
@@ -942,7 +945,7 @@ and close_one_function t ~external_env ~by_closure_id decl
       ~return_continuation:(Function_decl.return_continuation decl)
       exn_continuation params ~dbg ~body ~my_closure
   in
-  let params_arity = Kinded_parameter.List.arity params in
+  let params_arity = Kinded_parameter.List.arity_with_subkinds params in
   let is_tupled =
     match Function_decl.kind decl with
     | Curried -> false
@@ -1049,7 +1052,9 @@ let ilambda_to_flambda ~backend ~module_ident ~module_block_size_in_words
       body (List.rev field_vars)
   in
   let load_fields_cont_handler =
-    let param = Kinded_parameter.create module_block_var K.value in
+    let param =
+      Kinded_parameter.create module_block_var K.With_subkind.any_value
+    in
     let params_and_handler =
       Continuation_params_and_handler.create [param]
         ~handler:load_fields_body;

--- a/middle_end/flambda/from_lambda/ilambda.ml
+++ b/middle_end/flambda/from_lambda/ilambda.ml
@@ -131,7 +131,7 @@ let print_simple_and_value_kind ppf (simple, kind) =
 
 let rec print_function ppf
       ({ return_continuation; kind; params; body; free_idents_of_body = _; attr;
-         exn_continuation; return = _; loc = _; stub = _;
+         exn_continuation; return; loc = _; stub = _;
        } : function_declaration) =
   let pr_params ppf params =
     match kind with
@@ -157,8 +157,9 @@ let rec print_function ppf
         print_simple_and_value_kind)
       extra_args
   end;
-  fprintf ppf "%a@ %a%a)@]"
+  fprintf ppf "%a@ : %a@ %a%a)@]"
     pr_params params
+    Printlambda.value_kind' return
     Printlambda.function_attribute attr
     print body
 

--- a/middle_end/flambda/from_lambda/lambda_conversions.ml
+++ b/middle_end/flambda/from_lambda/lambda_conversions.ml
@@ -17,6 +17,7 @@
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
 module K = Flambda_kind
+module KS = Flambda_kind.With_subkind
 module L = Lambda
 module P = Flambda_primitive
 
@@ -28,12 +29,12 @@ let check_float_array_optimisation_enabled () =
 
 let value_kind (value_kind : L.value_kind) =
   match value_kind with
-  | Pgenval
-  | Pfloatval
-  | Pboxedintval Pint32
-  | Pboxedintval Pint64
-  | Pboxedintval Pnativeint
-  | Pintval -> K.value
+  | Pgenval -> KS.any_value
+  | Pfloatval -> KS.boxed_float
+  | Pboxedintval Pint32 -> KS.boxed_int32
+  | Pboxedintval Pint64 -> KS.boxed_int64
+  | Pboxedintval Pnativeint -> KS.boxed_nativeint
+  | Pintval -> KS.tagged_immediate
 
 let inline_attribute (attr : L.inline_attribute) : Inline_attribute.t =
   match attr with

--- a/middle_end/flambda/from_lambda/lambda_conversions.mli
+++ b/middle_end/flambda/from_lambda/lambda_conversions.mli
@@ -18,7 +18,7 @@
 
 (** Conversions of basic Lambda data types to their Flambda equivalents. *)
 
-val value_kind : Lambda.value_kind -> Flambda_kind.t
+val value_kind : Lambda.value_kind -> Flambda_kind.With_subkind.t
 
 val inline_attribute
    : Lambda.inline_attribute

--- a/middle_end/flambda/from_lambda/prepare_lambda.ml
+++ b/middle_end/flambda/from_lambda/prepare_lambda.ml
@@ -281,10 +281,10 @@ let rec prepare env (lam : L.lambda) (k : L.lambda -> L.lambda) =
         loc = loc;
       }))
   | Llet ((Strict | Alias | StrictOpt), Pgenval, fun_id,
-      Lfunction { kind; params; body = fbody; attr; loc; _ }, body) ->
+      Lfunction { kind; params; body = fbody; attr; loc; return; }, body) ->
     begin match
       Simplif.split_default_wrapper ~id:fun_id ~kind ~params
-        ~body:fbody ~return:Pgenval ~attr ~loc
+        ~body:fbody ~return ~attr ~loc
     with
     | [fun_id, def] ->
       (* CR mshinwell: Here and below, mark the wrappers as stubs *)
@@ -315,9 +315,9 @@ let rec prepare env (lam : L.lambda) (k : L.lambda -> L.lambda) =
     prepare_list_with_flatten_map env bindings
       ~flatten_map:(fun fun_id (binding : L.lambda) ->
         match binding with
-        | Lfunction { kind; params; body = fbody; attr; loc; _ } ->
+        | Lfunction { kind; params; body = fbody; attr; loc; return; _ } ->
           Simplif.split_default_wrapper ~id:fun_id ~kind ~params
-            ~body:fbody ~return:Pgenval ~attr ~loc
+            ~body:fbody ~return ~attr ~loc
         | _ -> [fun_id, binding])
       (fun bindings ->
         prepare env body (fun body ->

--- a/middle_end/flambda/inlining/inlining_transforms.ml
+++ b/middle_end/flambda/inlining/inlining_transforms.ml
@@ -92,7 +92,7 @@ let inline dacc ~callee ~args function_decl
                   let pop_wrapper_cont = Continuation.create () in
                   let pop_wrapper_handler =
                     let kinded_params =
-                      List.map (fun k -> (Variable.create "wrapper_return", k))
+                      List.map (fun k -> Variable.create "wrapper_return", k)
                         (Code.result_arity code)
                     in
                     let trap_action =
@@ -124,7 +124,9 @@ let inline dacc ~callee ~args function_decl
               in
               let wrapper_handler =
                 let param = Variable.create "exn" in
-                let kinded_params = [KP.create param K.value] in
+                let kinded_params =
+                  [KP.create param K.With_subkind.any_value]
+                in
                 let exn_handler =
                   Exn_continuation.exn_handler apply_exn_continuation
                 in

--- a/middle_end/flambda/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda/parser/flambda_to_fexpr.ml
@@ -296,13 +296,15 @@ let kind (k : Flambda_kind.t) : Fexpr.kind =
   | Fabricated -> Fabricated
   | Naked_number nnk -> Naked_number (naked_number_kind nnk)
 
-let arity (a : Flambda_arity.t) : Fexpr.flambda_arity =
-  List.map kind a
+let arity (a : Flambda_arity.With_subkinds.t) : Fexpr.flambda_arity =
+  List.map kind (Flambda_arity.With_subkinds.to_arity a)
+
+let arity_without_subkinds a = List.map kind a
 
 let kinded_parameter env (kp : Kinded_parameter.t)
       : Fexpr.kinded_parameter * Env.t =
   let k =
-    match kind (Kinded_parameter.kind kp) with
+    match kind (Flambda_kind.With_subkind.kind (Kinded_parameter.kind kp)) with
     | Value -> None
     | k -> Some k
   in
@@ -562,7 +564,7 @@ and static_let_expr env bound_symbols defining_expr body : Fexpr.expr =
       in
       let param_arity =
         match Flambda.Code.params_and_body code with
-        | Deleted -> 
+        | Deleted ->
           Some (arity (Flambda.Code.params_arity code))
         | Present _ ->
           None (* arity will be determined from params *)
@@ -741,10 +743,19 @@ and apply_expr env (app : Apply_expr.t) : Fexpr.expr =
   in
   let arities : Fexpr.function_arities option =
     match Apply_expr.call_kind app with
-    | Function (Indirect_known_arity { param_arity; return_arity })
+    | Function (Indirect_known_arity { param_arity; return_arity }) ->
+      let params_arity =
+        Flambda_arity.With_subkinds.to_arity param_arity
+        |> arity_without_subkinds
+      in
+      let ret_arity =
+        Flambda_arity.With_subkinds.to_arity return_arity
+        |> arity_without_subkinds
+      in
+      Some { params_arity; ret_arity; }
     | C_call { param_arity; return_arity; _ } ->
-      let params_arity = arity param_arity in
-      let ret_arity = arity return_arity in
+      let params_arity = arity_without_subkinds param_arity in
+      let ret_arity = arity_without_subkinds return_arity in
       Some { params_arity; ret_arity }
     | _ ->
       None

--- a/middle_end/flambda/simplify/basic/apply_cont_rewrite.ml
+++ b/middle_end/flambda/simplify/basic/apply_cont_rewrite.ml
@@ -163,8 +163,10 @@ let rewrite_use t id apply_cont : rewrite_use_result =
    "extra args" as in [Exn_continuation]. *)
 let rewrite_exn_continuation t id exn_cont =
   let exn_cont_arity = Exn_continuation.arity exn_cont in
-  let original_params_arity = List.map KP.kind t.original_params in
-  if not (Flambda_arity.equal exn_cont_arity original_params_arity) then begin
+  let original_params_arity = KP.List.arity_with_subkinds t.original_params in
+  if not (Flambda_arity.With_subkinds.equal exn_cont_arity
+    original_params_arity)
+  then begin
     Misc.fatal_errorf "Arity of exception continuation %a does not \
         match@ [original_params] (%a)"
       Exn_continuation.print exn_cont
@@ -197,4 +199,4 @@ let rewrite_exn_continuation t id exn_cont =
     ~extra_args
 
 let original_params_arity t =
-  KP.List.arity t.original_params
+  KP.List.arity_with_subkinds t.original_params

--- a/middle_end/flambda/simplify/basic/apply_cont_rewrite.mli
+++ b/middle_end/flambda/simplify/basic/apply_cont_rewrite.mli
@@ -58,6 +58,6 @@ val rewrite_exn_continuation
   -> Exn_continuation.t
   -> Exn_continuation.t
 
-val original_params_arity : t -> Flambda_arity.t
+val original_params_arity : t -> Flambda_arity.With_subkinds.t
 
 val does_nothing : t -> bool

--- a/middle_end/flambda/simplify/basic/continuation_in_env.ml
+++ b/middle_end/flambda/simplify/basic/continuation_in_env.ml
@@ -18,12 +18,12 @@
 
 type t =
   | Unknown of {
-      arity : Flambda_arity.t;
+      arity : Flambda_arity.With_subkinds.t;
       handler : Flambda.Continuation_handler.t option;
     }
-  | Unreachable of { arity : Flambda_arity.t; }
+  | Unreachable of { arity : Flambda_arity.With_subkinds.t; }
   | Inline of {
-      arity : Flambda_arity.t;
+      arity : Flambda_arity.With_subkinds.t;
       handler : Flambda.Continuation_handler.t;
     }
 

--- a/middle_end/flambda/simplify/basic/continuation_in_env.mli
+++ b/middle_end/flambda/simplify/basic/continuation_in_env.mli
@@ -18,15 +18,15 @@
 
 type t =
   | Unknown of {
-      arity : Flambda_arity.t;
+      arity : Flambda_arity.With_subkinds.t;
       handler : Flambda.Continuation_handler.t option;
     }
-  | Unreachable of { arity : Flambda_arity.t; }
+  | Unreachable of { arity : Flambda_arity.With_subkinds.t; }
   | Inline of {
-      arity : Flambda_arity.t;
+      arity : Flambda_arity.With_subkinds.t;
       handler : Flambda.Continuation_handler.t;
     }
 
 val print : Format.formatter -> t -> unit
 
-val arity : t -> Flambda_arity.t
+val arity : t -> Flambda_arity.With_subkinds.t

--- a/middle_end/flambda/simplify/env/simplify_envs_intf.ml
+++ b/middle_end/flambda/simplify/env/simplify_envs_intf.ml
@@ -126,6 +126,11 @@ module type Downwards_env = sig
 
   val add_parameters_with_unknown_types : t -> Kinded_parameter.t list -> t
 
+  val add_parameters_with_unknown_types'
+     : t
+    -> Kinded_parameter.t list
+    -> t * (Flambda_type.t list)
+
   val extend_typing_environment : t -> Flambda_type.Typing_env_extension.t -> t
 
   val with_typing_env : t -> Flambda_type.Typing_env.t -> t
@@ -205,14 +210,14 @@ module type Upwards_env = sig
      : t
     -> Continuation.t
     -> Scope.t
-    -> Flambda_arity.t
+    -> Flambda_arity.With_subkinds.t
     -> t
 
   val add_continuation_with_handler
      : t
     -> Continuation.t
     -> Scope.t
-    -> Flambda_arity.t
+    -> Flambda_arity.With_subkinds.t
     -> Continuation_handler.t
     -> t
 
@@ -220,13 +225,13 @@ module type Upwards_env = sig
      : t
     -> Continuation.t
     -> Scope.t
-    -> Flambda_arity.t
+    -> Flambda_arity.With_subkinds.t
     -> t
 
   val add_continuation_alias
      : t
     -> Continuation.t
-    -> Flambda_arity.t
+    -> Flambda_arity.With_subkinds.t
     -> alias_for:Continuation.t
     -> t
 
@@ -234,7 +239,7 @@ module type Upwards_env = sig
      : t
     -> Continuation.t
     -> Scope.t
-    -> Flambda_arity.t
+    -> Flambda_arity.With_subkinds.t
     -> Continuation_handler.t
     -> t
 
@@ -255,7 +260,7 @@ module type Upwards_env = sig
     -> Exn_continuation.t
     -> Exn_continuation.t
 
-  val continuation_arity : t -> Continuation.t -> Flambda_arity.t
+  val continuation_arity : t -> Continuation.t -> Flambda_arity.With_subkinds.t
 
   val check_continuation_is_bound : t -> Continuation.t -> unit
 

--- a/middle_end/flambda/simplify/simplify_common.ml
+++ b/middle_end/flambda/simplify/simplify_common.ml
@@ -88,7 +88,12 @@ let add_wrapper_for_fixed_arity_continuation0 uacc cont_or_apply_cont
   match UE.find_apply_cont_rewrite uenv original_cont with
   | None -> This_continuation cont
   | Some rewrite when Apply_cont_rewrite.does_nothing rewrite ->
-    let arity_in_rewrite = Apply_cont_rewrite.original_params_arity rewrite in
+    (* CR mshinwell: think more about this check w.r.t. subkinds *)
+    let arity = Flambda_arity.With_subkinds.to_arity arity in
+    let arity_in_rewrite =
+      Apply_cont_rewrite.original_params_arity rewrite
+      |> Flambda_arity.With_subkinds.to_arity
+    in
     if not (Flambda_arity.equal arity arity_in_rewrite) then begin
       Misc.fatal_errorf "Arity %a provided to fixed-arity-wrapper \
           addition function does not match arity %a in rewrite:@ %a"
@@ -388,7 +393,7 @@ let split_direct_over_application apply ~param_arity =
   let after_full_application = Continuation.create () in
   let after_full_application_handler =
     let params_and_handler =
-      let func_param = KP.create func_var K.value in
+      let func_param = KP.create func_var K.With_subkind.any_value in
       Continuation_params_and_handler.create [func_param]
         ~handler:(Expr.create_apply perform_over_application)
     in

--- a/middle_end/flambda/simplify/simplify_common.mli
+++ b/middle_end/flambda/simplify/simplify_common.mli
@@ -49,13 +49,13 @@ val add_wrapper_for_switch_arm
    : Upwards_acc.t
   -> Flambda.Apply_cont.t
   -> use_id:Apply_cont_rewrite_id.t
-  -> Flambda_arity.t
+  -> Flambda_arity.With_subkinds.t
   -> add_wrapper_for_switch_arm_result
 
 val add_wrapper_for_fixed_arity_apply
    : Upwards_acc.t
   -> use_id:Apply_cont_rewrite_id.t
-  -> Flambda_arity.t
+  -> Flambda_arity.With_subkinds.t
   -> Apply_expr.t
   -> Flambda.Expr.t
 
@@ -98,6 +98,5 @@ val project_tuple
     the application of the leftover arguments. *)
 val split_direct_over_application
   : Apply_expr.t
- -> param_arity:Flambda_arity.t
+ -> param_arity:Flambda_arity.With_subkinds.t
  -> Flambda.Expr.t
-

--- a/middle_end/flambda/simplify/simplify_toplevel.rec.mli
+++ b/middle_end/flambda/simplify/simplify_toplevel.rec.mli
@@ -20,7 +20,7 @@ val simplify_toplevel
    : Downwards_acc.t
   -> Flambda.Expr.t
   -> return_continuation:Continuation.t
-  -> return_arity:Flambda_arity.t
+  -> return_arity:Flambda_arity.With_subkinds.t
   -> Exn_continuation.t
   -> return_cont_scope:Scope.t
   -> exn_cont_scope:Scope.t

--- a/middle_end/flambda/simplify/template/simplify.templ.ml
+++ b/middle_end/flambda/simplify/template/simplify.templ.ml
@@ -86,8 +86,8 @@ let run ~backend ~round unit =
       Exn_continuation.create ~exn_handler:exn_continuation ~extra_args:[]
     in
     Simplify_toplevel.simplify_toplevel dacc (FU.body unit) ~return_continuation
-      ~return_arity:[K.value] exn_continuation ~return_cont_scope
-      ~exn_cont_scope
+      ~return_arity:[K.With_subkind.any_value] exn_continuation
+      ~return_cont_scope ~exn_cont_scope
   in
   let return_cont_env = DA.continuation_uses_env dacc in
   let all_code =

--- a/middle_end/flambda/terms/apply_cont_expr.ml
+++ b/middle_end/flambda/terms/apply_cont_expr.ml
@@ -16,8 +16,6 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
-module K = Flambda_kind
-
 type t = {
   k : Continuation.t;
   args : Simple.t list;
@@ -105,6 +103,8 @@ end)
 
 let print_with_cache ~cache:_ ppf t = print ppf t
 
+let invariant _env _ = ()
+(*
 let invariant env ({ k; args; trap_action; dbg=_; } as t) =
   let module E = Invariant_env in
   let unbound_continuation cont reason =
@@ -123,7 +123,8 @@ let invariant env ({ k; args; trap_action; dbg=_; } as t) =
   let stack = E.current_continuation_stack env in
   E.Continuation_stack.unify cont stack cont_stack;
 *)
-  if not (Flambda_arity.equal args_arity arity) then begin
+  (* XXX This check can't be equality any more *)
+  if not (Flambda_arity.With_subkinds.equal args_arity arity) then begin
     Misc.fatal_errorf "Continuation %a called with wrong arity in \
         this [Apply_cont] term: expected %a but found %a:@ %a"
       Continuation.print k
@@ -200,6 +201,7 @@ let invariant env ({ k; args; trap_action; dbg=_; } as t) =
   E.Continuation_stack.unify cont stack cont_stack
   current_stack
   *)
+*)
 
 (* CR mshinwell: Check the sort of [k]. *)
 let create ?trap_action k ~args ~dbg = { k; args; trap_action; dbg; }
@@ -248,7 +250,7 @@ let apply_name_permutation ({ k; args; trap_action; dbg; } as t) perm =
 
 let all_ids_for_export { k; args; trap_action; dbg = _; } =
   List.fold_left (fun ids arg -> Ids_for_export.add_simple ids arg)
-    (Ids_for_export.add_continuation 
+    (Ids_for_export.add_continuation
       (Trap_action.Option.all_ids_for_export trap_action)
       k)
     args
@@ -297,5 +299,5 @@ let to_one_arg_without_trap_action t =
   | Some _ -> None
   | None ->
     match t.args with
-    | [arg] -> Some arg 
+    | [arg] -> Some arg
     | [] | _::_::_ -> None

--- a/middle_end/flambda/terms/apply_expr.ml
+++ b/middle_end/flambda/terms/apply_expr.ml
@@ -121,7 +121,7 @@ let invariant env
     | Function Indirect_unknown_arity ->
       E.check_simples_are_bound_and_of_kind env args K.value
     | Function (Indirect_known_arity { param_arity; return_arity = _; }) ->
-      ignore (param_arity : Flambda_arity.t);
+      ignore (param_arity : Flambda_arity.With_subkinds.t);
       E.check_simples_are_bound env args
     | Method { kind; obj; } ->
       ignore (kind : Call_kind.method_kind);
@@ -145,7 +145,7 @@ let invariant env
       | a ->
         Misc.fatal_errorf "This [Apply] never returns and so expects an empty \
                            arity, but has a call kind arity of %a:@ %a"
-          Flambda_arity.print a print t
+          Flambda_arity.With_subkinds.print a print t
       end
     (* general case *)
     | Return continuation ->
@@ -163,13 +163,14 @@ let invariant env
             print t
         end;
         let expected_arity = Call_kind.return_arity call_kind in
-        if not (Flambda_arity.equal arity expected_arity)
+        if not (Flambda_arity.With_subkinds.compatible expected_arity
+          ~when_used_at:arity)
         then begin
           Misc.fatal_errorf "Continuation %a called with wrong arity in \
                              this [Apply] term: expected %a but used at %a:@ %a"
             Continuation.print continuation
-            Flambda_arity.print expected_arity
-            Flambda_arity.print arity
+            Flambda_arity.With_subkinds.print expected_arity
+            Flambda_arity.With_subkinds.print arity
             print t
         end (*;
               E.Continuation_stack.unify continuation stack cont_stack *)
@@ -190,13 +191,14 @@ let invariant env
             print t
         | Exn_handler -> ()
         end;
-        let expected_arity = [Flambda_kind.value] in
-        if not (Flambda_arity.equal arity expected_arity) then begin
+        let expected_arity = [Flambda_kind.With_subkind.any_value] in
+        if not (Flambda_arity.With_subkinds.equal arity expected_arity)
+        then begin
           Misc.fatal_errorf "Exception continuation %a named in this \
                              [Apply] term has the wrong arity: expected %a but have %a:@ %a"
             Continuation.print continuation
-            Flambda_arity.print expected_arity
-            Flambda_arity.print arity
+            Flambda_arity.With_subkinds.print expected_arity
+            Flambda_arity.With_subkinds.print arity
             print t
         end (*;
               E.Continuation_stack.unify exn_continuation stack cont_stack *)

--- a/middle_end/flambda/terms/call_kind.mli
+++ b/middle_end/flambda/terms/call_kind.mli
@@ -27,15 +27,15 @@ module Function_call : sig
         closure_id : Closure_id.t;
         (** The [closure_id] identifies which closure is to be passed to the
             function. *)
-        return_arity : Flambda_arity.t;
+        return_arity : Flambda_arity.With_subkinds.t;
         (** [return_arity] describes what the callee returns.  It matches up
             with the arity of [continuation] in the enclosing [Apply.t]
             record. *)
       }
     | Indirect_unknown_arity
     | Indirect_known_arity of {
-        param_arity : Flambda_arity.t;
-        return_arity : Flambda_arity.t;
+        param_arity : Flambda_arity.With_subkinds.t;
+        return_arity : Flambda_arity.With_subkinds.t;
       }
 end
 
@@ -59,14 +59,14 @@ include Contains_ids.S with type t := t
 val direct_function_call
    : Code_id.t
   -> Closure_id.t
-  -> return_arity:Flambda_arity.t
+  -> return_arity:Flambda_arity.With_subkinds.t
   -> t
 
 val indirect_function_call_unknown_arity : unit -> t
 
 val indirect_function_call_known_arity
-   : param_arity:Flambda_arity.t
-  -> return_arity:Flambda_arity.t
+   : param_arity:Flambda_arity.With_subkinds.t
+  -> return_arity:Flambda_arity.With_subkinds.t
   -> t
 
 val method_call : method_kind -> obj:Simple.t -> t
@@ -77,4 +77,4 @@ val c_call
   -> return_arity:Flambda_arity.t
   -> t
 
-val return_arity : t -> Flambda_arity.t
+val return_arity : t -> Flambda_arity.With_subkinds.t

--- a/middle_end/flambda/terms/code.rec.ml
+++ b/middle_end/flambda/terms/code.rec.ml
@@ -20,8 +20,8 @@ type t = {
   code_id : Code_id.t;
   params_and_body : Function_params_and_body.t Or_deleted.t;
   newer_version_of : Code_id.t option;
-  params_arity : Flambda_arity.t;
-  result_arity : Flambda_arity.t;
+  params_arity : Flambda_arity.With_subkinds.t;
+  result_arity : Flambda_arity.With_subkinds.t;
   stub : bool;
   inline : Inline_attribute.t;
   is_a_functor : bool;
@@ -125,21 +125,21 @@ let print_with_cache ~cache ppf
     (if not is_a_functor then Flambda_colours.elide () else C.normal ())
     is_a_functor
     (Flambda_colours.normal ())
-    (if Flambda_arity.is_singleton_value params_arity
+    (if Flambda_arity.With_subkinds.is_singleton_value params_arity
      then Flambda_colours.elide ()
      else Flambda_colours.normal ())
     (Flambda_colours.normal ())
-    Flambda_arity.print params_arity
-    (if Flambda_arity.is_singleton_value params_arity
+    Flambda_arity.With_subkinds.print params_arity
+    (if Flambda_arity.With_subkinds.is_singleton_value params_arity
      then Flambda_colours.elide ()
      else Flambda_colours.normal ())
     (Flambda_colours.normal ())
-    (if Flambda_arity.is_singleton_value result_arity
+    (if Flambda_arity.With_subkinds.is_singleton_value result_arity
      then Flambda_colours.elide ()
      else Flambda_colours.normal ())
     (Flambda_colours.normal ())
-    Flambda_arity.print result_arity
-    (if Flambda_arity.is_singleton_value result_arity
+    Flambda_arity.With_subkinds.print result_arity
+    (if Flambda_arity.With_subkinds.is_singleton_value result_arity
      then Flambda_colours.elide ()
      else Flambda_colours.normal ())
     (Flambda_colours.normal ())

--- a/middle_end/flambda/terms/code.rec.mli
+++ b/middle_end/flambda/terms/code.rec.mli
@@ -35,9 +35,9 @@ val params_and_body_must_be_present
 
 val newer_version_of : t -> Code_id.t option
 
-val params_arity : t -> Flambda_arity.t
+val params_arity : t -> Flambda_arity.With_subkinds.t
 
-val result_arity : t -> Flambda_arity.t
+val result_arity : t -> Flambda_arity.With_subkinds.t
 
 val stub : t -> bool
 
@@ -51,8 +51,8 @@ val create
    : Code_id.t  (** needed for [compare], although useful otherwise too *)
   -> params_and_body:Function_params_and_body.t Or_deleted.t
   -> newer_version_of:Code_id.t option
-  -> params_arity:Flambda_arity.t
-  -> result_arity:Flambda_arity.t
+  -> params_arity:Flambda_arity.With_subkinds.t
+  -> result_arity:Flambda_arity.With_subkinds.t
   -> stub:bool
   -> inline:Inline_attribute.t
   -> is_a_functor:bool

--- a/middle_end/flambda/terms/continuation_handler.rec.ml
+++ b/middle_end/flambda/terms/continuation_handler.rec.ml
@@ -149,9 +149,12 @@ let import import_map
   { params_and_handler; stub; is_exn_handler; }
 
 type behaviour =
-  | Unreachable of { arity : Flambda_arity.t; }
-  | Alias_for of { arity : Flambda_arity.t; alias_for : Continuation.t; }
-  | Unknown of { arity : Flambda_arity.t; }
+  | Unreachable of { arity : Flambda_arity.With_subkinds.t; }
+  | Alias_for of {
+      arity : Flambda_arity.With_subkinds.t;
+      alias_for : Continuation.t;
+    }
+  | Unknown of { arity : Flambda_arity.With_subkinds.t; }
 
 let behaviour t : behaviour =
   (* CR mshinwell: Maybe [behaviour] should be cached, to avoid re-opening
@@ -160,7 +163,7 @@ let behaviour t : behaviour =
      moment we just use a simple syntactic check. *)
   Continuation_params_and_handler.pattern_match t.params_and_handler
     ~f:(fun params ~handler ->
-      let arity = Kinded_parameter.List.arity params in
+      let arity = Kinded_parameter.List.arity_with_subkinds params in
       if t.is_exn_handler then
         Unknown { arity; }
       else
@@ -184,7 +187,8 @@ let behaviour t : behaviour =
 
 let arity t =
   Continuation_params_and_handler.pattern_match t.params_and_handler
-    ~f:(fun params ~handler:_ -> Kinded_parameter.List.arity params)
+    ~f:(fun params ~handler:_ ->
+      Kinded_parameter.List.arity_with_subkinds params)
 
 let with_params_and_handler t params_and_handler =
   { t with params_and_handler; }

--- a/middle_end/flambda/terms/continuation_handler.rec.mli
+++ b/middle_end/flambda/terms/continuation_handler.rec.mli
@@ -58,14 +58,17 @@ val is_exn_handler : t -> bool
    function declarations to hold one or more wrappers themselves. *)
 val stub : t -> bool
 
-val arity : t -> Flambda_arity.t
+val arity : t -> Flambda_arity.With_subkinds.t
 
 val with_params_and_handler : t -> Continuation_params_and_handler.t -> t
 
 type behaviour = private
-  | Unreachable of { arity : Flambda_arity.t; }
-  | Alias_for of { arity : Flambda_arity.t; alias_for : Continuation.t; }
-  | Unknown of { arity : Flambda_arity.t; }
+  | Unreachable of { arity : Flambda_arity.With_subkinds.t; }
+  | Alias_for of {
+      arity : Flambda_arity.With_subkinds.t;
+      alias_for : Continuation.t;
+    }
+  | Unknown of { arity : Flambda_arity.With_subkinds.t; }
 
 val behaviour : t -> behaviour
 

--- a/middle_end/flambda/terms/flambda.mli
+++ b/middle_end/flambda/terms/flambda.mli
@@ -372,14 +372,17 @@ end and Continuation_handler : sig
      function declarations to hold one or more wrappers themselves. *)
   val stub : t -> bool
 
-  val arity : t -> Flambda_arity.t
+  val arity : t -> Flambda_arity.With_subkinds.t
 
   val with_params_and_handler : t -> Continuation_params_and_handler.t -> t
 
   type behaviour = private
-    | Unreachable of { arity : Flambda_arity.t; }
-    | Alias_for of { arity : Flambda_arity.t; alias_for : Continuation.t; }
-    | Unknown of { arity : Flambda_arity.t; }
+    | Unreachable of { arity : Flambda_arity.With_subkinds.t; }
+    | Alias_for of {
+        arity : Flambda_arity.With_subkinds.t;
+        alias_for : Continuation.t;
+      }
+    | Unknown of { arity : Flambda_arity.With_subkinds.t; }
 
   val behaviour : t -> behaviour
 end and Continuation_params_and_handler : sig
@@ -664,9 +667,9 @@ end and Code : sig
 
   val newer_version_of : t -> Code_id.t option
 
-  val params_arity : t -> Flambda_arity.t
+  val params_arity : t -> Flambda_arity.With_subkinds.t
 
-  val result_arity : t -> Flambda_arity.t
+  val result_arity : t -> Flambda_arity.With_subkinds.t
 
   val stub : t -> bool
 
@@ -680,8 +683,8 @@ end and Code : sig
      : Code_id.t
     -> params_and_body:Function_params_and_body.t Or_deleted.t
     -> newer_version_of:Code_id.t option
-    -> params_arity:Flambda_arity.t
-    -> result_arity:Flambda_arity.t
+    -> params_arity:Flambda_arity.With_subkinds.t
+    -> result_arity:Flambda_arity.With_subkinds.t
     -> stub:bool
     -> inline:Inline_attribute.t
     -> is_a_functor:bool

--- a/middle_end/flambda/terms/function_params_and_body.rec.ml
+++ b/middle_end/flambda/terms/function_params_and_body.rec.ml
@@ -32,7 +32,9 @@ type t = {
 let invariant _env _t = ()
 
 let create ~return_continuation exn_continuation params ~dbg ~body ~my_closure =
-  let my_closure = Kinded_parameter.create my_closure K.value in
+  let my_closure =
+    Kinded_parameter.create my_closure (K.With_subkind.create K.value Anything)
+  in
   let t0 = T0.create (params @ [my_closure]) body in
   let t1 = T1.create exn_continuation t0 in
   let abst = A.create return_continuation t1 in
@@ -63,7 +65,10 @@ let pattern_match_pair t1 t2 ~f =
 let print_with_cache ~cache ppf t =
   pattern_match t
     ~f:(fun ~return_continuation exn_continuation params ~body ~my_closure ->
-      let my_closure = Kinded_parameter.create my_closure Flambda_kind.value in
+      let my_closure =
+        Kinded_parameter.create my_closure
+          (K.With_subkind.create K.value Anything)
+      in
       fprintf ppf
         "@[<hov 1>(@<0>%s@<1>\u{03bb}@<0>%s@[<hov 1>\
          @<1>\u{3008}%a@<1>\u{3009}@<1>\u{300a}%a@<1>\u{300b}\

--- a/middle_end/flambda/to_cmm/un_cps_env.ml
+++ b/middle_end/flambda/to_cmm/un_cps_env.ml
@@ -263,7 +263,10 @@ let add_inline_cont env k vars e =
   { env with conts }
 
 let add_exn_handler env k h =
-  let arity = Flambda.Continuation_handler.arity h in
+  let arity =
+    Flambda.Continuation_handler.arity h
+    |> Flambda_arity.With_subkinds.to_arity
+  in
   match arity with
   | [] -> Misc.fatal_error "Exception handler with no arguments"
   | [_] -> env, []

--- a/middle_end/flambda/types/env/typing_env.rec.ml
+++ b/middle_end/flambda/types/env/typing_env.rec.ml
@@ -582,6 +582,7 @@ let check_optional_kind_matches name ty kind_opt =
 
 exception Missing_cmx_and_kind
 
+(* CR mshinwell: [kind] could also take a [subkind] *)
 let find_with_binding_time_and_mode' t name kind =
   match Name.Map.find name (names_to_types t) with
   | exception Not_found ->
@@ -671,7 +672,7 @@ let find_or_missing t name =
 let find_params t params =
   List.map (fun param ->
       let name = Kinded_parameter.name param in
-      let kind = Kinded_parameter.kind param in
+      let kind = Flambda_kind.With_subkind.kind (Kinded_parameter.kind param) in
     find t name (Some kind))
   params
 
@@ -1090,7 +1091,8 @@ let add_definitions_of_params t ~params =
         Name_in_binding_pos.create (Kinded_parameter.name param)
           Name_mode.normal
       in
-      add_definition t name (Kinded_parameter.kind param))
+      add_definition t name
+        (Flambda_kind.With_subkind.kind (Kinded_parameter.kind param)))
     t
     params
 

--- a/middle_end/flambda/types/env/typing_env_level.rec.ml
+++ b/middle_end/flambda/types/env/typing_env_level.rec.ml
@@ -752,7 +752,10 @@ let join_cse envs_with_levels cse ~allowed =
             Flambda_primitive.result_kind' (EP.to_primitive prim)
           in
           let var = Variable.create "cse_param" in
-          let extra_param = Kinded_parameter.create var prim_result_kind in
+          let extra_param =
+            Kinded_parameter.create var
+              (Flambda_kind.With_subkind.create prim_result_kind Anything)
+          in
           let bound_to =
             Apply_cont_rewrite_id.Map.map Rhs_kind.bound_to bound_to_map
           in

--- a/middle_end/flambda/types/flambda_type.mli
+++ b/middle_end/flambda/types/flambda_type.mli
@@ -260,6 +260,8 @@ val bottom : Flambda_kind.t -> t
 (** Construct a top ("unknown") type of the given kind. *)
 val unknown : Flambda_kind.t -> t
 
+val unknown_with_subkind : Flambda_kind.With_subkind.t -> t
+
 (** Create an bottom type with the same kind as the given type. *)
 val bottom_like : t -> t
 
@@ -408,6 +410,10 @@ val get_alias_exn : t -> Simple.t
 
 (** For each of the kinds in an arity, create an "unknown" type. *)
 val unknown_types_from_arity : Flambda_arity.t -> t list
+
+val unknown_types_from_arity_with_subkinds
+   : Flambda_arity.With_subkinds.t
+  -> t list
 
 (** For each of the kinds in an arity, create an "bottom" type. *)
 val bottom_types_from_arity : Flambda_arity.t -> t list

--- a/middle_end/flambda/types/kinds/flambda_arity.ml
+++ b/middle_end/flambda/types/kinds/flambda_arity.ml
@@ -57,3 +57,56 @@ let is_singleton_value t =
   match t with
   | [kind] when Flambda_kind.equal kind Flambda_kind.value -> true
   | _ -> false
+
+module With_subkinds = struct
+  type arity = t
+  type t = Flambda_kind.With_subkind.t list
+
+  let create t = t
+
+  include Identifiable.Make (struct
+    type nonrec t = t
+
+    let compare t1 t2 =
+      Misc.Stdlib.List.compare Flambda_kind.With_subkind.compare t1 t2
+
+    let equal t1 t2 = (compare t1 t2 = 0)
+
+    let hash = Hashtbl.hash
+
+    let print ppf t =
+      match t with
+      | [] -> Format.pp_print_string ppf "Nullary"
+      | _ ->
+        Format.fprintf ppf "@[%a@]"
+          (Format.pp_print_list
+            ~pp_sep:(fun ppf () -> Format.fprintf ppf " @<1>\u{2a2f} ")
+            Flambda_kind.With_subkind.print)
+          t
+
+    let output chan t =
+      print (Format.formatter_of_out_channel chan) t
+  end)
+
+  let is_singleton_value t =
+    match t with
+    | [kind]
+      when Flambda_kind.equal (Flambda_kind.With_subkind.kind kind)
+        Flambda_kind.value -> true
+    | _ -> false
+
+  let to_arity t = List.map Flambda_kind.With_subkind.kind t
+
+  let of_arity arity =
+    List.map (fun kind -> Flambda_kind.With_subkind.create kind Anything) arity
+
+  let compatible t ~when_used_at =
+    if List.compare_lengths t when_used_at <> 0 then begin
+      Misc.fatal_errorf "Mismatched arities:@ %a@ and@ %a"
+        print t
+        print when_used_at
+    end;
+    List.for_all2 (fun kind when_used_at ->
+        Flambda_kind.With_subkind.compatible kind ~when_used_at)
+      t when_used_at
+end

--- a/middle_end/flambda/types/kinds/flambda_arity.mli
+++ b/middle_end/flambda/types/kinds/flambda_arity.mli
@@ -36,3 +36,20 @@ val is_all_naked_floats : t -> bool
 val is_singleton_value : t -> bool
 
 include Identifiable.S with type t := t
+
+module With_subkinds : sig
+  type arity = t
+  type t = Flambda_kind.With_subkind.t list
+
+  val create : Flambda_kind.With_subkind.t list -> t
+
+  val is_singleton_value : t -> bool
+
+  val to_arity : t -> arity
+
+  val of_arity : arity -> t
+
+  val compatible : t -> when_used_at:t -> bool
+
+  include Identifiable.S with type t := t
+end

--- a/middle_end/flambda/types/kinds/flambda_kind.mli
+++ b/middle_end/flambda/types/kinds/flambda_kind.mli
@@ -151,3 +151,52 @@ module Naked_number : sig
 
   val print : Format.formatter -> _ t -> unit
 end
+
+module With_subkind : sig
+  module Subkind : sig
+    type t =
+      | Anything
+      | Boxed_float
+      | Boxed_int32
+      | Boxed_int64
+      | Boxed_nativeint
+      | Tagged_immediate
+
+    include Identifiable.S with type t := t
+  end
+
+  type kind = t
+  type t
+
+  val create : kind -> Subkind.t -> t
+
+  val kind : t -> kind
+  val subkind : t -> Subkind.t
+
+  val any_value : t
+  val naked_immediate : t
+  val naked_float : t
+  val naked_int32 : t
+  val naked_int64 : t
+  val naked_nativeint : t
+  val boxed_float : t
+  val boxed_int32 : t
+  val boxed_int64 : t
+  val boxed_nativeint : t
+  val tagged_immediate : t
+
+  type descr = private
+    | Any_value
+    | Naked_number of Naked_number_kind.t
+    | Boxed_float
+    | Boxed_int32
+    | Boxed_int64
+    | Boxed_nativeint
+    | Tagged_immediate
+
+  val descr : t -> descr
+
+  val compatible : t -> when_used_at:t -> bool
+
+  include Identifiable.S with type t := t
+end

--- a/middle_end/flambda/types/template/flambda_type.templ.ml
+++ b/middle_end/flambda/types/template/flambda_type.templ.ml
@@ -59,6 +59,23 @@ type 'a type_accessor = Typing_env.t -> 'a
 let unknown_types_from_arity arity =
   List.map (fun kind -> unknown kind) arity
 
+let unknown_with_subkind kind =
+  match Flambda_kind.With_subkind.descr kind with
+  | Any_value -> any_value ()
+  | Naked_number Naked_immediate -> any_naked_immediate ()
+  | Naked_number Naked_float -> any_naked_float ()
+  | Naked_number Naked_int32 -> any_naked_int32 ()
+  | Naked_number Naked_int64 -> any_naked_int64 ()
+  | Naked_number Naked_nativeint -> any_naked_nativeint ()
+  | Boxed_float -> any_boxed_float ()
+  | Boxed_int32 -> any_boxed_int32 ()
+  | Boxed_int64 -> any_boxed_int64 ()
+  | Boxed_nativeint -> any_boxed_nativeint ()
+  | Tagged_immediate -> any_tagged_immediate ()
+
+let unknown_types_from_arity_with_subkinds arity =
+  List.map (fun kind -> unknown_with_subkind kind) arity
+
 let bottom_types_from_arity arity =
   List.map (fun kind -> bottom kind) arity
 

--- a/middle_end/flambda/unboxing/unbox_continuation_params.ml
+++ b/middle_end/flambda/unboxing/unbox_continuation_params.ml
@@ -89,7 +89,7 @@ module Make (U : Unboxing_spec) = struct
     (*
     Format.eprintf "UNBOX: %a\n%!" Index.print index;
     *)
-    let param_kind = KP.kind extra_param in
+    let param_kind = K.With_subkind.kind (KP.kind extra_param) in
     let field_var = Variable.create "field_at_use" in
     let field_name =
       Name_in_binding_pos.create (Name.var field_var) Name_mode.in_types
@@ -289,7 +289,8 @@ module Make (U : Unboxing_spec) = struct
             | Aborted -> Aborted
             | Continue (extra_args, field_types_by_id) ->
               let param_type =
-                T.alias_type_of (KP.kind extra_param) (KP.simple extra_param)
+                T.alias_type_of (K.With_subkind.kind (KP.kind extra_param))
+                  (KP.simple extra_param)
               in
               let all_field_types_by_id_rev =
                 field_types_by_id :: all_field_types_by_id_rev
@@ -338,7 +339,9 @@ module Make (U : Unboxing_spec) = struct
             in
             let var = Variable.create name in
             let param =
-              KP.create var (U.kind_of_unboxed_field_of_param index)
+              KP.create var
+                (K.With_subkind.create (U.kind_of_unboxed_field_of_param index)
+                  Anything)
             in
             Index.Map.add index param new_params)
           indexes
@@ -372,7 +375,7 @@ module Make (U : Unboxing_spec) = struct
             List.length all_field_types_by_id);
           let typing_env, extra_params_and_args =
             List.fold_left2
-              (fun (typing_env, extra_params_and_args) 
+              (fun (typing_env, extra_params_and_args)
                   field_type field_types_by_id ->
                 if not (U.unbox_recursively ~field_type) then
                   typing_env, extra_params_and_args
@@ -512,7 +515,7 @@ end = struct
     | Tag -> "tag"
     | Field { index; } ->
       Format.asprintf "field%a" Targetint.OCaml.print index
-end 
+end
 
 (* CR mshinwell: Presumably this can supercede [Block_of_values_spec]? *)
 module Variants_spec : Unboxing_spec


### PR DESCRIPTION
This is a rewrite of an old patch that propagates the "value subkind" information (specifically: tagged immediate, boxed float/int32/int64/nativeint) present in the type `Lambda.value_kind` onto parameters of continuations, parameters of functions and return values of functions.

This is a good thing to do anyway and will probably be needed for reasonable treatment of loops (so recursive continuations can get some semblance of accurate parameter types on the first round).  However this wasn't what triggered this work.  I think this is also needed to behave on a par with Closure when in classic mode, specifically when join computations are disabled.  When join computations are disabled (`-no-flambda-join-points`, which will be implied by `-Oclassic`), for a join involving strictly more than one arm, no information is propagated into the continuation handler at the join point -- except that already present at the fork point and the types of any lifted constants.  In particular this means that the types of the parameters of the continuation at the join point will be unknown.  If those parameters are e.g. boxed floats, arising from a `let`-binding in the source code, it will mean we are unable to unbox them (since their types are completely unknown).  I suspect this causes regressions against Closure and Cmmgen.  This patch rectifies this, and I hope will solve the problem.

@lukemaurer It would be nice to add support for specifying the subkinds in the Fexpr syntax when you have time.