### PR TITLE
Remove lift-toplevel-inconstants

### DIFF
--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -476,9 +476,6 @@ let read_one_param ppf position name v =
   | "flambda-unbox-along-intra-function-control-flow" ->
     set "flambda-unbox-along-intra-function-control-flow"
       [ Flambda.unbox_along_intra_function_control_flow ] v
-  | "flambda-lift-toplevel-inconstants" ->
-    set "flambda-lift-toplevel-inconstants"
-      [ Flambda.lift_toplevel_inconstants ] v
   | "flambda-backend-cse-at-toplevel" ->
     set "flambda-backend-cse-at-toplevel"
       [ Flambda.backend_cse_at_toplevel ] v

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -924,17 +924,6 @@ let mk_no_flambda_unbox_along_intra_function_control_flow f =
     " Pass values within a function in their normal representation"
 ;;
 
-let mk_flambda_lift_toplevel_inconstants f =
-  "-flambda-lift-toplevel-inconstants", Arg.Unit f,
-    " Attempt to statically-allocate toplevel computations"
-;;
-
-let mk_no_flambda_lift_toplevel_inconstants f =
-  "-no-flambda-lift-toplevel-inconstants", Arg.Unit f,
-    " Do not attempt to statically-allocate toplevel computations, except for \
-      extension constructors"
-;;
-
 let mk_flambda_cse_depth f =
   "-flambda-cse-depth", Arg.Int f,
     " Depth threshold for eager tracking of CSE equations (default 2)"
@@ -1227,8 +1216,6 @@ module type Optcommon_options = sig
   val _no_flambda_join_points : unit -> unit
   val _flambda_unbox_along_intra_function_control_flow : unit -> unit
   val _no_flambda_unbox_along_intra_function_control_flow : unit -> unit
-  val _flambda_lift_toplevel_inconstants : unit -> unit
-  val _no_flambda_lift_toplevel_inconstants : unit -> unit
   val _flambda_backend_cse_at_toplevel : unit -> unit
   val _no_flambda_backend_cse_at_toplevel : unit -> unit
   val _flambda_cse_depth : int -> unit
@@ -1579,10 +1566,6 @@ struct
       F._flambda_unbox_along_intra_function_control_flow;
     mk_no_flambda_unbox_along_intra_function_control_flow
       F._no_flambda_unbox_along_intra_function_control_flow;
-    mk_flambda_lift_toplevel_inconstants
-      F._flambda_lift_toplevel_inconstants;
-    mk_no_flambda_lift_toplevel_inconstants
-      F._no_flambda_lift_toplevel_inconstants;
     mk_flambda_backend_cse_at_toplevel F._flambda_backend_cse_at_toplevel;
     mk_no_flambda_backend_cse_at_toplevel
       F._no_flambda_backend_cse_at_toplevel;
@@ -1742,10 +1725,6 @@ module Make_opttop_options (F : Opttop_options) = struct
       F._flambda_unbox_along_intra_function_control_flow;
     mk_no_flambda_unbox_along_intra_function_control_flow
       F._no_flambda_unbox_along_intra_function_control_flow;
-    mk_flambda_lift_toplevel_inconstants
-      F._flambda_lift_toplevel_inconstants;
-    mk_no_flambda_lift_toplevel_inconstants
-      F._no_flambda_lift_toplevel_inconstants;
     mk_flambda_backend_cse_at_toplevel F._flambda_backend_cse_at_toplevel;
     mk_no_flambda_backend_cse_at_toplevel
       F._no_flambda_backend_cse_at_toplevel;
@@ -2053,10 +2032,6 @@ module Default = struct
       set Flambda.unbox_along_intra_function_control_flow
     let _no_flambda_unbox_along_intra_function_control_flow =
       clear Flambda.unbox_along_intra_function_control_flow
-    let _flambda_lift_toplevel_inconstants =
-      set Flambda.lift_toplevel_inconstants
-    let _no_flambda_lift_toplevel_inconstants =
-      clear Flambda.lift_toplevel_inconstants
     let _flambda_backend_cse_at_toplevel =
       set Flambda.backend_cse_at_toplevel
     let _no_flambda_backend_cse_at_toplevel =

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -228,8 +228,6 @@ module type Optcommon_options = sig
   val _no_flambda_join_points : unit -> unit
   val _flambda_unbox_along_intra_function_control_flow : unit -> unit
   val _no_flambda_unbox_along_intra_function_control_flow : unit -> unit
-  val _flambda_lift_toplevel_inconstants : unit -> unit
-  val _no_flambda_lift_toplevel_inconstants : unit -> unit
   val _flambda_backend_cse_at_toplevel : unit -> unit
   val _no_flambda_backend_cse_at_toplevel : unit -> unit
   val _flambda_cse_depth : int -> unit

