### PR TITLE
Symbol projections

### DIFF
--- a/.depend
+++ b/.depend
@@ -5199,35 +5199,29 @@ middle_end/flambda/inlining/inlining_transforms.cmi : \
 middle_end/flambda/lifting/lift_inconstants.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
-    lambda/tag.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/simplify/simplify_import.cmi \
     middle_end/flambda/lifting/reification.cmi \
     middle_end/flambda/compilenv_deps/linkage_name.cmi \
-    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/lifting/lift_inconstants.cmi
 middle_end/flambda/lifting/lift_inconstants.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
     middle_end/flambda/naming/var_in_binding_pos.cmx \
-    lambda/tag.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/simplify/simplify_import.cmx \
     middle_end/flambda/lifting/reification.cmx \
     middle_end/flambda/compilenv_deps/linkage_name.cmx \
-    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
     middle_end/flambda/lifting/lift_inconstants.cmi
 middle_end/flambda/lifting/lift_inconstants.cmi : \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/types/flambda_type.cmi \
     middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/simplify/env/downwards_acc.cmi \
-    middle_end/flambda/basic/continuation_extra_params_and_args.cmi
+    middle_end/flambda/simplify/env/downwards_acc.cmi
 middle_end/flambda/lifting/reification.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
@@ -5235,6 +5229,7 @@ middle_end/flambda/lifting/reification.cmo : \
     middle_end/flambda/simplify/simplify_import.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/simplify/basic/reachable.cmi \
+    middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/basic/mutability.cmi \
     utils/misc.cmi \
@@ -5249,6 +5244,7 @@ middle_end/flambda/lifting/reification.cmx : \
     middle_end/flambda/simplify/simplify_import.cmx \
     middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/simplify/basic/reachable.cmx \
+    middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/basic/mutability.cmx \
     utils/misc.cmx \
@@ -5809,6 +5805,7 @@ middle_end/flambda/simplify/simplify.cmo : \
     middle_end/flambda/compilenv_deps/target_imm.cmi \
     lambda/tag.cmi \
     middle_end/flambda/basic/symbol_scoping_rule.cmi \
+    middle_end/flambda/terms/symbol_projection.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     lambda/switch.cmi \
     middle_end/flambda/lifting/sort_lifted_constants.cmi \
@@ -5833,7 +5830,6 @@ middle_end/flambda/simplify/simplify.cmo : \
     utils/misc.cmi \
     parsing/location.cmi \
     middle_end/flambda/compilenv_deps/linkage_name.cmi \
-    middle_end/flambda/lifting/lift_inconstants.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/inlining/inlining_transforms.cmi \
     middle_end/flambda/inlining/inlining_decision.cmi \
@@ -5875,6 +5871,7 @@ middle_end/flambda/simplify/simplify.cmx : \
     middle_end/flambda/compilenv_deps/target_imm.cmx \
     lambda/tag.cmx \
     middle_end/flambda/basic/symbol_scoping_rule.cmx \
+    middle_end/flambda/terms/symbol_projection.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
     lambda/switch.cmx \
     middle_end/flambda/lifting/sort_lifted_constants.cmx \
@@ -5899,7 +5896,6 @@ middle_end/flambda/simplify/simplify.cmx : \
     utils/misc.cmx \
     parsing/location.cmx \
     middle_end/flambda/compilenv_deps/linkage_name.cmx \
-    middle_end/flambda/lifting/lift_inconstants.cmx \
     middle_end/flambda/basic/kinded_parameter.cmx \
     middle_end/flambda/inlining/inlining_transforms.cmx \
     middle_end/flambda/inlining/inlining_decision.cmx \
@@ -5987,9 +5983,11 @@ middle_end/flambda/simplify/simplify_binary_primitive.cmi : \
 middle_end/flambda/simplify/simplify_common.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/var_within_closure.cmi \
+    middle_end/flambda/naming/var_in_binding_pos.cmi \
     utils/targetint.cmi \
     lambda/tag.cmi \
     middle_end/flambda/basic/symbol_scoping_rule.cmi \
+    middle_end/flambda/terms/symbol_projection.cmi \
     middle_end/flambda/simplify/simplify_import.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/terms/set_of_closures.cmi \
@@ -6015,9 +6013,11 @@ middle_end/flambda/simplify/simplify_common.cmo : \
 middle_end/flambda/simplify/simplify_common.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
     middle_end/flambda/basic/var_within_closure.cmx \
+    middle_end/flambda/naming/var_in_binding_pos.cmx \
     utils/targetint.cmx \
     lambda/tag.cmx \
     middle_end/flambda/basic/symbol_scoping_rule.cmx \
+    middle_end/flambda/terms/symbol_projection.cmx \
     middle_end/flambda/simplify/simplify_import.cmx \
     middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/terms/set_of_closures.cmx \
@@ -6048,6 +6048,7 @@ middle_end/flambda/simplify/simplify_common.cmi : \
     middle_end/flambda/simplify/env/simplify_envs.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/simplify/basic/reachable.cmi \
+    middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/types/flambda_type.cmi \
     middle_end/flambda/terms/flambda_primitive.cmi \
@@ -6069,7 +6070,6 @@ middle_end/flambda/simplify/simplify_expr.rec.cmo : \
     middle_end/flambda/unboxing/unbox_continuation_params.cmi \
     middle_end/flambda/compilenv_deps/target_imm.cmi \
     middle_end/flambda/basic/symbol_scoping_rule.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
     lambda/switch.cmi \
     middle_end/flambda/lifting/sort_lifted_constants.cmi \
     middle_end/flambda/simplify/simplify_import.cmi \
@@ -6104,7 +6104,6 @@ middle_end/flambda/simplify/simplify_expr.rec.cmo : \
     middle_end/flambda/basic/closure_id.cmi \
     utils/clflags.cmi \
     middle_end/flambda/terms/call_kind.cmi \
-    middle_end/flambda/terms/bound_symbols.cmi \
     middle_end/flambda/naming/bindable_let_bound.cmi \
     middle_end/flambda/basic/apply_cont_rewrite_id.cmi \
     middle_end/flambda/simplify/basic/apply_cont_rewrite.cmi \
@@ -6117,7 +6116,6 @@ middle_end/flambda/simplify/simplify_expr.rec.cmx : \
     middle_end/flambda/unboxing/unbox_continuation_params.cmx \
     middle_end/flambda/compilenv_deps/target_imm.cmx \
     middle_end/flambda/basic/symbol_scoping_rule.cmx \
-    middle_end/flambda/compilenv_deps/symbol.cmx \
     lambda/switch.cmx \
     middle_end/flambda/lifting/sort_lifted_constants.cmx \
     middle_end/flambda/simplify/simplify_import.cmx \
@@ -6152,7 +6150,6 @@ middle_end/flambda/simplify/simplify_expr.rec.cmx : \
     middle_end/flambda/basic/closure_id.cmx \
     utils/clflags.cmx \
     middle_end/flambda/terms/call_kind.cmx \
-    middle_end/flambda/terms/bound_symbols.cmx \
     middle_end/flambda/naming/bindable_let_bound.cmx \
     middle_end/flambda/basic/apply_cont_rewrite_id.cmx \
     middle_end/flambda/simplify/basic/apply_cont_rewrite.cmx \
@@ -6212,17 +6209,20 @@ middle_end/flambda/simplify/simplify_import.cmi : \
     middle_end/flambda/basic/continuation_extra_params_and_args.cmi \
     middle_end/flambda/basic/code_id_or_symbol.cmi
 middle_end/flambda/simplify/simplify_named.rec.cmo : \
+    middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
+    middle_end/flambda/compilenv_deps/target_imm.cmi \
+    middle_end/flambda/terms/symbol_projection.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/simplify/simplify_primitive.cmi \
     middle_end/flambda/simplify/simplify_import.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/lifting/reification.cmi \
+    middle_end/flambda/basic/reg_width_const.cmi \
     middle_end/flambda/simplify/basic/reachable.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/basic/name.cmi \
     utils/misc.cmi \
-    middle_end/flambda/lifting/lift_inconstants.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/simplify/env/downwards_acc.cmi \
     middle_end/flambda/basic/closure_id.cmi \
@@ -6231,17 +6231,20 @@ middle_end/flambda/simplify/simplify_named.rec.cmo : \
     middle_end/flambda/naming/bindable_let_bound.cmi \
     middle_end/flambda/simplify/simplify_named.rec.cmi
 middle_end/flambda/simplify/simplify_named.rec.cmx : \
+    middle_end/flambda/compilenv_deps/variable.cmx \
     middle_end/flambda/naming/var_in_binding_pos.cmx \
+    middle_end/flambda/compilenv_deps/target_imm.cmx \
+    middle_end/flambda/terms/symbol_projection.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/simplify/simplify_primitive.cmx \
     middle_end/flambda/simplify/simplify_import.cmx \
     middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/lifting/reification.cmx \
+    middle_end/flambda/basic/reg_width_const.cmx \
     middle_end/flambda/simplify/basic/reachable.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/basic/name.cmx \
     utils/misc.cmx \
-    middle_end/flambda/lifting/lift_inconstants.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/simplify/env/downwards_acc.cmx \
     middle_end/flambda/basic/closure_id.cmx \
@@ -6250,7 +6253,6 @@ middle_end/flambda/simplify/simplify_named.rec.cmx : \
     middle_end/flambda/naming/bindable_let_bound.cmx \
     middle_end/flambda/simplify/simplify_named.rec.cmi
 middle_end/flambda/simplify/simplify_named.rec.cmi : \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/simplify/basic/reachable.cmi \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/simplify/env/downwards_acc.cmi \
@@ -6271,6 +6273,7 @@ middle_end/flambda/simplify/simplify_primitive.cmx : \
     middle_end/flambda/simplify/simplify_primitive.cmi
 middle_end/flambda/simplify/simplify_primitive.cmi : \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
+    middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/simplify/basic/reachable.cmi \
     middle_end/flambda/types/flambda_type.cmi \
     middle_end/flambda/terms/flambda_primitive.cmi \
@@ -6281,6 +6284,7 @@ middle_end/flambda/simplify/simplify_set_of_closures.rec.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
+    middle_end/flambda/terms/symbol_projection.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/simplify/simplify_import.cmi \
     middle_end/flambda/basic/simple.cmi \
@@ -6314,6 +6318,7 @@ middle_end/flambda/simplify/simplify_set_of_closures.rec.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
     middle_end/flambda/basic/var_within_closure.cmx \
     middle_end/flambda/naming/var_in_binding_pos.cmx \
+    middle_end/flambda/terms/symbol_projection.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/simplify/simplify_import.cmx \
     middle_end/flambda/basic/simple.cmx \
