### PR TITLE
New join algorithm for classic mode

### DIFF
--- a/middle_end/flambda/inlining/inlining_transforms.ml
+++ b/middle_end/flambda/inlining/inlining_transforms.ml
@@ -26,6 +26,7 @@ module VB = Var_in_binding_pos
 let inline dacc ~callee ~args function_decl
       ~apply_return_continuation ~apply_exn_continuation
       ~apply_inlining_depth ~unroll_to dbg =
+  (* CR mshinwell: Add meet constraint to the return continuation *)
   let denv = DA.denv dacc in
   let code = DE.find_code denv (I.code_id function_decl) in
   let params_and_body =

--- a/middle_end/flambda/simplify/typing_helpers/continuation_uses.ml
+++ b/middle_end/flambda/simplify/typing_helpers/continuation_uses.ml
@@ -77,22 +77,32 @@ let arity t = t.arity
 
 let get_uses t = t.uses
 
-(* CR mshinwell: Four possible stages of join (turn into proper comment):
-
-   1. Simple erasure policy
-     - If the type has no free variables, propagate it
-     - For each x in the free variables of the type, resolve x using [Aliases].
-       If it resolves to a name in scope in the destination env then keep it.
-       Otherwise unknown.
-     - Don't produce any existentials in the resulting extension if there is
-       more than one path
-   2. For the "=x" case, if no name can be found in scope in the destination
-      env equal to x, then expand the head of x recursively, to obtain a
-      better type.  Propagate this.
-   3. Support existentials from multiple paths.  This probably requires
-      something like [Join_env] from the prototype.
-   4. Path sensitivity.
-*)
+let simple_join typing_env uses ~params =
+  (* This join is intended to be sufficient to match Closure + Cmmgen
+     on unboxing, but not really anything more. *)
+  let bottom_types =
+    ListLabels.map params ~f:(fun param ->
+      Kinded_parameter.kind param
+      |> Flambda_kind.With_subkind.kind
+      |> T.bottom)
+  in
+  let joined_types =
+    ListLabels.fold_left uses ~init:bottom_types ~f:(fun joined_types use ->
+      ListLabels.map2 joined_types (U.arg_types use)
+        ~f:(fun joined_type arg_type ->
+          let arg_type =
+            T.eviscerate arg_type (DE.typing_env (U.env_at_use use))
+          in
+          (* The only names left in [arg_type] will be symbols; they will
+             always be defined in [typing_env].  So we can use the same
+             environment throughout the join. *)
+          T.join typing_env ~left_env:typing_env ~left_ty:joined_type
+            ~right_env:typing_env ~right_ty:arg_type))
+  in
+  ListLabels.fold_left2 params joined_types ~init:typing_env
+    ~f:(fun handler_env param joined_type ->
+      let name = Kinded_parameter.name param in
+      TE.add_equation handler_env name joined_type)
 
 let compute_handler_env t
       ~env_at_fork_plus_params_and_consts
@@ -110,6 +120,17 @@ Format.eprintf "%d uses for %a\n%!"
     let definition_scope_level =
       DE.get_continuation_scope_level env_at_fork_plus_params_and_consts
     in
+    let need_to_meet_param_types =
+      (* CR mshinwell: Unsure if this is worth doing. *)
+      (* If there is information available from the subkinds of the
+         parameters, we will need to meet the existing parameter types
+         (e.g. "unknown boxed float") with the argument types at each
+         use. *)
+      List.exists (fun param ->
+          Kinded_parameter.kind param
+          |> Flambda_kind.With_subkind.has_useful_subkind_info)
+        params
+    in
     let use_envs_with_ids =
       List.map (fun use ->
       (*
@@ -120,8 +141,12 @@ Format.eprintf "%d uses for %a\n%!"
         *)
           let use_env =
             DE.map_typing_env (U.env_at_use use) ~f:(fun typing_env ->
-              TE.add_equations_on_params typing_env
-                ~params ~param_types:(U.arg_types use))
+              if need_to_meet_param_types then
+                TE.meet_equations_on_params typing_env
+                  ~params ~param_types:(U.arg_types use)
+              else
+                TE.add_equations_on_params typing_env
+                  ~params ~param_types:(U.arg_types use))
           in
           use_env, U.id use, U.use_kind use)
         uses