--- a/middle_end/flambda/compilenv_deps/flambda_features.ml
+++ b/middle_end/flambda/compilenv_deps/flambda_features.ml
@@ -17,7 +17,6 @@
 let join_points () = !Clflags.Flambda.join_points
 let unbox_along_intra_function_control_flow () =
   !Clflags.Flambda.unbox_along_intra_function_control_flow
-let lift_toplevel_inconstants () = !Clflags.Flambda.lift_toplevel_inconstants
 let backend_cse_at_toplevel () = !Clflags.Flambda.backend_cse_at_toplevel
 let cse_depth () = !Clflags.Flambda.cse_depth
 

--- a/middle_end/flambda/compilenv_deps/flambda_features.mli
+++ b/middle_end/flambda/compilenv_deps/flambda_features.mli
@@ -16,7 +16,6 @@
 
 val join_points : unit -> bool
 val unbox_along_intra_function_control_flow : unit -> bool
-val lift_toplevel_inconstants : unit -> bool
 val backend_cse_at_toplevel : unit -> bool
 val cse_depth : unit -> int
 

--- a/middle_end/flambda/lifting/lift_inconstants.ml
+++ b/middle_end/flambda/lifting/lift_inconstants.ml
@@ -18,28 +18,6 @@
 
 open! Simplify_import
 
-let matches_extension_constructor static_const =
-  match (static_const : Static_const.t) with
-  | Block (tag, mut, _fields) ->
-    begin match mut with
-    | Immutable_unique ->
-      (* Only extension constructors, with an object tag, are supposed to be
-         Immutable_unique *)
-      assert (Tag.equal Tag.object_tag (Tag.Scannable.to_tag tag));
-      true
-    | Mutable | Immutable -> false
-    end
-  | (Code _ | Set_of_closures _ | Boxed_float _ | Boxed_int32 _ | Boxed_int64 _
-    | Boxed_nativeint _ | Immutable_float_block _ | Immutable_float_array _
-    | Mutable_string _ | Immutable_string _) -> false
-
-let allowed_for_toplevel_lifting static_const =
-  (* Always try to lift extension constructors, as they're not likely
-     to create many extra equations and can often prevent sets of closures
-     from being closed if not lifted. *)
-  if Flambda_features.lift_toplevel_inconstants () then true
-  else matches_extension_constructor static_const
-
 type reify_primitive_at_toplevel_result =
   | Lift of {
     symbol : Symbol.t;
@@ -63,10 +41,7 @@ let reify_primitive_at_toplevel dacc bound_var ty =
     (* There's no point in lifting constant values, as these should
        already have been lifted. *)
     let static_const = Reification.create_static_const to_lift in
-    if Static_const.is_fully_static static_const
-      || not (allowed_for_toplevel_lifting static_const)
-    then
-      Cannot_reify
+    if Static_const.is_fully_static static_const then Cannot_reify
     else begin
       match DA.find_shareable_constant dacc static_const with
       | Some symbol -> Shared symbol

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -427,7 +427,6 @@ let unboxed_types = ref false
 module Flambda = struct
   let join_points = ref true
   let unbox_along_intra_function_control_flow = ref true
-  let lift_toplevel_inconstants = ref true
   let backend_cse_at_toplevel = ref false
   let cse_depth = ref 2
 
@@ -448,7 +447,6 @@ module Flambda = struct
     cse_depth := 2;
     join_points := false;
     unbox_along_intra_function_control_flow := true;
-    lift_toplevel_inconstants := true;
     Expert.fallback_inlining_heuristic := true;
     backend_cse_at_toplevel := false;
     ()
@@ -457,7 +455,6 @@ module Flambda = struct
     cse_depth := 2;
     join_points := true;
     unbox_along_intra_function_control_flow := true;
-    lift_toplevel_inconstants := true;
     Expert.fallback_inlining_heuristic := false;
     backend_cse_at_toplevel := false;
     ()
@@ -466,7 +463,6 @@ module Flambda = struct
     cse_depth := 2;
     join_points := true;
     unbox_along_intra_function_control_flow := true;
-    lift_toplevel_inconstants := true;
     Expert.fallback_inlining_heuristic := false;
     backend_cse_at_toplevel := false;
     ()
@@ -475,7 +471,6 @@ module Flambda = struct
     cse_depth := 2;
     join_points := true;
     unbox_along_intra_function_control_flow := true;
-    lift_toplevel_inconstants := true;
     Expert.fallback_inlining_heuristic := false;
     backend_cse_at_toplevel := false;
     ()

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -247,7 +247,6 @@ val insn_sched_default : bool
 module Flambda : sig
   val join_points : bool ref
   val unbox_along_intra_function_control_flow : bool ref
-  val lift_toplevel_inconstants : bool ref
   val backend_cse_at_toplevel : bool ref
   val cse_depth : int ref
 


### PR DESCRIPTION
It seems unlikely we would ever want to disable this, and it makes things easier to think about if the option of disabling it isn't available.