@@ -6668,17 +6673,27 @@ middle_end/flambda/simplify/env/downwards_acc.cmi : \
     middle_end/flambda/types/structures/code_age_relation.cmi
 middle_end/flambda/simplify/env/simplify_envs.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
+    middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
+    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/target_imm.cmi \
+    lambda/tag.cmi \
+    middle_end/flambda/terms/symbol_projection.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/simplify/env/simplify_envs_intf.cmo \
     middle_end/flambda/basic/simple.cmi \
+    middle_end/flambda/terms/set_of_closures.cmi \
     middle_end/flambda/basic/scope.cmi \
+    middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/naming/name_in_binding_pos.cmi \
     middle_end/flambda/basic/name.cmi \
+    middle_end/flambda/basic/mutability.cmi \
     utils/misc.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
+    middle_end/flambda/terms/function_declarations.cmi \
     middle_end/flambda/types/flambda_type.cmi \
+    middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/flambda_backend_intf.cmi \
     middle_end/flambda/types/kinds/flambda_arity.cmi \
     middle_end/flambda/terms/flambda.cmi \
@@ -6695,17 +6710,27 @@ middle_end/flambda/simplify/env/simplify_envs.cmo : \
     middle_end/flambda/simplify/env/simplify_envs.cmi
 middle_end/flambda/simplify/env/simplify_envs.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
+    middle_end/flambda/basic/var_within_closure.cmx \
     middle_end/flambda/naming/var_in_binding_pos.cmx \
+    utils/targetint.cmx \
+    middle_end/flambda/compilenv_deps/target_imm.cmx \
+    lambda/tag.cmx \
+    middle_end/flambda/terms/symbol_projection.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/simplify/env/simplify_envs_intf.cmx \
     middle_end/flambda/basic/simple.cmx \
+    middle_end/flambda/terms/set_of_closures.cmx \
     middle_end/flambda/basic/scope.cmx \
+    middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/naming/name_in_binding_pos.cmx \
     middle_end/flambda/basic/name.cmx \
+    middle_end/flambda/basic/mutability.cmx \
     utils/misc.cmx \
     middle_end/flambda/basic/kinded_parameter.cmx \
+    middle_end/flambda/terms/function_declarations.cmx \
     middle_end/flambda/types/flambda_type.cmx \
+    middle_end/flambda/types/kinds/flambda_kind.cmx \
     middle_end/flambda/flambda_backend_intf.cmi \
     middle_end/flambda/types/kinds/flambda_arity.cmx \
     middle_end/flambda/terms/flambda.cmx \
@@ -6725,9 +6750,11 @@ middle_end/flambda/simplify/env/simplify_envs.cmi : \
 middle_end/flambda/simplify/env/simplify_envs_intf.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
+    middle_end/flambda/terms/symbol_projection.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/basic/scope.cmi \
+    middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_in_binding_pos.cmi \
     middle_end/flambda/basic/name.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
@@ -6749,9 +6776,11 @@ middle_end/flambda/simplify/env/simplify_envs_intf.cmo : \
 middle_end/flambda/simplify/env/simplify_envs_intf.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
     middle_end/flambda/naming/var_in_binding_pos.cmx \
+    middle_end/flambda/terms/symbol_projection.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/basic/scope.cmx \
+    middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_in_binding_pos.cmx \
     middle_end/flambda/basic/name.cmx \
     middle_end/flambda/basic/kinded_parameter.cmx \
@@ -6818,7 +6847,9 @@ middle_end/flambda/simplify/typing_helpers/continuation_uses.cmo : \
     middle_end/flambda/basic/scope.cmi \
     middle_end/flambda/simplify/typing_helpers/one_continuation_use.cmi \
     utils/misc.cmi \
+    middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/types/flambda_type.cmi \
+    middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/types/kinds/flambda_arity.cmi \
@@ -6833,7 +6864,9 @@ middle_end/flambda/simplify/typing_helpers/continuation_uses.cmx : \
     middle_end/flambda/basic/scope.cmx \
     middle_end/flambda/simplify/typing_helpers/one_continuation_use.cmx \
     utils/misc.cmx \
+    middle_end/flambda/basic/kinded_parameter.cmx \
     middle_end/flambda/types/flambda_type.cmx \
+    middle_end/flambda/types/kinds/flambda_kind.cmx \
     middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/types/kinds/flambda_arity.cmx \
@@ -6910,12 +6943,9 @@ middle_end/flambda/terms/apply_cont_expr.cmo : \
     middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     utils/misc.cmi \
-    middle_end/flambda/basic/invariant_env.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     utils/identifiable.cmi \
-    middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
-    middle_end/flambda/types/kinds/flambda_arity.cmi \
     lambda/debuginfo.cmi \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/terms/apply_cont_expr.cmi
@@ -6925,12 +6955,9 @@ middle_end/flambda/terms/apply_cont_expr.cmx : \
     middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     utils/misc.cmx \
-    middle_end/flambda/basic/invariant_env.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     utils/identifiable.cmx \
-    middle_end/flambda/types/kinds/flambda_kind.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
-    middle_end/flambda/types/kinds/flambda_arity.cmx \
     lambda/debuginfo.cmx \
     middle_end/flambda/basic/continuation.cmx \
     middle_end/flambda/terms/apply_cont_expr.cmi
@@ -7461,7 +7488,6 @@ middle_end/flambda/terms/function_params_and_body.rec.cmo : \
     utils/printing_cache.cmi \
     middle_end/flambda/naming/name_abstraction.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
-    middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/types/kinds/flambda_arity.cmi \
     middle_end/flambda/basic/exn_continuation.cmi \
@@ -7474,7 +7500,6 @@ middle_end/flambda/terms/function_params_and_body.rec.cmx : \
     utils/printing_cache.cmx \
     middle_end/flambda/naming/name_abstraction.cmx \
     middle_end/flambda/basic/kinded_parameter.cmx \
-    middle_end/flambda/types/kinds/flambda_kind.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/types/kinds/flambda_arity.cmx \
     middle_end/flambda/basic/exn_continuation.cmx \
@@ -7756,6 +7781,31 @@ middle_end/flambda/terms/switch_expr.cmi : \
     middle_end/flambda/basic/expr_std.cmo \
     middle_end/flambda/cmx/contains_ids.cmo \
     middle_end/flambda/terms/apply_cont_expr.cmi
+middle_end/flambda/terms/symbol_projection.cmo : \
+    middle_end/flambda/basic/var_within_closure.cmi \
+    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/symbol.cmi \
+    middle_end/flambda/naming/name_occurrences.cmi \
+    middle_end/flambda/naming/name_mode.cmi \
+    middle_end/flambda/cmx/ids_for_export.cmi \
+    middle_end/flambda/basic/closure_id.cmi \
+    middle_end/flambda/terms/symbol_projection.cmi
+middle_end/flambda/terms/symbol_projection.cmx : \
+    middle_end/flambda/basic/var_within_closure.cmx \
+    utils/targetint.cmx \
+    middle_end/flambda/compilenv_deps/symbol.cmx \
+    middle_end/flambda/naming/name_occurrences.cmx \
+    middle_end/flambda/naming/name_mode.cmx \
+    middle_end/flambda/cmx/ids_for_export.cmx \
+    middle_end/flambda/basic/closure_id.cmx \
+    middle_end/flambda/terms/symbol_projection.cmi
+middle_end/flambda/terms/symbol_projection.cmi : \
+    middle_end/flambda/basic/var_within_closure.cmi \
+    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/symbol.cmi \
+    middle_end/flambda/naming/contains_names.cmo \
+    middle_end/flambda/cmx/contains_ids.cmo \
+    middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/to_cmm/un_cps.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/var_within_closure.cmi \
@@ -7794,6 +7844,7 @@ middle_end/flambda/to_cmm/un_cps.cmo : \
     middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/cmx/flambda_cmx_format.cmi \
+    middle_end/flambda/types/kinds/flambda_arity.cmi \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/cmx/exported_offsets.cmi \
     middle_end/flambda/cmx/exported_code.cmi \
@@ -7857,6 +7908,7 @@ middle_end/flambda/to_cmm/un_cps.cmx : \
     middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/cmx/flambda_cmx_format.cmx \
+    middle_end/flambda/types/kinds/flambda_arity.cmx \
     middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/cmx/exported_offsets.cmx \
     middle_end/flambda/cmx/exported_code.cmx \
@@ -7896,8 +7948,8 @@ middle_end/flambda/to_cmm/un_cps_closure.cmo : \
     middle_end/flambda/terms/flambda_unit.cmi \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/cmx/exported_offsets.cmi \
+    middle_end/flambda/cmx/exported_code.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/basic/closure_id.cmi \
     middle_end/flambda/to_cmm/un_cps_closure.cmi
 middle_end/flambda/to_cmm/un_cps_closure.cmx : \
@@ -7911,14 +7963,15 @@ middle_end/flambda/to_cmm/un_cps_closure.cmx : \
     middle_end/flambda/terms/flambda_unit.cmx \
     middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/cmx/exported_offsets.cmx \
+    middle_end/flambda/cmx/exported_code.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
-    middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/basic/closure_id.cmx \
     middle_end/flambda/to_cmm/un_cps_closure.cmi
 middle_end/flambda/to_cmm/un_cps_closure.cmi : \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/terms/flambda_unit.cmi \
     middle_end/flambda/cmx/exported_offsets.cmi \
+    middle_end/flambda/cmx/exported_code.cmi \
     middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/to_cmm/un_cps_env.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
@@ -7930,6 +7983,7 @@ middle_end/flambda/to_cmm/un_cps_env.cmo : \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/terms/function_declaration.cmi \
     middle_end/flambda/compilenv_deps/flambda_features.cmi \
+    middle_end/flambda/types/kinds/flambda_arity.cmi \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/cmx/exported_offsets.cmi \
     middle_end/flambda/cmx/exported_code.cmi \
@@ -7951,6 +8005,7 @@ middle_end/flambda/to_cmm/un_cps_env.cmx : \
     middle_end/flambda/basic/kinded_parameter.cmx \
     middle_end/flambda/terms/function_declaration.cmx \
     middle_end/flambda/compilenv_deps/flambda_features.cmx \
+    middle_end/flambda/types/kinds/flambda_arity.cmx \
     middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/cmx/exported_offsets.cmx \
     middle_end/flambda/cmx/exported_code.cmx \
@@ -8140,6 +8195,7 @@ middle_end/flambda/types/flambda_type.cmo : \
     middle_end/flambda/types/basic/tag_or_unknown_and_size.cmi \
     middle_end/flambda/types/basic/tag_and_size.cmi \
     lambda/tag.cmi \
