### PR TITLE
Improve performance of lifted constants

### DIFF
--- a/middle_end/flambda/compilenv_deps/patricia_tree.ml
+++ b/middle_end/flambda/compilenv_deps/patricia_tree.ml
@@ -716,6 +716,29 @@ struct
         else
           Empty
 
+  let rec inter_domain_is_non_empty t0 t1 =
+    match t0, t1 with
+    | Empty, _
+    | _, Empty -> false
+    | Leaf (i, _), _ -> mem i t1
+    | _, Leaf (i, _) -> mem i t0
+    | Branch(prefix0, bit0, t00, t01), Branch(prefix1, bit1, t10, t11) ->
+        if equal_prefix prefix0 bit0 prefix1 bit1 then
+          (inter_domain_is_non_empty t00 t10)
+            || (inter_domain_is_non_empty t01 t11)
+        else if includes_prefix prefix0 bit0 prefix1 bit1 then
+          if zero_bit prefix1 bit0 then
+            inter_domain_is_non_empty t00 t1
+          else
+            inter_domain_is_non_empty t01 t1
+        else if includes_prefix prefix1 bit1 prefix0 bit0 then
+          if zero_bit prefix0 bit1 then
+            inter_domain_is_non_empty t0 t10
+          else
+            inter_domain_is_non_empty t0 t11
+        else
+          false
+
   let rec diff t0 t1 =
     match t0, t1 with
     | Empty, _ -> Empty

--- a/middle_end/flambda/lifting/sort_lifted_constants.mli
+++ b/middle_end/flambda/lifting/sort_lifted_constants.mli
@@ -23,17 +23,6 @@
 
 open! Simplify_import
 
-type result = private {
-  bindings_outermost_last : LC.t list;
-}
-
-val empty_result : result
-
-val sort
-   : fold_over_lifted_constants:(
-          init:(CIS.Set.t CIS.Map.t * LC.t CIS.Map.t)
-       -> f:(CIS.Set.t CIS.Map.t * LC.t CIS.Map.t
-         -> LC.t
-         -> CIS.Set.t CIS.Map.t * LC.t CIS.Map.t)
-       -> CIS.Set.t CIS.Map.t * LC.t CIS.Map.t)
-  -> result
+(* CR mshinwell: Split [Simplify_envs] into separate files then move this
+   sorting algorithm into [LCS] *)
+val sort : LCS.t -> LCS.t

--- a/middle_end/flambda/naming/name_occurrences.ml
+++ b/middle_end/flambda/naming/name_occurrences.ml
@@ -380,10 +380,15 @@ end = struct
     | Potentially_many map1, Potentially_many map2 ->
       N.Set.subset (N.Map.keys map1) (N.Map.keys map2)
 
-  (* CR mshinwell: Provide better implementation.  Only used in closure
-     conversion at the moment. *)
   let inter_domain_is_non_empty t1 t2 =
-    not (N.Set.is_empty (N.Set.inter (keys t1) (keys t2)))
+    match t1, t2 with
+    | Empty, (Empty | One _ | Potentially_many _)
+    | (One _ | Potentially_many _), Empty -> false
+    | One (name1, _), One (name2, _) -> N.equal name1 name2
+    | One (name, _), Potentially_many map
+    | Potentially_many map, One (name, _) -> N.Map.mem name map
+    | Potentially_many map1, Potentially_many map2 ->
+      N.Map.inter_domain_is_non_empty map1 map2
 
   let mem t name =
     match t with

--- a/middle_end/flambda/simplify/env/simplify_envs_intf.ml
+++ b/middle_end/flambda/simplify/env/simplify_envs_intf.ml
@@ -357,7 +357,11 @@ module type Lifted_constant = sig
 
   val concat : t list -> t
 
+  val is_fully_static : t -> bool
+
   val all_defined_symbols : t -> Symbol.Set.t
+
+  val free_names_of_defining_exprs : t -> Name_occurrences.t
 end
 
 module type Lifted_constant_state = sig
@@ -372,11 +376,40 @@ module type Lifted_constant_state = sig
 
   val singleton : lifted_constant -> t
 