@@ -166,25 +191,19 @@ Format.eprintf "Unknown at or later than %a\n%!"
             use_envs_with_ids
         in
         let typing_env = DE.typing_env denv in
-        let compute_join =
-          if Flambda_features.join_points () then true
+        let handler_env, extra_params_and_args =
+          if not (Flambda_features.join_points ()) then
+            let handler_env = simple_join typing_env uses ~params in
+            handler_env, Continuation_extra_params_and_args.empty
           else
-            match use_envs_with_ids with
-            | [_] -> true
-            | [] | _::_ -> false
-        in
-        let env_extension, extra_params_and_args =
-          if compute_join then
-            TE.cut_and_n_way_join typing_env
-              use_envs_with_ids
-              ~params
-              ~unknown_if_defined_at_or_later_than:
-                (Scope.next definition_scope_level)
-              ~extra_lifted_consts_in_use_envs
-          else
-            T.Typing_env_extension.empty (),
-              Continuation_extra_params_and_args.empty
-        in
+            let env_extension, extra_params_and_args =
+              TE.cut_and_n_way_join typing_env
+                use_envs_with_ids
+                ~params
+                ~unknown_if_defined_at_or_later_than:
+                  (Scope.next definition_scope_level)
+                ~extra_lifted_consts_in_use_envs
+            in
 (*
 Format.eprintf "handler env extension for %a is:@ %a\n%!"
   Continuation.print t.continuation
@@ -192,19 +211,21 @@ Format.eprintf "handler env extension for %a is:@ %a\n%!"
 Format.eprintf "The extra params and args are:@ %a\n%!"
   Continuation_extra_params_and_args.print extra_params_and_args;
 *)
-        let handler_env =
-          typing_env
-          |> TE.add_definitions_of_params
-            ~params:extra_params_and_args.extra_params
+            let handler_env =
+              typing_env
+              |> TE.add_definitions_of_params
+                ~params:extra_params_and_args.extra_params
+            in
+            let handler_env =
+              TE.add_env_extension handler_env env_extension
+            in
+            handler_env, extra_params_and_args
         in
         let handler_env =
           TE.with_code_age_relation handler_env
             code_age_relation_after_body
         in
-        let handler_env =
-          DE.with_typing_env denv
-            (TE.add_env_extension handler_env env_extension)
-        in
+        let handler_env = DE.with_typing_env denv handler_env in
         let is_single_use =
           match uses with
           | [_] -> true

--- a/middle_end/flambda/types/env/typing_env.rec.mli
+++ b/middle_end/flambda/types/env/typing_env.rec.mli
@@ -58,6 +58,12 @@ val add_equations_on_params
   -> param_types:Type_grammar.t list
   -> t
 
+val meet_equations_on_params
+   : t
+  -> params:Kinded_parameter.t list
+  -> param_types:Type_grammar.t list
+  -> t
+
 (** If the kind of the name is known, it should be specified, otherwise it
     can be omitted.  Such omission will cause an error if the name satisfies
     [variable_is_from_missing_cmx_file]. *)

--- a/middle_end/flambda/types/flambda_type.mli
+++ b/middle_end/flambda/types/flambda_type.mli
@@ -102,6 +102,12 @@ module Typing_env : sig
     -> param_types:flambda_type list
     -> t
 
+  val meet_equations_on_params
+     : t
+    -> params:Kinded_parameter.t list
+    -> param_types:flambda_type list
+    -> t
+
   val add_cse
      : t
     -> Flambda_primitive.Eligible_for_cse.t
@@ -253,6 +259,12 @@ val make_suitable_for_environment
   -> Typing_env_extension.t
 
 val apply_rec_info : flambda_type -> Rec_info.t -> flambda_type Or_bottom.t
+
+(* Remove any information from the inside of the type, leaving only its
+   outer structure, and in some cases leaving only "Unknown".  Alias types
+   are only preserved if they indicate equalities to constants or symbols.
+   The resulting type will be suitable for a fast join operation. *)
+val eviscerate : t -> Typing_env.t -> t
 
 (** Construct a bottom type of the given kind. *)
 val bottom : Flambda_kind.t -> t

--- a/middle_end/flambda/types/kinds/flambda_kind.ml
+++ b/middle_end/flambda/types/kinds/flambda_kind.ml
@@ -506,4 +506,13 @@ module With_subkind = struct
     (* All other combinations are incompatible. *)
     | (Any_value | Naked_number _ | Boxed_float | Boxed_int32 | Boxed_int64
       | Boxed_nativeint | Tagged_immediate), _ -> false