+    middle_end/flambda/terms/symbol_projection.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/types/basic/string_info.cmi \
     middle_end/flambda/basic/simple.cmi \
@@ -8201,6 +8257,7 @@ middle_end/flambda/types/flambda_type.cmx : \
     middle_end/flambda/types/basic/tag_or_unknown_and_size.cmx \
     middle_end/flambda/types/basic/tag_and_size.cmx \
     lambda/tag.cmx \
+    middle_end/flambda/terms/symbol_projection.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/types/basic/string_info.cmx \
     middle_end/flambda/basic/simple.cmx \
@@ -8256,6 +8313,7 @@ middle_end/flambda/types/flambda_type.cmi : \
     utils/targetint.cmi \
     middle_end/flambda/compilenv_deps/target_imm.cmi \
     lambda/tag.cmi \
+    middle_end/flambda/terms/symbol_projection.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/types/basic/string_info.cmi \
     middle_end/flambda/basic/simple.cmi \
@@ -8426,6 +8484,7 @@ middle_end/flambda/types/type_grammar.rec.cmi : \
 middle_end/flambda/types/type_head_intf.cmo : \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
     utils/printing_cache.cmi \
+    middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/types/basic/or_bottom_or_absorbing.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
     middle_end/flambda/types/structures/lattice_ops_intf.cmo \
@@ -8434,6 +8493,7 @@ middle_end/flambda/types/type_head_intf.cmo : \
 middle_end/flambda/types/type_head_intf.cmx : \
     middle_end/flambda/compilenv_deps/rec_info.cmx \
     utils/printing_cache.cmx \
+    middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/types/basic/or_bottom_or_absorbing.cmx \
     middle_end/flambda/types/basic/or_bottom.cmx \
     middle_end/flambda/types/structures/lattice_ops_intf.cmx \
@@ -8665,6 +8725,7 @@ middle_end/flambda/types/env/meet_or_join_env.rec.cmi : \
     middle_end/flambda/basic/simple.cmi
 middle_end/flambda/types/env/typing_env.rec.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
+    middle_end/flambda/terms/symbol_projection.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/basic/scope.cmi \
@@ -8689,6 +8750,7 @@ middle_end/flambda/types/env/typing_env.rec.cmo : \
     middle_end/flambda/types/env/typing_env.rec.cmi
 middle_end/flambda/types/env/typing_env.rec.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
+    middle_end/flambda/terms/symbol_projection.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/basic/scope.cmx \
@@ -8712,6 +8774,8 @@ middle_end/flambda/types/env/typing_env.rec.cmx : \
     middle_end/flambda/types/env/aliases.cmx \
     middle_end/flambda/types/env/typing_env.rec.cmi
 middle_end/flambda/types/env/typing_env.rec.cmi : \
+    middle_end/flambda/compilenv_deps/variable.cmi \
+    middle_end/flambda/terms/symbol_projection.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/basic/scope.cmi \
@@ -8751,6 +8815,7 @@ middle_end/flambda/types/env/typing_env_extension.rec.cmi : \
 middle_end/flambda/types/env/typing_env_level.rec.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
+    middle_end/flambda/terms/symbol_projection.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/basic/simple.cmi \
     utils/printing_cache.cmi \
@@ -8777,6 +8842,7 @@ middle_end/flambda/types/env/typing_env_level.rec.cmo : \
 middle_end/flambda/types/env/typing_env_level.rec.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
     middle_end/flambda/naming/var_in_binding_pos.cmx \
+    middle_end/flambda/terms/symbol_projection.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/basic/simple.cmx \
     utils/printing_cache.cmx \
@@ -8802,6 +8868,7 @@ middle_end/flambda/types/env/typing_env_level.rec.cmx : \
     middle_end/flambda/types/env/typing_env_level.rec.cmi
 middle_end/flambda/types/env/typing_env_level.rec.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
+    middle_end/flambda/terms/symbol_projection.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/basic/simple.cmi \
     utils/printing_cache.cmi \
@@ -8832,6 +8899,7 @@ middle_end/flambda/types/kinds/flambda_kind.cmo : \
     utils/targetint.cmi \
     middle_end/flambda/compilenv_deps/target_imm.cmi \
     utils/numbers.cmi \
+    utils/misc.cmi \
     utils/identifiable.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi
@@ -8839,6 +8907,7 @@ middle_end/flambda/types/kinds/flambda_kind.cmx : \
     utils/targetint.cmx \
     middle_end/flambda/compilenv_deps/target_imm.cmx \
     utils/numbers.cmx \
+    utils/misc.cmx \
     utils/identifiable.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmi
@@ -9085,6 +9154,7 @@ middle_end/flambda/types/structures/type_structure_intf.cmx : \
     middle_end/flambda/cmx/contains_ids.cmx
 middle_end/flambda/types/type_of_kind/type_of_kind_naked_float0.rec.cmo : \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
+    middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/types/basic/or_bottom_or_absorbing.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
     utils/numbers.cmi \
@@ -9094,6 +9164,7 @@ middle_end/flambda/types/type_of_kind/type_of_kind_naked_float0.rec.cmo : \
     middle_end/flambda/types/type_of_kind/type_of_kind_naked_float0.rec.cmi
 middle_end/flambda/types/type_of_kind/type_of_kind_naked_float0.rec.cmx : \
     middle_end/flambda/compilenv_deps/rec_info.cmx \
+    middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/types/basic/or_bottom_or_absorbing.cmx \
     middle_end/flambda/types/basic/or_bottom.cmx \
     utils/numbers.cmx \
@@ -9110,6 +9181,7 @@ middle_end/flambda/types/type_of_kind/type_of_kind_naked_immediate0.rec.cmo : \
     lambda/tag.cmi \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
     utils/printing_cache.cmi \
+    middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/types/basic/or_bottom_or_absorbing.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
@@ -9122,6 +9194,7 @@ middle_end/flambda/types/type_of_kind/type_of_kind_naked_immediate0.rec.cmx : \
     lambda/tag.cmx \
     middle_end/flambda/compilenv_deps/rec_info.cmx \
     utils/printing_cache.cmx \
+    middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/types/basic/or_bottom_or_absorbing.cmx \
     middle_end/flambda/types/basic/or_bottom.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
@@ -9133,6 +9206,7 @@ middle_end/flambda/types/type_of_kind/type_of_kind_naked_immediate0.rec.cmi : \
     middle_end/flambda/compilenv_deps/target_imm.cmi
 middle_end/flambda/types/type_of_kind/type_of_kind_naked_int32_0.rec.cmo : \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
+    middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/types/basic/or_bottom_or_absorbing.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
     utils/numbers.cmi \
@@ -9142,6 +9216,7 @@ middle_end/flambda/types/type_of_kind/type_of_kind_naked_int32_0.rec.cmo : \
     middle_end/flambda/types/type_of_kind/type_of_kind_naked_int32_0.rec.cmi
 middle_end/flambda/types/type_of_kind/type_of_kind_naked_int32_0.rec.cmx : \
     middle_end/flambda/compilenv_deps/rec_info.cmx \
+    middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/types/basic/or_bottom_or_absorbing.cmx \
     middle_end/flambda/types/basic/or_bottom.cmx \
     utils/numbers.cmx \
@@ -9153,6 +9228,7 @@ middle_end/flambda/types/type_of_kind/type_of_kind_naked_int32_0.rec.cmi : \
     middle_end/flambda/types/type_head_intf.cmo
 middle_end/flambda/types/type_of_kind/type_of_kind_naked_int64_0.rec.cmo : \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
+    middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/types/basic/or_bottom_or_absorbing.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
     utils/numbers.cmi \
@@ -9162,6 +9238,7 @@ middle_end/flambda/types/type_of_kind/type_of_kind_naked_int64_0.rec.cmo : \
     middle_end/flambda/types/type_of_kind/type_of_kind_naked_int64_0.rec.cmi
 middle_end/flambda/types/type_of_kind/type_of_kind_naked_int64_0.rec.cmx : \
     middle_end/flambda/compilenv_deps/rec_info.cmx \
+    middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/types/basic/or_bottom_or_absorbing.cmx \
     middle_end/flambda/types/basic/or_bottom.cmx \
     utils/numbers.cmx \
@@ -9174,6 +9251,7 @@ middle_end/flambda/types/type_of_kind/type_of_kind_naked_int64_0.rec.cmi : \
 middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.cmo : \
     utils/targetint.cmi \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
+    middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/types/basic/or_bottom_or_absorbing.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
@@ -9183,6 +9261,7 @@ middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.cmo : \
 middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.cmx : \
     utils/targetint.cmx \
     middle_end/flambda/compilenv_deps/rec_info.cmx \
+    middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/types/basic/or_bottom_or_absorbing.cmx \
     middle_end/flambda/types/basic/or_bottom.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \

--- a/Makefile
+++ b/Makefile
@@ -278,7 +278,8 @@ MIDDLE_END_FLAMBDA_BASIC=\
   middle_end/flambda/basic/apply_cont_rewrite_id.cmo \
   middle_end/flambda/basic/continuation_extra_params_and_args.cmo \
   middle_end/flambda/basic/symbol_scoping_rule.cmo \
-  middle_end/flambda/basic/or_deleted.cmo
+  middle_end/flambda/basic/or_deleted.cmo \
+  middle_end/flambda/terms/symbol_projection.cmo
 
 MIDDLE_END_FLAMBDA_NAMING=\
   middle_end/flambda/naming/contains_names.cmo \

--- a/flambdatest/mlexamples/int32.ml
+++ b/flambdatest/mlexamples/int32.ml
@@ -111,7 +111,7 @@ external ( asr ) : int -> int -> int = "%asrint"
 
 let max_int = (-1) lsr 1
 let min_int = max_int + 1
-
+(*
 (* Floating-point operations *)
 
 external ( ~-. ) : float -> float = "%negfloat"
@@ -260,8 +260,9 @@ let bool_of_string_opt = function
 
 let string_of_int n =
   format_int "%d" n
-
+*)
 external int_of_string : string -> int = "caml_int_of_string"
+(*
 
 let int_of_string_opt s =
   (* TODO: provide this directly as a non-raising primitive. *)
@@ -561,7 +562,7 @@ let exit retcode =
   sys_exit retcode
 
 let _ = register_named_value "Pervasives.do_at_exit" do_at_exit
-
+*)
 end
 
 open Stdlib
@@ -619,7 +620,7 @@ let unsigned_to_int =
       fun n -> let i = to_int n in Some (if i < 0 then i + move else i)
   | _ ->
       assert false