+  (* Use if the order of constants doesn't matter. *)
   val add : t -> lifted_constant -> t
 
+  val add_innermost : t -> lifted_constant -> t
+
+  val add_outermost : t -> lifted_constant -> t
+
+  val singleton_sorted_array_of_constants
+     : innermost_first:lifted_constant array
+     -> t
+
+  (* Use if the order of constants doesn't matter. *)
   val union : t -> t -> t
 
-  val fold : t -> init:'a -> f:('a -> lifted_constant -> 'a) -> 'a
+  val union_ordered : innermost:t -> outermost:t -> t
+
+  (* Use if the order of constants doesn't matter. *)
+  val fold
+     : t
+    -> init:'a
+    -> f:('a -> lifted_constant -> 'a)
+    -> 'a
+
+  val fold_outermost_first
+     : t
+    -> init:'a
+    -> f:('a -> lifted_constant -> 'a)
+    -> 'a
+
+  val fold_innermost_first
+     : t
+    -> init:'a
+    -> f:('a -> lifted_constant -> 'a)
+    -> 'a
 
   val all_defined_symbols : t -> Symbol.Set.t
 end

--- a/middle_end/flambda/simplify/env/upwards_acc.ml
+++ b/middle_end/flambda/simplify/env/upwards_acc.ml
@@ -33,14 +33,14 @@ type t = {
 }
 
 let print ppf
-      { uenv; code_age_relation; lifted_constants; used_closure_vars;
-        all_code = _; shareable_constants; } =
+      { uenv; code_age_relation; lifted_constants;
+        used_closure_vars; all_code = _; shareable_constants; } =
   Format.fprintf ppf "@[<hov 1>(\
-      @[(uenv@ %a)@]@ \
-      @[(code_age_relation@ %a)@]@ \
-      @[(lifted_constants@ %a)@]@ \
-      @[(used_closure_vars@ %a)@]@ \
-      @[(shareable_constants@ %a)@]\
+      @[<hov 1>(uenv@ %a)@]@ \
+      @[<hov 1>(code_age_relation@ %a)@]@ \
+      @[<hov 1>(lifted_constants@ %a)@]@ \
+      @[<hov 1>(used_closure_vars@ %a)@]@ \
+      @[<hov 1>(shareable_constants@ %a)@]\
       )@]"
     UE.print uenv
     Code_age_relation.print code_age_relation
@@ -59,17 +59,21 @@ let create uenv dacc =
 
 let uenv t = t.uenv
 let code_age_relation t = t.code_age_relation
-let lifted_constants_still_to_be_placed t = t.lifted_constants
+let lifted_constants t = t.lifted_constants
 
-let add_lifted_constant_still_to_be_placed t const =
+(* Don't add empty LCS to the list *)
+
+let add_outermost_lifted_constant t const =
   { t with
-    lifted_constants = LCS.add t.lifted_constants const;
+    lifted_constants = LCS.add_outermost t.lifted_constants const;
   }
 
-let with_lifted_constants_still_to_be_placed t lifted_constants =
-  { t with lifted_constants; }
-let no_lifted_constants_still_to_be_placed t =
-  LCS.is_empty t.lifted_constants
+let with_lifted_constants t lifted_constants =
+  { t with
+    lifted_constants;
+  }
+
+let no_lifted_constants t = LCS.is_empty t.lifted_constants
 
 let map_uenv t ~f =
   { t with

--- a/middle_end/flambda/simplify/env/upwards_acc.mli
+++ b/middle_end/flambda/simplify/env/upwards_acc.mli
@@ -30,23 +30,15 @@ val code_age_relation : t -> Code_age_relation.t
 
 (** Return the lifted constants that still need to be placed (i.e. have
     [Let]-expressions made for them) on the upwards traversal. *)
-val lifted_constants_still_to_be_placed
-   : t
-  -> Simplify_envs.Lifted_constant_state.t
+val lifted_constants : t -> Simplify_envs.Lifted_constant_state.t
 
-val add_lifted_constant_still_to_be_placed
-   : t
-  -> Simplify_envs.Lifted_constant.t
-  -> t
+val add_outermost_lifted_constant : t -> Simplify_envs.Lifted_constant.t -> t
 
 (** Replace the accumulator of lifted constants returned by
-    [lifted_constants_still_to_be_placed]. *)
-val with_lifted_constants_still_to_be_placed
-   : t
-  -> Simplify_envs.Lifted_constant_state.t
-  -> t
+    [lifted_constants]. *)
+val with_lifted_constants : t -> Simplify_envs.Lifted_constant_state.t -> t
 
-val no_lifted_constants_still_to_be_placed : t -> bool
+val no_lifted_constants : t -> bool
 
 (** Map the environment component of the given upwards accumulator. *)
 val map_uenv

--- a/middle_end/flambda/simplify/simplify_common.ml
+++ b/middle_end/flambda/simplify/simplify_common.ml
@@ -338,7 +338,7 @@ let remove_unused_closure_vars uacc (static_const : Static_const.t)
 let remove_unused_closure_vars_list uacc static_consts =
   List.map (remove_unused_closure_vars uacc) static_consts
 
-let create_let_symbol uacc (scoping_rule : Symbol_scoping_rule.t)
+let create_let_symbols uacc (scoping_rule : Symbol_scoping_rule.t)
       code_age_relation lifted_constant body =
   let bound_symbols = LC.bound_symbols lifted_constant in
   let defining_exprs = LC.defining_exprs lifted_constant in

--- a/middle_end/flambda/simplify/simplify_common.mli
+++ b/middle_end/flambda/simplify/simplify_common.mli
@@ -70,14 +70,14 @@ val bind_let_bound
   -> body:Flambda.Expr.t
   -> Flambda.Expr.t
 
-(** Create a [Let_symbol] expression around a given body.  Two optimisations
+(** Create [Let_symbol] expression(s) around a given body.  Two optimisations
     are performed:
-    1. Best efforts are made not to create the [Let_symbol] if it would be
-       redundant.
+    1. Best efforts are made not to create the [Let_symbol](s) if it/they
+       would be redundant.
     2. Closure variables are removed if they are not used according to the
        given [r].  Such [r] must have seen all uses in the whole
        compilation unit. *)
-val create_let_symbol
+val create_let_symbols
    : Upwards_acc.t
   -> Symbol_scoping_rule.t
   -> Code_age_relation.t

--- a/middle_end/flambda/simplify/simplify_set_of_closures.rec.ml
+++ b/middle_end/flambda/simplify/simplify_set_of_closures.rec.ml
@@ -469,7 +469,7 @@ let simplify_set_of_closures0 dacc context set_of_closures
              the downwards traversal turns into an upwards traversal is in
              such a context, not all of the constants may currently be
              present in [DA]. *)
-          UA.lifted_constants_still_to_be_placed uacc_after_upwards_traversal
+          UA.lifted_constants uacc_after_upwards_traversal
         in
         let result_function_decls_in_set =
           (closure_id, function_decl) :: result_function_decls_in_set

--- a/utils/identifiable.ml
+++ b/utils/identifiable.ml
@@ -75,6 +75,7 @@ module type Map = sig
         -> 'b
         -> 'b option
   val inter : (key -> 'a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
+  val inter_domain_is_non_empty : 'a t -> 'a t -> bool
 end
 
 module type Tbl = sig
@@ -222,6 +223,8 @@ module Make_map (T : Thing) (Set : Set with module T := T) = struct
         | None, None | None, Some _ | Some _, None -> None
         | Some datum1, Some datum2 -> Some (f key datum1 datum2))
       t1 t2
+
+  let inter_domain_is_non_empty _ _ = Misc.fatal_error "Not yet implemented"
 end [@@@inline always]
 
 module Make_set (T : Thing) = struct

--- a/utils/identifiable.mli
+++ b/utils/identifiable.mli
@@ -95,6 +95,7 @@ module type Map = sig
         -> 'b option
 
   val inter : (key -> 'a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
+  val inter_domain_is_non_empty : 'a t -> 'a t -> bool
 end
 
 module type Tbl = sig


### PR DESCRIPTION
I hope this will improve compilation time significantly, and in any case, it's a good cleanup.

Once we can delete dominator-scoped "let symbol" (@chambart is working on this), the lifted constant code will be able to be simplified further.  (At present it tries to push constant definitions back up to static "let symbols" so that they will be deleted if they are unused.)