### PR TITLE
Stop frame descriptor overflow

### DIFF
--- a/asmcomp/emitaux.ml
+++ b/asmcomp/emitaux.ml
@@ -191,9 +191,10 @@ let emit_frames a =
         then 3 else 2
     in
     a.efa_code_label fd.fd_lbl;
-    a.efa_16 (fd.fd_frame_size + flags);
-    a.efa_16 (List.length fd.fd_live_offset);
-    List.iter a.efa_16 fd.fd_live_offset;
+    a.efa_32 (Int32.of_int (fd.fd_frame_size + flags));
+    let num_live = List.length fd.fd_live_offset in
+    a.efa_32 (Int32.of_int num_live);
+    List.iter (fun ofs -> a.efa_32 (Int32.of_int ofs)) fd.fd_live_offset;
     begin match fd.fd_debuginfo with
     | _ when flags = 0 ->
       ()

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -702,8 +702,8 @@ G(caml_system__code_end):
 G(caml_system__frametable):
         .quad   1           /* one descriptor */
         .quad   LBL(107)    /* return address into callback */
-        .value  -1          /* negative frame size => use callback link */
-        .value  0           /* no roots here */
+        .long   -1          /* negative frame size => use callback link */
+        .long   0           /* no roots here */
         .align  EIGHT_ALIGN
         .quad   16
         .quad   0

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -45,9 +45,9 @@ frame_descr * caml_next_frame_descriptor(uintnat * pc, char ** sp)
       h = (h+1) & caml_frame_descriptors_mask;
     }
     /* Skip to next frame */
-    if (d->frame_size != 0xFFFF) {
+    if (d->frame_size != 0xFFFFFFFF) {
       /* Regular frame, update sp/pc and return the frame descriptor */
-      *sp += (d->frame_size & 0xFFFC);
+      *sp += (d->frame_size & 0xFFFFFFFC);
       *pc = Saved_return_address(*sp);
 #ifdef Mask_already_scanned
       *pc = Mask_already_scanned(*pc);

--- a/runtime/caml/stack.h
+++ b/runtime/caml/stack.h
@@ -85,9 +85,9 @@ struct caml_context {
 
 typedef struct {
   uintnat retaddr;
-  unsigned short frame_size;
-  unsigned short num_live;
-  unsigned short live_ofs[1 /* num_live */];
+  unsigned int frame_size;
+  unsigned int num_live;
+  unsigned int live_ofs[1 /* num_live */];
   /*
     If frame_size & 2, then allocation info follows:
   unsigned char num_allocs;

--- a/runtime/roots_nat.c
+++ b/runtime/roots_nat.c
@@ -247,8 +247,8 @@ void caml_oldify_local_roots (void)
   frame_descr * d;
   uintnat h;
   intnat i, j;
-  int n, ofs;
-  unsigned short * p;
+  unsigned int n, ofs;
+  unsigned int * p;
   value * glob;
   value * root;
   struct caml__roots_block *lr;
@@ -288,7 +288,7 @@ void caml_oldify_local_roots (void)
         if (d->retaddr == retaddr) break;
         h = (h+1) & caml_frame_descriptors_mask;
       }
-      if (d->frame_size != 0xFFFF) {
+      if (d->frame_size != 0xFFFFFFFF) {
         /* Scan the roots in this frame */
         for (p = d->live_ofs, n = d->num_live; n > 0; n--, p++) {
           ofs = *p;
@@ -300,7 +300,7 @@ void caml_oldify_local_roots (void)
           Oldify (root);
         }
         /* Move to next frame */
-        sp += (d->frame_size & 0xFFFC);
+        sp += (d->frame_size & 0xFFFFFFFC);
         retaddr = Saved_return_address(sp);
 #ifdef Already_scanned
         /* Stop here if the frame has been scanned during earlier GCs  */
@@ -448,8 +448,10 @@ void caml_do_local_roots(scanning_action f, char * bottom_of_stack,
   value * regs;
   frame_descr * d;
   uintnat h;
-  int i, j, n, ofs;
-  unsigned short * p;
+  int i, j;
+  unsigned int n;
+  unsigned int ofs;
+  unsigned int * p;
   value * root;
   struct caml__roots_block *lr;
 
@@ -465,7 +467,7 @@ void caml_do_local_roots(scanning_action f, char * bottom_of_stack,
         if (d->retaddr == retaddr) break;
         h = (h+1) & caml_frame_descriptors_mask;
       }
-      if (d->frame_size != 0xFFFF) {
+      if (d->frame_size != 0xFFFFFFFF) {
         /* Scan the roots in this frame */
         for (p = d->live_ofs, n = d->num_live; n > 0; n--, p++) {
           ofs = *p;
@@ -477,7 +479,7 @@ void caml_do_local_roots(scanning_action f, char * bottom_of_stack,
           f (*root, root);
         }
         /* Move to next frame */
-        sp += (d->frame_size & 0xFFFC);
+        sp += (d->frame_size & 0xFFFFFFFC);
         retaddr = Saved_return_address(sp);
 #ifdef Mask_already_scanned
         retaddr = Mask_already_scanned(retaddr);

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -81,7 +81,7 @@ void caml_garbage_collection(void)
       h = (h + 1) & caml_frame_descriptors_mask;
     }
     /* Must be an allocation frame */
-    CAMLassert(d && d->frame_size != 0xFFFF && (d->frame_size & 2));
+    CAMLassert(d && d->frame_size != 0xFFFFFFFF && (d->frame_size & 2));
   }
 
   /* Compute the total allocation size at this point,


### PR DESCRIPTION
This is a temporary patch as I think Stephen Dolan has plans for a more efficient representation.  We've had a few cases where Flambda 2 is generating large stack frames, probably caused by large module initialisers.  I still suspect we might need some kind of construct to allow incremental patching of symbols to avoid this.  Some more detailed investigation is needed at some point.  The problem with large frames is that they can cause overflow in the 16-bit fields in the frame descriptors.  Stephen said to me he'd already thought about fixing this, so I think this problem has already arisen in a non-Flambda 2 context too.  We should also fix the compiler so that it causes an error if a descriptor's field is going to overflow, since at least the GNU assembler truncates the field with only a warning, not an error.