-
+(*
 external format : string -> int32 -> string = "caml_int32_format"
 let to_string n = format "%d" n
 
@@ -651,3 +652,4 @@ let unsigned_div n d =
 
 let unsigned_rem n d =
   sub n (mul (unsigned_div n d) d)
+*)

--- a/flambdatest/mlexamples/protect_refs.ml
+++ b/flambdatest/mlexamples/protect_refs.ml
@@ -1,0 +1,30 @@
+let rec iter f = function
+    [] -> ()
+  | a::l -> f a; iter f l
+
+type 'a ref = { mutable contents : 'a; }
+external ref : 'a -> 'a ref = "%makemutable"
+external ( ! ) : 'a ref -> 'a = "%field0"
+external ( := ) : 'a ref -> 'a -> unit = "%setfield0"
+external raise : exn -> 'a = "%raise"
+
+type ref_and_value = R : 'a ref * 'a -> ref_and_value
+
+let protect_refs =
+  let set_refs l = iter (fun (R (r, v)) -> r := v) l in
+  fun refs f ->
+    set_refs refs;
+    f ()
+
+type unification_mode =
+  | Expression
+  | Pattern
+
+let umode = ref Expression
+
+let[@inline never] set_mode_pattern f =
+  protect_refs
+    [R (umode, Pattern)] f
+
+let () =
+  set_mode_pattern (fun () -> ())

--- a/flambdatest/mlexamples/symbol_projections.ml
+++ b/flambdatest/mlexamples/symbol_projections.ml
@@ -1,0 +1,14 @@
+external getenv : string -> string = "caml_sys_getenv"
+external (+) : int -> int -> int = "%addint"
+
+let foo =
+  match getenv "FOO" with
+  | exception _ -> false
+  | _ -> true
+
+let f x =
+  let g y =
+    if foo then y + y
+    else y
+  in
+  x, g

