### PR TITLE
Pass exported code to `Un_cps_closure.compute_offsets`

### DIFF
--- a/middle_end/flambda/to_cmm/un_cps.ml
+++ b/middle_end/flambda/to_cmm/un_cps.ml
@@ -1421,7 +1421,7 @@ let unit (middle_end_result : Flambda_middle_end.middle_end_result) =
   in
   let functions_info = middle_end_result.all_code in
   Profile.record_call "flambda_to_cmm" (fun () ->
-    let offsets = Un_cps_closure.compute_offsets offsets unit in
+    let offsets = Un_cps_closure.compute_offsets offsets functions_info unit in
     begin match middle_end_result.cmx with
     | None -> () (* Either opaque was passed, or there is no need to export
                     offsets *)

--- a/middle_end/flambda/to_cmm/un_cps_closure.mli
+++ b/middle_end/flambda/to_cmm/un_cps_closure.mli
@@ -14,7 +14,8 @@
 
 (* Compute offsets for elements in sets of closures *)
 
-val compute_offsets : Exported_offsets.t -> Flambda_unit.t -> Exported_offsets.t
+val compute_offsets :
+  Exported_offsets.t -> Exported_code.t -> Flambda_unit.t -> Exported_offsets.t
 (** Compute offsets for a whole compilation unit.
     Takes the offsets from all cmx files read as input. *)
 


### PR DESCRIPTION
We were generating a map of code ids to code by traversing the unit, but
the only caller of `compute_offsets` already has an `Exported_code.t` at
hand, so we can just use that and avoid a double traversal.