+
+  let has_useful_subkind_info t =
+    match t.subkind with
+    | Anything -> false
+    | Boxed_float
+    | Boxed_int32
+    | Boxed_int64
+    | Boxed_nativeint
+    | Tagged_immediate -> true
 end

--- a/middle_end/flambda/types/kinds/flambda_kind.mli
+++ b/middle_end/flambda/types/kinds/flambda_kind.mli
@@ -173,6 +173,8 @@ module With_subkind : sig
   val kind : t -> kind
   val subkind : t -> Subkind.t
 
+  val has_useful_subkind_info : t -> bool
+
   val any_value : t
   val naked_immediate : t
   val naked_float : t

--- a/middle_end/flambda/types/type_descr_intf.ml
+++ b/middle_end/flambda/types/type_descr_intf.ml
@@ -64,6 +64,13 @@ module type S = sig
 
   val apply_rec_info : t -> Rec_info.t -> t Or_bottom.t
 
+  val eviscerate
+     : force_to_kind:(flambda_type -> t)  (* CR mshinwell: "of_type"? *)
+    -> t
+    -> typing_env
+    -> Flambda_kind.t
+    -> t
+
   val expand_head
      : force_to_kind:(flambda_type -> t)  (* CR mshinwell: "of_type"? *)
     -> t

--- a/middle_end/flambda/types/type_grammar.rec.ml
+++ b/middle_end/flambda/types/type_grammar.rec.ml
@@ -200,6 +200,44 @@ let apply_rec_info t rec_info : _ Or_bottom.t =
     | Bottom -> Bottom
     end
 
+let eviscerate t env =
+  match t with
+  | Value ty ->
+    let ty =
+      T_V.eviscerate ~force_to_kind:force_to_kind_value ty env K.value
+    in
+    Value ty
+  | Naked_immediate ty ->
+    let ty =
+      T_NI.eviscerate ~force_to_kind:force_to_kind_naked_immediate ty env
+        K.naked_immediate
+    in
+    Naked_immediate ty
+  | Naked_float ty ->
+    let ty =
+      T_Nf.eviscerate ~force_to_kind:force_to_kind_naked_float ty env
+        K.naked_float
+    in
+    Naked_float ty
+  | Naked_int32 ty ->
+    let ty =
+      T_N32.eviscerate ~force_to_kind:force_to_kind_naked_int32 ty env
+        K.naked_int32
+    in
+    Naked_int32 ty
+  | Naked_int64 ty ->
+    let ty =
+      T_N64.eviscerate ~force_to_kind:force_to_kind_naked_int64 ty env
+        K.naked_int64
+    in
+    Naked_int64 ty
+  | Naked_nativeint ty ->
+    let ty =
+      T_NN.eviscerate ~force_to_kind:force_to_kind_naked_nativeint ty env
+        K.naked_nativeint
+    in
+    Naked_nativeint ty
+
 let kind t =
   match t with
   | Value _ -> K.value

--- a/middle_end/flambda/types/type_grammar.rec.mli
+++ b/middle_end/flambda/types/type_grammar.rec.mli
@@ -41,6 +41,8 @@ val alias_type_of : Flambda_kind.t -> Simple.t -> t
 
 val apply_rec_info : t -> Rec_info.t -> t Or_bottom.t
 
+val eviscerate : t -> Typing_env.t -> t
+
 val get_alias_exn : t -> Simple.t
 
 val is_obviously_bottom : t -> bool

--- a/middle_end/flambda/types/type_head_intf.ml
+++ b/middle_end/flambda/types/type_head_intf.ml
@@ -45,4 +45,6 @@ module type S = sig
   end
 
   val apply_rec_info : t -> Rec_info.t -> t Or_bottom.t
+
+  val eviscerate : t -> t Or_unknown.t
 end

--- a/middle_end/flambda/types/type_of_kind/type_of_kind_naked_float0.rec.ml
+++ b/middle_end/flambda/types/type_of_kind/type_of_kind_naked_float0.rec.ml
@@ -38,6 +38,8 @@ let apply_rec_info t rec_info : _ Or_bottom.t =
   if Rec_info.is_initial rec_info then Ok t
   else Bottom
 