--- a/flambdatest/mlexamples/symbol_projections2.ml
+++ b/flambdatest/mlexamples/symbol_projections2.ml
@@ -1,0 +1,12 @@
+(* From pchambart 2020-07-22, ocaml-flambda/ocaml issue #214 *)
+
+external opaque_identity : 'a -> 'a = "%opaque"
+external (+) : int -> int -> int = "%addint"
+let[@inline never] ignore _ = ()
+
+let v = opaque_identity 33
+
+let g () =
+  let () = ignore () in
+  let f x = x + v in
+  f

--- a/flambdatest/mlexamples/symbol_projections3.ml
+++ b/flambdatest/mlexamples/symbol_projections3.ml
@@ -1,0 +1,15 @@
+external getenv : string -> string = "caml_sys_getenv"
+external (+) : int -> int -> int = "%addint"
+
+let foo =
+  match getenv "FOO" with
+  | exception _ -> false
+  | _ -> true
+
+let f x =
+  let g y =
+    if foo then y + y
+    else y
+  in
+  let block_to_lift = foo, foo in
+  x, g, block_to_lift

--- a/flambdatest/mlexamples/symbol_projections4.ml
+++ b/flambdatest/mlexamples/symbol_projections4.ml
@@ -1,0 +1,21 @@
+external getenv : string -> string = "caml_sys_getenv"
+external (+) : int -> int -> int = "%addint"
+
+let foo =
+  match getenv "FOO" with
+  | exception _ -> false
+  | _ -> true
+
+let f x b =
+  if b then
+    let g y =
+      if foo then y + y
+      else y
+    in
+    x, g
+  else
+    let h y =
+      if foo then y + y + y
+      else y
+    in
+    x, h

--- a/flambdatest/mlexamples/symbol_projections5.ml
+++ b/flambdatest/mlexamples/symbol_projections5.ml
@@ -1,0 +1,27 @@
+external getenv : string -> string = "caml_sys_getenv"
+external (+) : int -> int -> int = "%addint"
+external (<) : int -> int -> bool = "%lessthan"
+external (&&) : bool -> bool -> bool = "%logand"
+
+let foo =
+  match getenv "FOO" with
+  | exception _ -> false
+  | _ -> true
+
+type t =
+  | S of (int -> t)
+  | T of (int -> t)
+
+let f b =
+  if b then
+    let rec g y =
+      if y < 0 then S g
+      else T g
+    in
+    g
+  else
+    let rec h z =
+      if z < 0 then S h
+      else T h
+    in
+    h

--- a/flambdatest/mlexamples/symbol_projections6.ml
+++ b/flambdatest/mlexamples/symbol_projections6.ml
@@ -1,0 +1,27 @@
+external getenv : string -> string = "caml_sys_getenv"
+external (+) : int -> int -> int = "%addint"
+external (<) : int -> int -> bool = "%lessthan"
+external (&&) : bool -> bool -> bool = "%sequand"
+
+let foo =
+  match getenv "FOO" with
+  | exception _ -> false
+  | _ -> true
+
+type t =
+  | S of (int -> (t * bool))
+  | T of (int -> (t * bool))
+
+let f b =
+  if b then
+    let rec g y =
+      if y < 0 && foo then S g, foo
+      else T g, foo
+    in
+    g
+  else
+    let rec h z =
+      if z < 0 && foo then S h, foo
+      else T h, foo
+    in
+    h

--- a/flambdatest/mlexamples/symbol_projections7.ml
+++ b/flambdatest/mlexamples/symbol_projections7.ml
@@ -1,0 +1,11 @@
+external word_size : unit -> int = "%word_size"
+external (+) : int -> int -> int = "%addint"
+external opaque : 'a -> 'a = "%opaque"
+let foo =
+  match word_size () with
+  | 32 -> (fun x -> x + 1)
+  | 64 ->
+    let y = opaque 2 in
+    (fun x -> x + y)
+  | _ ->
+      assert false

--- a/middle_end/flambda/basic/mutability.ml
+++ b/middle_end/flambda/basic/mutability.ml
@@ -50,3 +50,8 @@ let to_lambda t : Asttypes.mutable_flag =
   | Mutable -> Mutable
   | Immutable -> Immutable
   | Immutable_unique -> Immutable
+
+let is_mutable t =
+  match t with
+  | Mutable -> true
+  | Immutable | Immutable_unique -> false

--- a/middle_end/flambda/basic/mutability.mli
+++ b/middle_end/flambda/basic/mutability.mli
@@ -31,3 +31,5 @@ val compare : t -> t -> int
 val join : t -> t -> t
 
 val to_lambda : t -> Asttypes.mutable_flag
+
+val is_mutable : t -> bool

--- a/middle_end/flambda/basic/simple.ml
+++ b/middle_end/flambda/basic/simple.ml
@@ -47,6 +47,10 @@ let [@inline always] is_symbol t =
 let [@inline always] is_const t =
   pattern_match t ~name:(fun _ -> false) ~const:(fun _ -> true)
 
+let pattern_match' t ~var ~symbol ~const =
+  pattern_match t ~const
+    ~name:(fun name -> Name.pattern_match name ~var ~symbol)
+
 let const_from_descr descr = const (RWC.of_descr descr)
 
 let without_rec_info t = pattern_match t ~name ~const

--- a/middle_end/flambda/basic/simple.mli
+++ b/middle_end/flambda/basic/simple.mli
@@ -78,6 +78,13 @@ val is_var : t -> bool
 
 val free_names_in_types : t -> Name_occurrences.t
 
+val pattern_match'
+   : t
+  -> var:(Variable.t -> 'a)
+  -> symbol:(Symbol.t -> 'a)
+  -> const:(Reg_width_const.t -> 'a)
+  -> 'a
+
 module List : sig
   type nonrec t = t list
 

--- a/middle_end/flambda/compilenv_deps/reg_width_things.mli
+++ b/middle_end/flambda/compilenv_deps/reg_width_things.mli
@@ -164,9 +164,9 @@ module Simple : sig
     -> const:(Const.t -> 'a)
     -> 'a
 
-   (* [same s1 s2] returns true iff they represent the same name or const
-      i.e. [same s (with_rec_info s rec_info)] returns true *)
-   val same : t -> t -> bool
+  (* [same s1 s2] returns true iff they represent the same name or const
+     i.e. [same s (with_rec_info s rec_info)] returns true *)
+  val same : t -> t -> bool
 
   val export : t -> exported
 

--- a/middle_end/flambda/lifting/lift_inconstants.ml
+++ b/middle_end/flambda/lifting/lift_inconstants.ml
@@ -34,6 +34,7 @@ let reify_primitive_at_toplevel dacc bound_var ty =
      the [is_fully_static] check below. *)
   match
     T.reify ~allowed_if_free_vars_defined_in:typing_env
+      ~additional_free_var_criterion:(DE.is_defined_at_toplevel (DA.denv dacc))
       ~allow_unique:true
       typing_env ~min_name_mode:NM.normal ty
   with

--- a/middle_end/flambda/lifting/sort_lifted_constants.ml
+++ b/middle_end/flambda/lifting/sort_lifted_constants.ml
@@ -30,12 +30,10 @@ let build_dep_graph lifted_constants =
         ~f:(fun (dep_graph, code_id_or_symbol_to_const) definition ->
           let module D = LC.Definition in
           let free_names =
-            let free_names =
-              Static_const.free_names (D.defining_expr definition)
-            in
+            let free_names = D.free_names definition in
             match D.descr definition with
             | Code _ | Block_like _ -> free_names
-            | Set_of_closures { denv = _; closure_symbols_with_types; } ->
+            | Set_of_closures { closure_symbols_with_types; _; } ->
               (* To avoid existing sets of closures (with or without associated
                  code) being pulled apart, we add a dependency from each of the
                  closure symbols (in the current set) to all of the others

--- a/middle_end/flambda/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda/simplify/simplify_binary_primitive.ml
@@ -990,7 +990,7 @@ let try_cse dacc prim arg1 arg2 ~min_name_mode ~result_var
       | Ok arg2, _arg2_ty ->
         let original_prim : P.t = Binary (prim, arg1, arg2) in
         Simplify_common.try_cse dacc ~original_prim ~result_kind
-          ~min_name_mode ~result_var
+          ~args:[arg1; arg2] ~min_name_mode ~result_var
 
 let simplify_binary_primitive dacc (prim : P.binary_primitive)
       arg1 arg2 dbg ~result_var =
@@ -998,7 +998,7 @@ let simplify_binary_primitive dacc (prim : P.binary_primitive)
   let result_var' = Var_in_binding_pos.var result_var in
   let invalid ty =
     let env_extension = TEE.one_equation (Name.var result_var') ty in
-    Reachable.invalid (), env_extension, dacc
+    Reachable.invalid (), env_extension, [arg1; arg2], dacc
   in
   match
     try_cse dacc prim arg1 arg2 ~min_name_mode ~result_var:result_var'
@@ -1067,5 +1067,8 @@ let simplify_binary_primitive dacc (prim : P.binary_primitive)
               let env_extension = TEE.one_equation (Name.var result_var') ty in
               Reachable.reachable named, env_extension, dacc
         in
-        simplifier dacc ~original_term dbg ~arg1 ~arg1_ty ~arg2 ~arg2_ty
-          ~result_var
+        let reachable, env_extension, dacc =
+          simplifier dacc ~original_term dbg ~arg1 ~arg1_ty ~arg2 ~arg2_ty
+            ~result_var
+        in
+        reachable, env_extension, [arg1; arg2], dacc

--- a/middle_end/flambda/simplify/simplify_binary_primitive.mli
+++ b/middle_end/flambda/simplify/simplify_binary_primitive.mli
@@ -25,4 +25,5 @@ val simplify_binary_primitive
   -> Simple.t
   -> Debuginfo.t
   -> result_var:Var_in_binding_pos.t
-  -> Reachable.t * Flambda_type.Typing_env_extension.t * Downwards_acc.t
+  -> Reachable.t * Flambda_type.Typing_env_extension.t
+       * Simple.t list * Downwards_acc.t

--- a/middle_end/flambda/simplify/simplify_common.mli
+++ b/middle_end/flambda/simplify/simplify_common.mli
@@ -29,8 +29,11 @@ val simplify_projection
 
 type cse =
   | Invalid of Flambda_type.t
+  (* CR mshinwell: Use a record type for the following and all of the
+     simplify_*primitive.mli files *)
   | Applied of
-      (Reachable.t * Flambda_type.Typing_env_extension.t * Downwards_acc.t)
+      (Reachable.t * Flambda_type.Typing_env_extension.t
+        * Simple.t list * Downwards_acc.t)
   | Not_applied of Downwards_acc.t
 
 val try_cse
@@ -38,6 +41,7 @@ val try_cse
   -> original_prim:Flambda_primitive.t
   -> result_kind:Flambda_kind.t
   -> min_name_mode:Name_mode.t
+  -> args:Simple.t list
   -> result_var:Variable.t
   -> cse
 
@@ -83,6 +87,16 @@ val create_let_symbols
   -> Code_age_relation.t
   -> Simplify_envs.Lifted_constant.t
   -> Flambda.Expr.t
+  -> Flambda.Expr.t * Upwards_acc.t
+
+val place_lifted_constants
+   : Upwards_acc.t
+  -> Symbol_scoping_rule.t
+  -> lifted_constants_from_defining_expr:Simplify_envs.Lifted_constant_state.t
+  -> lifted_constants_from_body:Simplify_envs.Lifted_constant_state.t
+  -> put_bindings_around_body:(body:Flambda.Expr.t -> Flambda.Expr.t)
+  -> body:Flambda.Expr.t
+  -> critical_deps_of_bindings:Name_occurrences.t
   -> Flambda.Expr.t * Upwards_acc.t
 
 (** Create the projection of a tuple (assumed to be a size-tuple of

--- a/middle_end/flambda/simplify/simplify_named.rec.ml
+++ b/middle_end/flambda/simplify/simplify_named.rec.ml
@@ -14,7 +14,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-[@@@ocaml.warning "+a-30-40-41-42"]
+[@@@ocaml.warning "+a-4-30-40-41-42"]
 
 open! Simplify_import
 
@@ -25,6 +25,122 @@ type simplify_named_result = {
 
 let bindings_result bindings_outermost_first dacc =
   { bindings_outermost_first; dacc; }
+
+let record_any_symbol_projection dacc (defining_expr : Reachable.t)
+      (prim : P.t) args bindable_let_bound ~bound_var named =
+  (* Projections from symbols bound to variables are important to remember,
+     since if such a variable occurs in a set of closures environment or
+     other value that can potentially be lifted, the knowledge that the
+     variable is equal to a symbol projection can make the difference between
+     being able to lift and not being able to lift.  We try to avoid
+     recording symbol projections whose answer is known (in particular the
+     answer is a symbol or a constant), since such symbol projection
+     knowledge doesn't affect lifting decisions. *)
+  let can_record_proj =
+    (* We only need to record a projection if the defining expression remains
+       as a [Prim].  In particular if the defining expression simplified to
+       a variable (via the [Simple] constructor), then in the event that the
+       variable is itself a symbol projection, the environment will already
+       know this fact.
+       We don't need to record a projection if we are currently at toplevel,
+       since any variable involved in a constant to be lifted from that
+       position will also be at toplevel. *)
+    (not (DE.at_unit_toplevel (DA.denv dacc)))
+      && match defining_expr with
+         | Reachable (Prim _) -> true
+         | Reachable (Simple _ | Set_of_closures _ | Static_consts _)
+         | Invalid _ -> false
+  in
+  let proj =
+    let module SP = Symbol_projection in
+    (* The [args] being queried here are the post-simplification arguments
+       of the primitive, so we can directly read off whether they are
+       symbols or constants, as needed. *)
+    match prim with
+    | Unary (Project_var { project_from; var; }, _)
+        when can_record_proj ->
+      begin match args with
+      | [closure] ->
+        Simple.pattern_match' closure
+          ~const:(fun _ -> None)
+          ~symbol:(fun symbol_projected_from ->
+            Some (SP.create symbol_projected_from
+              (SP.Projection.project_var project_from var)))
+          ~var:(fun _ -> None)
+      | [] | _::_ ->
+        Misc.fatal_errorf "Expected one argument:@ %a@ =@ %a"
+          Bindable_let_bound.print bindable_let_bound
+          Named.print named
+      end
+    | Binary (Block_load _, _, _) when can_record_proj ->
+      begin match args with
+      | [block; index] ->
+        Simple.pattern_match index
+          ~const:(fun const ->
+            match Reg_width_const.descr const with
+            | Tagged_immediate imm ->
+              Simple.pattern_match' block
+                ~const:(fun _ -> None)
+                ~symbol:(fun symbol_projected_from ->
+                  let index = Target_imm.to_targetint imm in
+                  Some (SP.create symbol_projected_from
+                    (SP.Projection.block_load ~index)))
+                ~var:(fun _ -> None)
+            | Naked_immediate _ | Naked_float _
+            | Naked_int32 _ | Naked_int64 _ | Naked_nativeint _ ->
+              Misc.fatal_errorf "Kind error for [Block_load] index:@ \
+                  %a@ =@ %a"
+                Bindable_let_bound.print bindable_let_bound
+                Named.print named)
+          ~name:(fun _ -> None)
+      | [] | _::_ ->
+        Misc.fatal_errorf "Expected two arguments:@ %a@ =@ %a"
+          Bindable_let_bound.print bindable_let_bound
+          Named.print named
+      end
+    | Unary (
+      ( Duplicate_block _
+      | Duplicate_array _
+      | Is_int
+      | Get_tag
+      | Array_length _
+      | Bigarray_length _
+      | String_length _
+      | Int_as_pointer
+      | Opaque_identity
+      | Int_arith _
+      | Float_arith _
+      | Num_conv _
+      | Boolean_not
+      | Unbox_number _
+      | Box_number _
+      | Select_closure _
+      | Project_var _ ), _)
+    | Binary (
+      ( Block_load _
+      | Array_load _
+      | String_or_bigstring_load _
+      | Bigarray_load _
+      | Phys_equal _
+      | Int_arith _
+      | Int_shift _
+      | Int_comp _
+      | Float_arith _
+      | Float_comp _ ), _, _)
+    | Ternary (
+      ( Block_set _
+      | Array_set _
+      | Bytes_or_bigstring_set _
+      | Bigarray_set _ ), _, _, _)
+    | Variadic (
+      ( Make_block _
+      | Make_array _ ), _) -> None
+  in
+  match proj with
+  | None -> dacc
+  | Some proj ->
+    let var = Var_in_binding_pos.var bound_var in
+    DA.map_denv dacc ~f:(fun denv -> DE.add_symbol_projection denv var proj)
 
 let simplify_named0 dacc (bindable_let_bound : Bindable_let_bound.t)
       (named : Named.t) =
@@ -47,7 +163,12 @@ let simplify_named0 dacc (bindable_let_bound : Bindable_let_bound.t)
     end
   | Prim (prim, dbg) ->
     let bound_var = Bindable_let_bound.must_be_singleton bindable_let_bound in
-    let term, env_extension, dacc =
+    let term, env_extension, simplified_args, dacc =
+      (* [simplified_args] has to be returned from [simplify_primitive] because
+         in at least one case (for [Project_var]), the simplifier may return
+         something other than a [Prim] as the [term].  However we need the
+         simplified arguments of the actual primitive for the symbol
+         projection check below. *)
       Simplify_primitive.simplify_primitive dacc ~original_named:named
         prim dbg ~result_var:bound_var
     in
@@ -62,7 +183,15 @@ let simplify_named0 dacc (bindable_let_bound : Bindable_let_bound.t)
        Without this check, we could end up lifting definitions that have
        a type that looks like an allocation but that are instead a projection
        from a bigger structure. *)
-    let allow_lifting = P.only_generative_effects prim in
+    let allow_lifting =
+      (* CR mshinwell: We probably shouldn't lift if the let binding is going
+         to be deleted, as lifting may cause [Dominator]-scoped bindings to
+         be inserted, that cannot be deleted.  However this situation probably
+         doesn't arise that much, and won't be an issue once we can lift
+         [Dominator]-scoped bindings. *)
+      P.only_generative_effects prim
+        && Name_mode.is_normal (Var_in_binding_pos.name_mode bound_var)
+    in
     let defining_expr, dacc, ty =
       Reification.try_to_reify dacc term ~bound_to:bound_var ~allow_lifting
     in
@@ -70,32 +199,11 @@ let simplify_named0 dacc (bindable_let_bound : Bindable_let_bound.t)
       if T.is_bottom (DA.typing_env dacc) ty then Reachable.invalid ()
       else defining_expr
     in
-    if DE.at_unit_toplevel (DA.denv dacc)
-      && allow_lifting
-      && Name_mode.is_normal (Var_in_binding_pos.name_mode bound_var)
-    then begin
-      match
-        Lift_inconstants.reify_primitive_at_toplevel dacc bound_var ty
-      with
-      | Cannot_reify ->
-        bindings_result [bindable_let_bound, defining_expr] dacc
-      | Shared symbol ->
-        let defining_expr =
-          Reachable.reachable (Named.create_simple (Simple.symbol symbol))
-        in
-        bindings_result [bindable_let_bound, defining_expr] dacc
-      | Lift { symbol; static_const; } ->
-        let dacc =
-          LC.create_block_like symbol static_const (DA.denv dacc) ty
-          |> DA.add_lifted_constant_also_to_env dacc
-        in
-        let defining_expr =
-          Reachable.reachable (Named.create_simple (Simple.symbol symbol))
-        in
-        bindings_result [bindable_let_bound, defining_expr] dacc
-    end
-    else
-      bindings_result [bindable_let_bound, defining_expr] dacc
+    let dacc =
+      record_any_symbol_projection dacc defining_expr prim simplified_args
+        bindable_let_bound ~bound_var named
+    in
+    bindings_result [bindable_let_bound, defining_expr] dacc
   | Set_of_closures set_of_closures ->
     let bindings, dacc =
       Simplify_set_of_closures.simplify_non_lifted_set_of_closures dacc
@@ -173,7 +281,11 @@ let simplify_named0 dacc (bindable_let_bound : Bindable_let_bound.t)
             let typ =
               TE.find (DA.typing_env dacc) (Name.symbol symbol) (Some K.value)
             in
-            LC.create_block_like symbol static_const (DA.denv dacc) typ
+            (* The [symbol_projections] map is empty because we only introduce
+               symbol projections when lifting -- and [static_const] has
+               already been lifted. *)
+            LC.create_block_like symbol static_const (DA.denv dacc)
+              ~symbol_projections:Variable.Map.empty typ
           | Code code_id -> LC.create_code code_id static_const
           | Set_of_closures closure_symbols ->
             let closure_symbols_with_types =
@@ -186,6 +298,8 @@ let simplify_named0 dacc (bindable_let_bound : Bindable_let_bound.t)
             in
             LC.create_set_of_closures (DA.denv dacc)
               ~closure_symbols_with_types
+              (* Same comment as above re. [symbol_projections]. *)
+              ~symbol_projections:Variable.Map.empty
               static_const)
     in
     let dacc = DA.add_lifted_constant dacc (LC.concat lifted_constants) in

--- a/middle_end/flambda/simplify/simplify_primitive.mli
+++ b/middle_end/flambda/simplify/simplify_primitive.mli
@@ -24,4 +24,5 @@ val simplify_primitive
   -> Flambda_primitive.t
   -> Debuginfo.t
   -> result_var:Var_in_binding_pos.t
-  -> Reachable.t * Flambda_type.Typing_env_extension.t * Downwards_acc.t
+  -> Reachable.t * Flambda_type.Typing_env_extension.t
+       * Simple.t list * Downwards_acc.t

--- a/middle_end/flambda/simplify/simplify_ternary_primitive.ml
+++ b/middle_end/flambda/simplify/simplify_ternary_primitive.ml
@@ -37,7 +37,7 @@ let try_cse dacc prim arg1 arg2 arg3 ~min_name_mode ~result_var
             Ternary (prim, arg1, arg2, arg3)
           in
           Simplify_common.try_cse dacc ~original_prim ~result_kind
-            ~min_name_mode ~result_var
+            ~args:[arg1; arg2; arg3] ~min_name_mode ~result_var
 
 let simplify_ternary_primitive dacc (prim : P.ternary_primitive)
       arg1 arg2 arg3 dbg ~result_var =
@@ -45,7 +45,7 @@ let simplify_ternary_primitive dacc (prim : P.ternary_primitive)
   let result_var' = Var_in_binding_pos.var result_var in
   let invalid ty =
     let env_extension = TEE.one_equation (Name.var result_var') ty in
-    Reachable.invalid (), env_extension, dacc
+    Reachable.invalid (), env_extension, [arg1; arg2; arg3], dacc
   in
   match
     try_cse dacc prim arg1 arg2 arg3 ~min_name_mode
@@ -74,4 +74,4 @@ let simplify_ternary_primitive dacc (prim : P.ternary_primitive)
             in
             let ty = T.unknown result_kind in
             let env_extension = TEE.one_equation (Name.var result_var') ty in
-            Reachable.reachable named, env_extension, dacc
+            Reachable.reachable named, env_extension, [arg1; arg2; arg3], dacc

--- a/middle_end/flambda/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda/simplify/simplify_unary_primitive.ml
@@ -449,7 +449,7 @@ let try_cse dacc prim arg ~min_name_mode ~result_var : Simplify_common.cse =
     | Ok arg, _arg_ty ->
       let original_prim : P.t = Unary (prim, arg) in
       Simplify_common.try_cse dacc ~original_prim ~result_kind
-        ~min_name_mode ~result_var
+        ~args:[arg] ~min_name_mode ~result_var
 
 let simplify_unary_primitive dacc (prim : P.unary_primitive)
       arg dbg ~result_var =
@@ -457,7 +457,7 @@ let simplify_unary_primitive dacc (prim : P.unary_primitive)
   let result_var' = Var_in_binding_pos.var result_var in
   let invalid ty =
     let env_extension = TEE.one_equation (Name.var result_var') ty in
-    Reachable.invalid (), env_extension, dacc
+    Reachable.invalid (), env_extension, [arg], dacc
   in
   match try_cse dacc prim arg ~min_name_mode ~result_var:result_var' with
   | Invalid ty -> invalid ty
@@ -515,4 +515,7 @@ let simplify_unary_primitive dacc (prim : P.unary_primitive)
             let env_extension = TEE.one_equation (Name.var result_var') ty in
             Reachable.reachable named, env_extension, dacc
       in
-      simplifier dacc ~original_term ~arg ~arg_ty ~result_var
+      let reachable, env_extension, dacc =
+        simplifier dacc ~original_term ~arg ~arg_ty ~result_var
+      in
+      reachable, env_extension, [arg], dacc

--- a/middle_end/flambda/simplify/simplify_unary_primitive.mli
+++ b/middle_end/flambda/simplify/simplify_unary_primitive.mli
@@ -24,4 +24,5 @@ val simplify_unary_primitive
   -> Simple.t
   -> Debuginfo.t
   -> result_var:Var_in_binding_pos.t
-  -> Reachable.t * Flambda_type.Typing_env_extension.t * Downwards_acc.t
+  -> Reachable.t * Flambda_type.Typing_env_extension.t
+       * Simple.t list * Downwards_acc.t

--- a/middle_end/flambda/simplify/simplify_variadic_primitive.ml
+++ b/middle_end/flambda/simplify/simplify_variadic_primitive.ml
@@ -26,7 +26,7 @@ let simplify_make_block_of_values dacc _prim dbg tag ~shape
   let invalid () =
     let ty = T.bottom K.value in
     let env_extension = TEE.one_equation (Name.var result_var) ty in
-    Reachable.invalid (), env_extension, dacc
+    Reachable.invalid (), env_extension, args, dacc
   in
   if List.compare_lengths shape args <> 0 then begin
     (* CR mshinwell: improve message *)
@@ -69,7 +69,7 @@ let simplify_make_block_of_values dacc _prim dbg tag ~shape
       | Mutable -> T.any_value ()
     in
     let env_extension = TEE.one_equation (Name.var result_var) ty in
-    Reachable.reachable term, env_extension, dacc
+    Reachable.reachable term, env_extension, args, dacc
   end
 
 let try_cse dacc ~original_prim prim args ~min_name_mode ~result_var
@@ -87,7 +87,7 @@ let try_cse dacc ~original_prim prim args ~min_name_mode ~result_var
         | Unchanged -> original_prim
       in
       Simplify_common.try_cse dacc ~original_prim ~result_kind
-        ~min_name_mode ~result_var
+        ~min_name_mode ~args ~result_var
 
   (* if Name_mode.is_phantom min_name_mode then
    *   (\* If this is producing the defining expr of a phantom binding,
@@ -111,7 +111,7 @@ let simplify_variadic_primitive dacc ~original_named ~original_prim
   let result_var' = Var_in_binding_pos.var result_var in
   let invalid ty =
     let env_extension = TEE.one_equation (Name.var result_var') ty in
-    Reachable.invalid (), env_extension, dacc
+    Reachable.invalid (), env_extension, args, dacc
   in
   match
     try_cse dacc ~original_prim prim args ~min_name_mode ~result_var:result_var'
@@ -154,4 +154,4 @@ let simplify_variadic_primitive dacc ~original_named ~original_prim
             T.array_of_length ~length
         in
         let env_extension = TEE.one_equation (Name.var result_var') ty in
-        Reachable.reachable named, env_extension, dacc
+        Reachable.reachable named, env_extension, args, dacc

--- a/middle_end/flambda/simplify/simplify_variadic_primitive.mli
+++ b/middle_end/flambda/simplify/simplify_variadic_primitive.mli
@@ -26,4 +26,5 @@ val simplify_variadic_primitive
   -> Simple.t list
   -> Debuginfo.t
   -> result_var:Var_in_binding_pos.t
-  -> Reachable.t * Flambda_type.Typing_env_extension.t * Downwards_acc.t
+  -> Reachable.t * Flambda_type.Typing_env_extension.t
+       * Simple.t list * Downwards_acc.t

--- a/middle_end/flambda/terms/function_declarations.ml
+++ b/middle_end/flambda/terms/function_declarations.ml
@@ -87,3 +87,6 @@ let filter t ~f =
   let funs = Closure_id.Map.filter f t.funs in
   let in_order = Closure_id.Lmap.filter f t.in_order in
   { funs; in_order; }
+
+let binds_closure_id t closure_id =
+  Closure_id.Map.mem closure_id t.funs

--- a/middle_end/flambda/terms/function_declarations.mli
+++ b/middle_end/flambda/terms/function_declarations.mli
@@ -58,6 +58,8 @@ val funs_in_order : t -> Function_declaration.t Closure_id.Lmap.t
 (** [find f t] raises [Not_found] if [f] is not in [t]. *)
 val find : t -> Closure_id.t -> Function_declaration.t
 
+val binds_closure_id : t -> Closure_id.t -> bool
+
 val compare : t -> t -> int
 
 val filter : t -> f:(Closure_id.t -> Function_declaration.t -> bool) -> t

--- a/middle_end/flambda/terms/symbol_projection.ml
+++ b/middle_end/flambda/terms/symbol_projection.ml
@@ -1,0 +1,107 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                   Mark Shinwell, Jane Street Europe                    *)
+(*                                                                        *)
+(*   Copyright 2020 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+module Projection = struct
+  type t =
+    | Block_load of { index : Targetint.OCaml.t; }
+    | Project_var of {
+        project_from : Closure_id.t;
+        var : Var_within_closure.t;
+      }
+
+  let block_load ~index = Block_load { index; }
+  let project_var project_from var = Project_var { project_from; var; }
+
+  let hash t =
+    match t with
+    | Block_load { index; } -> Targetint.OCaml.hash index
+    | Project_var { project_from; var; } ->
+      Hashtbl.hash (Closure_id.hash project_from, Var_within_closure.hash var)
+
+  let print ppf t =
+    match t with
+    | Block_load { index; } ->
+      Format.fprintf ppf "@[<hov 1>(Block_load@ \
+          @[<hov 1>(index@ %a)@]\
+          )@]"
+        Targetint.OCaml.print index
+    | Project_var { project_from; var; } ->
+      Format.fprintf ppf "@[<hov 1>(Project_var@ \
+          @[<hov 1>(project_from@ %a)@]@ \
+          @[<hov 1>(var@ %a)@]\
+          )@]"
+        Closure_id.print project_from
+        Var_within_closure.print var
+
+  let compare t1 t2 =
+    match t1, t2 with
+    | Block_load { index = index1; }, Block_load { index = index2; } ->
+      Targetint.OCaml.compare index1 index2
+    | Project_var { project_from = project_from1; var = var1; },
+        Project_var { project_from = project_from2; var = var2; } ->
+      let c = Closure_id.compare project_from1 project_from2 in
+      if c <> 0 then c
+      else Var_within_closure.compare var1 var2
+    | Block_load _, Project_var _ -> -1
+    | Project_var _, Block_load _ -> 1
+end
+
+type t = {
+  symbol : Symbol.t;
+  projection : Projection.t;
+}
+
+let print ppf { symbol; projection; } =
+  Format.fprintf ppf "@[<hov 1>(\
+      @[<hov 1>(symbol@ %a)@]@ \
+      @[<hov 1>(projection@ %a)@]\
+      )@]"
+    Symbol.print symbol
+    Projection.print projection
+
+let create symbol projection =
+  { symbol;
+    projection;
+  }
+
+let symbol t = t.symbol
+let projection t = t.projection
+
+let compare { symbol = symbol1; projection = projection1; }
+      { symbol = symbol2; projection = projection2; } =
+  let c = Symbol.compare symbol1 symbol2 in
+  if c <> 0 then c
+  else Projection.compare projection1 projection2
+
+let equal t1 t2 =
+  compare t1 t2 = 0
+
+let hash { symbol; projection; } =
+  Hashtbl.hash (Symbol.hash symbol, Projection.hash projection)
+
+let apply_name_permutation ({ symbol = _; projection = _; } as t) _perm = t
+
+let free_names { symbol; projection = _; } =
+  Name_occurrences.singleton_symbol symbol Name_mode.normal
+
+let all_ids_for_export { symbol; projection = _; } =
+  Ids_for_export.singleton_symbol symbol
+
+let import import_map { symbol; projection; } =
+  let symbol = Ids_for_export.Import_map.symbol import_map symbol in
+  { symbol;
+    projection;
+  }

--- a/middle_end/flambda/terms/symbol_projection.mli
+++ b/middle_end/flambda/terms/symbol_projection.mli
@@ -2,11 +2,9 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*                       Pierre Chambart, OCamlPro                        *)
-(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                   Mark Shinwell, Jane Street Europe                    *)
 (*                                                                        *)
-(*   Copyright 2013--2019 OCamlPro SAS                                    *)
-(*   Copyright 2014--2019 Jane Street Group LLC                           *)
+(*   Copyright 2020 Jane Street Group LLC                                 *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -14,17 +12,36 @@
 (*                                                                        *)
 (**************************************************************************)
 
-[@@@ocaml.warning "+a-4-30-40-41-42"]
+[@@@ocaml.warning "+a-30-40-41-42"]
 
-(** Simplification of primitives taking three arguments. *)
+module Projection : sig
+  type t = private
+    | Block_load of { index : Targetint.OCaml.t; }
+    | Project_var of {
+        project_from : Closure_id.t;
+        var : Var_within_closure.t;
+      }
 
-val simplify_ternary_primitive
-   : Downwards_acc.t
-  -> Flambda_primitive.ternary_primitive
-  -> Simple.t
-  -> Simple.t
-  -> Simple.t
-  -> Debuginfo.t
-  -> result_var:Var_in_binding_pos.t
-  -> Reachable.t * Flambda_type.Typing_env_extension.t
-       * Simple.t list * Downwards_acc.t
+  val block_load : index:Targetint.OCaml.t -> t
+
+  val project_var : Closure_id.t -> Var_within_closure.t -> t
+end
+
+type t
+
+val print : Format.formatter -> t -> unit
+
+val create : Symbol.t -> Projection.t -> t
+
+val symbol : t -> Symbol.t
+
+val projection : t -> Projection.t
+
+val compare : t -> t -> int
+
+val equal : t -> t -> bool
+
+val hash : t -> int
+
+include Contains_names.S with type t := t
+include Contains_ids.S with type t := t

--- a/middle_end/flambda/types/env/typing_env.rec.mli
+++ b/middle_end/flambda/types/env/typing_env.rec.mli
@@ -52,6 +52,10 @@ val add_symbol_definition : t -> Symbol.t -> t
 
 val add_symbol_definitions : t -> Symbol.Set.t -> t
 
+val add_symbol_projection : t -> Variable.t -> Symbol_projection.t -> t
+
+val find_symbol_projection : t -> Variable.t -> Symbol_projection.t option
+
 val add_equations_on_params
    : t
   -> params:Kinded_parameter.t list

--- a/middle_end/flambda/types/env/typing_env_level.rec.ml
+++ b/middle_end/flambda/types/env/typing_env_level.rec.ml
@@ -21,6 +21,7 @@ type t = {
   binding_times : Variable.Set.t Binding_time.Map.t;
   equations : Type_grammar.t Name.Map.t;
   cse : Simple.t Flambda_primitive.Eligible_for_cse.Map.t;
+  symbol_projections : Symbol_projection.t Variable.Map.t;
 }
 
 let defined_vars t = t.defined_vars
@@ -38,7 +39,10 @@ let defines_name_but_no_equations t name =
 *)
 
 let print_with_cache ~cache ppf
-      { defined_vars; binding_times = _; equations; cse; } =
+      { defined_vars; binding_times = _; equations; cse;
+        symbol_projections = _; } =
+  (* CR mshinwell: print symbol projections along with tidying up this
+     function *)
   let print_equations ppf equations =
     let equations = Name.Map.bindings equations in
     match equations with
@@ -106,7 +110,9 @@ let fold_on_defined_vars f t init =
     t.binding_times
     init
 
-let apply_name_permutation ({ defined_vars; binding_times; equations; cse; } as t)
+let apply_name_permutation
+      ({ defined_vars; binding_times; equations; cse; symbol_projections; }
+        as t)
       perm =
   let defined_vars_changed = ref false in
   let defined_vars' =
@@ -159,6 +165,9 @@ let apply_name_permutation ({ defined_vars; binding_times; equations; cse; } as 
       cse
       Flambda_primitive.Eligible_for_cse.Map.empty
   in
+  (* CR mshinwell: Maybe we should call
+     [Symbol_projection.apply_name_permutation] even though it currently
+     does nothing? *)
   if (not !defined_vars_changed)
     && (not !equations_changed)
     && (not !cse_changed)
@@ -168,9 +177,11 @@ let apply_name_permutation ({ defined_vars; binding_times; equations; cse; } as 
       binding_times = binding_times';
       equations = equations';
       cse = cse';
+      symbol_projections;
     }
 
-let free_names { defined_vars; binding_times = _; equations; cse; } =
+let free_names
+      { defined_vars; binding_times = _; equations; cse; symbol_projections; } =
   let free_names_defined_vars =
     Name_occurrences.create_variables (Variable.Map.keys defined_vars)
       Name_mode.in_types
@@ -185,37 +196,56 @@ let free_names { defined_vars; binding_times = _; equations; cse; } =
       equations
       free_names_defined_vars
   in
-  Flambda_primitive.Eligible_for_cse.Map.fold
-    (fun prim (bound_to : Simple.t) acc ->
-      Simple.pattern_match bound_to
-        ~const:(fun _ -> acc)
-        ~name:(fun name ->
-          let free_in_prim =
-            Name_occurrences.downgrade_occurrences_at_strictly_greater_kind
-              (Flambda_primitive.Eligible_for_cse.free_names prim)
-              Name_mode.in_types
-          in
-          Name_occurrences.add_name free_in_prim
-            name Name_mode.in_types))
-    cse
-    free_names_equations
+  let free_names =
+    Flambda_primitive.Eligible_for_cse.Map.fold
+      (fun prim (bound_to : Simple.t) acc ->
+        Simple.pattern_match bound_to
+          ~const:(fun _ -> acc)
+          ~name:(fun name ->
+            let free_in_prim =
+              Name_occurrences.downgrade_occurrences_at_strictly_greater_kind
+                (Flambda_primitive.Eligible_for_cse.free_names prim)
+                Name_mode.in_types
+            in
+            Name_occurrences.add_name free_in_prim
+              name Name_mode.in_types))
+      cse
+      free_names_equations
+  in
+  Variable.Map.fold (fun _var proj free_names ->
+      Name_occurrences.union free_names
+        (Symbol_projection.free_names proj))
+    symbol_projections
+    free_names
 
 let empty () =
   { defined_vars = Variable.Map.empty;
     binding_times = Binding_time.Map.empty;
     equations = Name.Map.empty;
     cse = Flambda_primitive.Eligible_for_cse.Map.empty;
+    symbol_projections = Variable.Map.empty;
   }
 
-let is_empty { defined_vars; binding_times; equations; cse; } =
+let is_empty
+      { defined_vars; binding_times; equations; cse;
+        symbol_projections; } =
   Variable.Map.is_empty defined_vars
     && Binding_time.Map.is_empty binding_times
     && Name.Map.is_empty equations
     && Flambda_primitive.Eligible_for_cse.Map.is_empty cse
+    && Variable.Map.is_empty symbol_projections
 
 let equations t = t.equations
 
 let cse t = t.cse
+
+let symbol_projections t = t.symbol_projections
+
+let add_symbol_projection t var proj =
+  let symbol_projections =
+    Variable.Map.add var proj t.symbol_projections
+  in
+  { t with symbol_projections; }
 
 let add_definition t var kind binding_time =
   if !Clflags.flambda_invariant_checks
@@ -265,6 +295,7 @@ let one_equation name ty =
     binding_times = Binding_time.Map.empty;
     equations = Name.Map.singleton name ty;
     cse = Flambda_primitive.Eligible_for_cse.Map.empty;
+    symbol_projections = Variable.Map.empty;
   }
 
 let add_or_replace_equation t name ty =
@@ -321,10 +352,16 @@ let concat (t1 : t) (t2 : t) =
       t1.cse
       t2.cse
   in
+  let symbol_projections =
+    Variable.Map.union (fun _var _proj1 proj2 -> Some proj2)
+      t1.symbol_projections
+      t2.symbol_projections
+  in
   { defined_vars;
     binding_times;
     equations;
     cse;
+    symbol_projections;
   }
 
 let meet_equation0 env t name typ =
@@ -438,7 +475,6 @@ let meet0 env (t1 : t) (t2 : t) =
       (t, env)
   in
   let cse =
-    (* CR mshinwell: Add [Map.inter] (also used elsewhere) *)
     Flambda_primitive.Eligible_for_cse.Map.merge (fun _ simple1 simple2 ->
         match simple1, simple2 with
         | None, None | None, Some _ | Some _, None -> None
@@ -447,7 +483,19 @@ let meet0 env (t1 : t) (t2 : t) =
           else None)
       t1.cse t2.cse
   in
-  { t with cse; }
+  let symbol_projections =
+    Variable.Map.merge (fun _ proj1 proj2 ->
+        match proj1, proj2 with
+        | None, None | None, Some _ | Some _, None -> None
+        | Some proj1, Some proj2 ->
+          if Symbol_projection.equal proj1 proj2 then Some proj1
+          else None)
+      t1.symbol_projections t2.symbol_projections
+  in
+  { t with
+    cse;
+    symbol_projections;
+  }
 
 let meet env t1 t2 =
   (* Care: the domains of [t1] and [t2] are treated as contravariant.
@@ -797,7 +845,8 @@ let join_cse envs_with_levels cse ~allowed =
      Name.Map.empty,
      allowed)
 
-let construct_joined_level envs_with_levels ~allowed ~joined_types ~cse =
+let construct_joined_level envs_with_levels ~env_at_fork ~allowed
+      ~joined_types ~cse =
   let module EP = Flambda_primitive.Eligible_for_cse in
   let defined_vars, binding_times =
     List.fold_left (fun (defined_vars, binding_times)
@@ -854,10 +903,28 @@ let construct_joined_level envs_with_levels ~allowed ~joined_types ~cse =
           ~name:(fun name -> Name_occurrences.mem_name allowed name))
       cse
   in
+  let symbol_projections =
+    List.fold_left (fun symbol_projections (_env_at_use, _id, _use_kind, t) ->
+        let projs_this_level =
+          Variable.Map.filter (fun var _ ->
+              let name = Name.var var in
+              Typing_env.mem ~min_name_mode:Name_mode.normal env_at_fork name
+                || Name_occurrences.mem_name allowed name)
+            t.symbol_projections
+        in
+        Variable.Map.union (fun _var proj1 proj2 ->
+            if Symbol_projection.equal proj1 proj2 then Some proj1
+            else None)
+          symbol_projections
+          projs_this_level)
+      Variable.Map.empty
+      envs_with_levels
+  in
   { defined_vars;
     binding_times;
     equations;
     cse;
+    symbol_projections;
   }
 
 let check_join_inputs ~env_at_fork _envs_with_levels ~params
@@ -1043,7 +1110,10 @@ let join ~env_at_fork envs_with_levels ~params
   *)
   (* Having calculated which equations to propagate, the resulting level can
      now be constructed. *)
-  let t = construct_joined_level envs_with_levels ~allowed ~joined_types ~cse in
+  let t =
+    construct_joined_level envs_with_levels ~env_at_fork ~allowed
+      ~joined_types ~cse
+  in
   (*
   Format.eprintf "Join result:@ %a\n%!" print t;
   *)
@@ -1077,7 +1147,13 @@ let all_ids_for_export t =
     Ids_for_export.add_simple ids simple
   in
   let ids = Flambda_primitive.Eligible_for_cse.Map.fold cse t.cse ids in
-  ids
+  let symbol_projection var proj ids =
+    let ids =
+      Ids_for_export.union ids (Symbol_projection.all_ids_for_export proj)
+    in
+    Ids_for_export.add_variable ids var
+  in
+  Variable.Map.fold symbol_projection t.symbol_projections ids
 
 let import _import_map _t =
   Misc.fatal_error "Import not implemented on Typing_env_level"

--- a/middle_end/flambda/types/env/typing_env_level.rec.mli
+++ b/middle_end/flambda/types/env/typing_env_level.rec.mli
@@ -60,6 +60,10 @@ val add_cse
   -> bound_to:Simple.t
   -> t
 
+val add_symbol_projection : t -> Variable.t -> Symbol_projection.t -> t
+
+val symbol_projections : t -> Symbol_projection.t Variable.Map.t
+
 val concat : t -> t -> t
 
 val meet : Meet_env.t -> t -> t -> t

--- a/middle_end/flambda/types/flambda_type.mli
+++ b/middle_end/flambda/types/flambda_type.mli
@@ -94,6 +94,10 @@ module Typing_env : sig
 
   val add_symbol_definitions : t -> Symbol.Set.t -> t
 
+  val add_symbol_projection : t -> Variable.t -> Symbol_projection.t -> t
+
+  val find_symbol_projection : t -> Variable.t -> Symbol_projection.t option
+
   val add_equation : t -> Name.t -> flambda_type -> t
 
   val add_equations_on_params
@@ -573,6 +577,7 @@ type reification_result = private
 
 val reify
    : ?allowed_if_free_vars_defined_in:Typing_env.t
+  -> ?additional_free_var_criterion:(Variable.t -> bool)
   -> ?disallowed_free_vars:Variable.Set.t
   -> ?allow_unique:bool
   -> Typing_env.t

--- a/middle_end/flambda/types/template/flambda_type.templ.ml
+++ b/middle_end/flambda/types/template/flambda_type.templ.ml
@@ -722,14 +722,19 @@ type reification_result =
 
 (* CR mshinwell: Think more to identify all the cases that should be
    in this function. *)
-let reify ?allowed_if_free_vars_defined_in ?disallowed_free_vars
-      ?(allow_unique = false)
+let reify ?allowed_if_free_vars_defined_in ?additional_free_var_criterion
+      ?disallowed_free_vars ?(allow_unique = false)
       env ~min_name_mode t : reification_result =
   let var_allowed var =
     match allowed_if_free_vars_defined_in with
     | None -> false
     | Some allowed_if_free_vars_defined_in ->
-      Typing_env.mem ~min_name_mode allowed_if_free_vars_defined_in (Name.var var)
+      Typing_env.mem ~min_name_mode allowed_if_free_vars_defined_in
+          (Name.var var)
+        && begin match additional_free_var_criterion with
+           | None -> true
+           | Some criterion -> criterion var
+           end
         && match disallowed_free_vars with
            | None -> true
            | Some disallowed_free_vars ->

--- a/utils/lmap.ml
+++ b/utils/lmap.ml
@@ -33,6 +33,7 @@ module type S = sig
   val map_sharing: ('a -> 'a) -> 'a t -> 'a t
   val filter_map: 'a t -> f:(key -> 'a -> 'b option) -> 'b t
   val to_seq : 'a t -> (key * 'a) Seq.t
+  val exists : (key -> 'a -> bool) -> 'a t -> bool
   val add_seq : (key * 'a) Seq.t -> 'a t -> 'a t
   val of_seq : (key * 'a) Seq.t -> 'a t
 
@@ -56,6 +57,7 @@ module Make (T : Thing) : S with type key = T.t = struct
   let iter f m = List.iter (fun (k, v) -> f k v) m
   let fold f m b = List.fold_left (fun b (k, v) -> f k v b) b m
   let filter p m = List.filter (fun (k, v) -> p k v) m
+  let exists f m = List.exists (fun (k, v) -> f k v) m
   let keys m = List.map fst m
   let data m = List.map snd m
   let bindings m = m

--- a/utils/lmap.mli
+++ b/utils/lmap.mli
@@ -57,10 +57,10 @@ module type S = sig
   (** The key should not already exist in the map; this is not checked. *)
   val add : key -> 'a -> 'a t -> 'a t
   val singleton : key -> 'a -> 'a t
-  
+
   (** Unlike [disjoint_union] on maps, the disjointness is not checked. *)
   val disjoint_union : 'a t -> 'a t -> 'a t
-  
+
   (** The given maps must be pairwise disjoint, which is not checked. *)
   val disjoint_union_many: 'a t list -> 'a t
   val iter : (key -> 'a -> unit) -> 'a t -> unit
@@ -69,7 +69,7 @@ module type S = sig
   val keys : _ t -> key list
   val data : 'a t -> 'a list
   val bindings : 'a t -> (key * 'a) list
-  
+
   (** Keys in the list must be distinct, which is not checked. *)
   val of_list : (key * 'a) list -> 'a t
   val find : key -> 'a t -> 'a
@@ -81,11 +81,13 @@ module type S = sig
   val map_sharing: ('a -> 'a) -> 'a t -> 'a t
   val filter_map: 'a t -> f:(key -> 'a -> 'b option) -> 'b t
   val to_seq : 'a t -> (key * 'a) Seq.t
-  
+
+  val exists : (key -> 'a -> bool) -> 'a t -> bool
+
   (** Keys in the sequence must be distinct from each other and from keys
       already in the map; neither of these conditions is checked. *)
   val add_seq : (key * 'a) Seq.t -> 'a t -> 'a t
-  
+
   (** Keys in the sequence must be distinct, which is not checked. *)
   val of_seq : (key * 'a) Seq.t -> 'a t
 


### PR DESCRIPTION
This patch adjusts `DE` and the typing environment to keep track of variables that are known to be equal to projections from symbols.  Two types of projections are supported: normal field projection from blocks, and projection of environment entries from sets of closures (`Project_var`).

The criteria for lifting a value (which is either done via reification, or explicitly in `Simplify_set_of_closures`) have now been changed to:
- the value's structure must be statically-known;
- any variables involved must either be defined at toplevel, or be equal to projections from symbols.

(This differs from previously not only with regard to the symbol projections, but also because previously, the position in the code where a potentially-liftable value was mattered.  That now does not matter; what matters is where the variables were defined that were involved in its construction, etc.)

The information about symbol projections involved in construction of lifted values is propagated to the point at which such values are placed in the code.  At that point, each projection is checked to see if it is projecting from a symbol currently being defined (typically another in the same mutually-recursive group of closures, as determined by `Sort_lifted_constants`).  If this is the case, then the projection is statically evaluated to a `Simple`.  Otherwise a new binding is inserted.  There shouldn't be any problem with the positioning of such projections relative to the constant definitions because the only recursive cases that should arise are handled by the static evaluation of the projections.

Some new examples have been added (`flambdatest/mlexamples/symbol_projection*.ml`).

This PR also removes the duplicate reification in `Simplify_named` (the second reification of which used to be used for the now-removed `-flambda-lift-toplevel-inconstants` option).