### PR TITLE
Fix bug in checking unboxability of variants

### DIFF
--- a/flambdatest/mlexamples/join_match.ml
+++ b/flambdatest/mlexamples/join_match.ml
@@ -1,0 +1,17 @@
+type t =
+  | A of int
+  | B of int
+  | C of int
+
+let[@inline always] g t =
+  match t with
+  | A x -> x + 1
+  | B x -> x * 2
+  | C x -> x * 42
+
+let bar x =
+  let t =
+    if x < 0 then A x
+    else B x
+  in
+  g t

--- a/middle_end/flambda/types/template/flambda_type.templ.ml
+++ b/middle_end/flambda/types/template/flambda_type.templ.ml
@@ -504,10 +504,15 @@ let prove_variant env t : variant_proof proof_allowing_kind_mismatch =
     begin match blocks_imms.immediates with
     | Unknown -> Unknown
     | Known imms ->
-      match prove_naked_immediates env imms with
+      let const_ctors : _ Or_unknown.t =
+        match prove_naked_immediates env imms with
+        | Unknown -> Unknown
+        | Invalid -> Known Target_imm.Set.empty
+        | Proved const_ctors -> Known const_ctors
+      in
+      match const_ctors with
       | Unknown -> Unknown
-      | Invalid -> Invalid
-      | Proved const_ctors ->
+      | Known const_ctors ->
         let valid =
           Target_imm.Set.for_all Target_imm.is_non_negative const_ctors
         in


### PR DESCRIPTION
If a variant type didn't have any constant constructors, we wouldn't unbox it...