+let eviscerate _ : _ Or_unknown.t = Unknown
+
 module Make_meet_or_join
   (E : Lattice_ops_intf.S
     with type meet_env := Meet_env.t

--- a/middle_end/flambda/types/type_of_kind/type_of_kind_naked_immediate0.rec.ml
+++ b/middle_end/flambda/types/type_of_kind/type_of_kind_naked_immediate0.rec.ml
@@ -71,6 +71,8 @@ let apply_rec_info t rec_info : _ Or_bottom.t =
   if Rec_info.is_initial rec_info then Ok t
   else Bottom
 
+let eviscerate _ : _ Or_unknown.t = Unknown
+
 module Make_meet_or_join
   (E : Lattice_ops_intf.S
     with type meet_env := Meet_env.t

--- a/middle_end/flambda/types/type_of_kind/type_of_kind_naked_int32_0.rec.ml
+++ b/middle_end/flambda/types/type_of_kind/type_of_kind_naked_int32_0.rec.ml
@@ -38,6 +38,8 @@ let apply_rec_info t rec_info : _ Or_bottom.t =
   if Rec_info.is_initial rec_info then Ok t
   else Bottom
 
+let eviscerate _ : _ Or_unknown.t = Unknown
+
 module Make_meet_or_join
   (E : Lattice_ops_intf.S
     with type meet_env := Meet_env.t

--- a/middle_end/flambda/types/type_of_kind/type_of_kind_naked_int64_0.rec.ml
+++ b/middle_end/flambda/types/type_of_kind/type_of_kind_naked_int64_0.rec.ml
@@ -38,6 +38,8 @@ let apply_rec_info t rec_info : _ Or_bottom.t =
   if Rec_info.is_initial rec_info then Ok t
   else Bottom
 
+let eviscerate _ : _ Or_unknown.t = Unknown
+
 module Make_meet_or_join
   (E : Lattice_ops_intf.S
     with type meet_env := Meet_env.t

--- a/middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.ml
+++ b/middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.ml
@@ -37,6 +37,8 @@ let apply_rec_info t rec_info : _ Or_bottom.t =
   if Rec_info.is_initial rec_info then Ok t
   else Bottom
 
+let eviscerate _ : _ Or_unknown.t = Unknown
+
 module Make_meet_or_join
   (E : Lattice_ops_intf.S
     with type meet_env := Meet_env.t

--- a/middle_end/flambda/types/type_of_kind/type_of_kind_value0.rec.ml
+++ b/middle_end/flambda/types/type_of_kind/type_of_kind_value0.rec.ml
@@ -195,6 +195,17 @@ let apply_rec_info t rec_info : _ Or_bottom.t =
     if Rec_info.is_initial rec_info then Ok t
     else Bottom
 
+let eviscerate t : _ Or_unknown.t =
+  match t with
+  | Boxed_float _ -> Known (Boxed_float (T.any_naked_float ()))
+  | Boxed_int32 _ -> Known (Boxed_int32 (T.any_naked_int32 ()))
+  | Boxed_int64 _ -> Known (Boxed_int64 (T.any_naked_int64 ()))
+  | Boxed_nativeint _ -> Known (Boxed_nativeint (T.any_naked_nativeint ()))
+  | Closures _
+  | Variant _
+  | String _
+  | Array _ -> Unknown
+
 let meet_unknown meet_contents ~contents_is_bottom env
     (or_unknown1 : _ Or_unknown.t) (or_unknown2 : _ Or_unknown.t)
     : ((_ Or_unknown.t) * TEE.t) Or_bottom.t =


### PR DESCRIPTION
#231 and #240 aren't sufficient to fix join in classic mode (in fact I think #231 was a mistake).  We need to make sure sufficient information is propagated for unboxing to match Closure + Cmmgen.  This patch implements a much simpler join algorithm, having removed the majority of information from the insides of types ("evisceration"), which I think does solve the problem.  The tests pass on the JS tree using this in classic mode.

This also ensures that value subkind information is used to constrain the types of continuations' parameters at join points.  I have left a CR that we should probably also do this when inlining, to ensure that subkind information from the returned arity of the function being inlined is propagated to the parameters of its return continuation.  I have a patch to do this but it needs some tidying up.  It also shouldn't actually affect anything in practice, so it can wait.