### PR TITLE
Rationalise return values from Simplify_named

### DIFF
--- a/middle_end/flambda/simplify/env/downwards_acc.ml
+++ b/middle_end/flambda/simplify/env/downwards_acc.ml
@@ -125,6 +125,12 @@ let add_lifted_constant t const =
     lifted_constants = LCS.add t.lifted_constants const;
   }
 
+let add_lifted_constant_also_to_env t const =
+  { t with
+    lifted_constants = LCS.add t.lifted_constants const;
+    denv = DE.add_lifted_constant t.denv const;
+  }
+
 let add_lifted_constants_from_list t consts =
   ListLabels.fold_left consts ~init:t ~f:add_lifted_constant
 

--- a/middle_end/flambda/simplify/env/downwards_acc.mli
+++ b/middle_end/flambda/simplify/env/downwards_acc.mli
@@ -71,6 +71,11 @@ val add_lifted_constant
   -> Simplify_envs.Lifted_constant.t
   -> t
 
+val add_lifted_constant_also_to_env
+   : t
+  -> Simplify_envs.Lifted_constant.t
+  -> t
+
 val add_lifted_constants_from_list
    : t
   -> Simplify_envs.Lifted_constant.t list

--- a/middle_end/flambda/simplify/simplify_named.rec.mli
+++ b/middle_end/flambda/simplify/simplify_named.rec.mli
@@ -18,17 +18,10 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
-type simplify_named_result = private
-  | Bindings of {
-      bindings_outermost_first : (Bindable_let_bound.t * Reachable.t) list;
-      dacc : Downwards_acc.t;
-    }
-  | Reified of {
-      definition : Named.t;
-      symbol : Symbol.t;
-      static_const :  Static_const.t;
-    }
-  | Shared of Symbol.t
+type simplify_named_result = private {
+  bindings_outermost_first : (Bindable_let_bound.t * Reachable.t) list;
+  dacc : Downwards_acc.t;
+}
 
 val simplify_named
    : Downwards_acc.t

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -428,7 +428,7 @@ module Flambda = struct
   let join_points = ref true
   let unbox_along_intra_function_control_flow = ref true
   let lift_inconstants = ref false
-  let lift_toplevel_inconstants = ref true
+  let lift_toplevel_inconstants = ref false
   let backend_cse_at_toplevel = ref false
   let cse_depth = ref 2
 

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -428,7 +428,7 @@ module Flambda = struct
   let join_points = ref true
   let unbox_along_intra_function_control_flow = ref true
   let lift_inconstants = ref false
-  let lift_toplevel_inconstants = ref false
+  let lift_toplevel_inconstants = ref true
   let backend_cse_at_toplevel = ref false
   let cse_depth = ref 2
 


### PR DESCRIPTION
At present there are three possible return values from `Simplify_named.simplify_named` (`Bindings`, `Reified` and `Shared`).  I think the latter two can both be expressed in terms of `Bindings` (which this patch now removes, making the return type just be a single record).  This simplifies the code and will make it easier for the forthcoming symbol projections patch.

This PR changes `lift_toplevel_inconstants` to be on by default, for checking; I will revert that before merging.