### PR TITLE
Fix handling of continuation uses env

### DIFF
--- a/flambdatest/mlexamples/from_odoc_texi.ml
+++ b/flambdatest/mlexamples/from_odoc_texi.ml
@@ -1,0 +1,12 @@
+type 'a ref = { mutable contents : 'a; }
+external ref : 'a -> 'a ref = "%makemutable"
+let (!) { contents; } = contents
+
+let esc_8bits = ref false
+
+external opaque : 'a -> 'a = "%opaque"
+let[@inline never] foo x = opaque x
+
+let y =
+  if !esc_8bits then [(foo "a", "b"); ]
+  else []

--- a/middle_end/flambda/simplify/env/continuation_uses_env.ml
+++ b/middle_end/flambda/simplify/env/continuation_uses_env.ml
@@ -75,3 +75,19 @@ let num_continuation_uses t cont =
   match Continuation.Map.find cont t.continuation_uses with
   | exception Not_found -> 0
   | uses -> Continuation_uses.number_of_uses uses
+
+let all_continuations_used t =
+  Continuation.Map.keys t.continuation_uses
+
+let union t1 t2 =
+  let continuation_uses =
+    Continuation.Map.union
+      (fun _ uses1 uses2 -> Some (Continuation_uses.union uses1 uses2))
+      t1.continuation_uses
+      t2.continuation_uses
+  in
+  { continuation_uses; }
+
+let remove t cont =
+  { continuation_uses = Continuation.Map.remove cont t.continuation_uses;
+  }

--- a/middle_end/flambda/simplify/env/continuation_uses_env.mli
+++ b/middle_end/flambda/simplify/env/continuation_uses_env.mli
@@ -28,3 +28,7 @@ include Continuation_uses_env_intf.S with type t := t
 
 (* CR mshinwell: refine interface *)
 val get_uses : t -> Continuation_uses.t Continuation.Map.t
+
+val remove : t -> Continuation.t -> t
+
+val union : t -> t -> t

--- a/middle_end/flambda/simplify/env/continuation_uses_env_intf.ml
+++ b/middle_end/flambda/simplify/env/continuation_uses_env_intf.ml
@@ -49,4 +49,6 @@ module type S = sig
     -> Continuation_env_and_param_types.t
 
   val num_continuation_uses : t -> Continuation.t -> int
+
+  val all_continuations_used : t -> Continuation.Set.t
 end

--- a/middle_end/flambda/simplify/env/downwards_acc.ml
+++ b/middle_end/flambda/simplify/env/downwards_acc.ml
@@ -174,3 +174,6 @@ let used_closure_vars t = t.used_closure_vars
 
 let with_used_closure_vars t ~used_closure_vars =
   { t with used_closure_vars; }
+
+let all_continuations_used t =
+  CUE.all_continuations_used t.continuation_uses_env

--- a/middle_end/flambda/simplify/env/simplify_envs.ml
+++ b/middle_end/flambda/simplify/env/simplify_envs.ml
@@ -394,6 +394,13 @@ end = struct
   let add_parameters_with_unknown_types ?at_unit_toplevel t params =
     fst (add_parameters_with_unknown_types' ?at_unit_toplevel t params)
 
+  let mark_parameters_as_toplevel t params =
+    let variables_defined_at_toplevel =
+      Variable.Set.union t.variables_defined_at_toplevel
+        (KP.List.var_set params)
+    in
+    { t with variables_defined_at_toplevel; }
+
   let extend_typing_environment t env_extension =
     let typing_env = TE.add_env_extension t.typing_env env_extension in
     { t with

--- a/middle_end/flambda/simplify/env/simplify_envs_intf.ml
+++ b/middle_end/flambda/simplify/env/simplify_envs_intf.ml
@@ -143,6 +143,8 @@ module type Downwards_env = sig
     -> Kinded_parameter.t list
     -> t * (Flambda_type.t list)
 
+  val mark_parameters_as_toplevel : t -> Kinded_parameter.t list -> t
+
   val extend_typing_environment : t -> Flambda_type.Typing_env_extension.t -> t
 
   val with_typing_env : t -> Flambda_type.Typing_env.t -> t

--- a/middle_end/flambda/simplify/typing_helpers/continuation_uses.ml
+++ b/middle_end/flambda/simplify/typing_helpers/continuation_uses.ml
@@ -71,6 +71,14 @@ let add_use t kind ~env_at_use id ~arg_types =
     raise Misc.Fatal_error
   end
 
+let union t1 t2 =
+  assert (Continuation.equal t1.continuation t2.continuation);
+  assert (Flambda_arity.equal t1.arity t2.arity);
+  { continuation = t1.continuation;
+    arity = t1.arity;
+    uses = t1.uses @ t2.uses;
+  }
+
 let number_of_uses t = List.length t.uses
 
 let arity t = t.arity

--- a/middle_end/flambda/simplify/typing_helpers/continuation_uses.mli
+++ b/middle_end/flambda/simplify/typing_helpers/continuation_uses.mli
@@ -55,3 +55,5 @@ val arity : t -> Flambda_arity.t
 val get_typing_env_no_more_than_one_use
    : t
   -> Flambda_type.Typing_env.t option
+
+val union : t -> t -> t


### PR DESCRIPTION
This patch fixes the handling of the continuation uses environment, which was collecting stale information.  The information needs to be accurate to avoid using `Expr.free_names` for the toplevel check, which this patch also does.