### PR TITLE
Remove uses of Expr.free_names in Un_cps

### DIFF
--- a/.depend
+++ b/.depend
@@ -4573,6 +4573,7 @@ middle_end/flambda/cmx/contains_ids.cmo : \
 middle_end/flambda/cmx/contains_ids.cmx : \
     middle_end/flambda/cmx/ids_for_export.cmx
 middle_end/flambda/cmx/exported_code.cmo : \
+    middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     utils/misc.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
@@ -4582,6 +4583,7 @@ middle_end/flambda/cmx/exported_code.cmo : \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/cmx/exported_code.cmi
 middle_end/flambda/cmx/exported_code.cmx : \
+    middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     utils/misc.cmx \
     middle_end/flambda/basic/kinded_parameter.cmx \
@@ -5526,6 +5528,7 @@ middle_end/flambda/naming/name_mode.cmi : \
 middle_end/flambda/naming/name_occurrences.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/var_within_closure.cmi \
+    middle_end/flambda/naming/num_occurrences.cmi \
     middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/basic/name.cmi \
@@ -5538,6 +5541,7 @@ middle_end/flambda/naming/name_occurrences.cmo : \
 middle_end/flambda/naming/name_occurrences.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
     middle_end/flambda/basic/var_within_closure.cmx \
+    middle_end/flambda/naming/num_occurrences.cmx \
     middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/basic/name.cmx \
@@ -5551,6 +5555,7 @@ middle_end/flambda/naming/name_occurrences.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
+    middle_end/flambda/naming/num_occurrences.cmi \
     middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/basic/name.cmi \
@@ -5572,6 +5577,11 @@ middle_end/flambda/naming/name_permutation.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/name.cmi \
     middle_end/flambda/basic/continuation.cmi
+middle_end/flambda/naming/num_occurrences.cmo : \
+    middle_end/flambda/naming/num_occurrences.cmi
+middle_end/flambda/naming/num_occurrences.cmx : \
+    middle_end/flambda/naming/num_occurrences.cmi
+middle_end/flambda/naming/num_occurrences.cmi :
 middle_end/flambda/naming/permutation.cmo : \
     utils/identifiable.cmi \
     middle_end/flambda/naming/permutation.cmi
@@ -5930,7 +5940,6 @@ middle_end/flambda/simplify/simplify.cmo : \
     middle_end/flambda/terms/call_kind.cmi \
     middle_end/flambda/terms/bound_symbols.cmi \
     middle_end/flambda/naming/bindable_let_bound.cmi \
-    middle_end/flambda/basic/apply_cont_rewrite_id.cmi \
     middle_end/flambda/simplify/basic/apply_cont_rewrite.cmi \
     middle_end/flambda/simplify/simplify.cmi
 middle_end/flambda/simplify/simplify.cmx : \
@@ -5997,7 +6006,6 @@ middle_end/flambda/simplify/simplify.cmx : \
     middle_end/flambda/terms/call_kind.cmx \
     middle_end/flambda/terms/bound_symbols.cmx \
     middle_end/flambda/naming/bindable_let_bound.cmx \
-    middle_end/flambda/basic/apply_cont_rewrite_id.cmx \
     middle_end/flambda/simplify/basic/apply_cont_rewrite.cmx \
     middle_end/flambda/simplify/simplify.cmi
 middle_end/flambda/simplify/simplify.cmi : \
@@ -6107,6 +6115,7 @@ middle_end/flambda/simplify/simplify_binary_primitive.cmo : \
     utils/misc.cmi \
     utils/identifiable.cmi \
     middle_end/flambda/types/flambda_type.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     lambda/debuginfo.cmi \
     middle_end/flambda/simplify/simplify_binary_primitive.cmi
 middle_end/flambda/simplify/simplify_binary_primitive.cmx : \
@@ -6127,6 +6136,7 @@ middle_end/flambda/simplify/simplify_binary_primitive.cmx : \
     utils/misc.cmx \
     utils/identifiable.cmx \
     middle_end/flambda/types/flambda_type.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     lambda/debuginfo.cmx \
     middle_end/flambda/simplify/simplify_binary_primitive.cmi
 middle_end/flambda/simplify/simplify_binary_primitive.cmi : \
@@ -6294,11 +6304,9 @@ middle_end/flambda/simplify/simplify_let_cont_expr.rec.cmo : \
     middle_end/flambda/naming/name_occurrences.cmi \
     utils/misc.cmi \
     middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/simplify/env/continuation_uses_env.cmi \
     middle_end/flambda/basic/continuation_extra_params_and_args.cmi \
     middle_end/flambda/simplify/env/continuation_env_and_param_types.cmi \
     middle_end/flambda/basic/continuation.cmi \
-    middle_end/flambda/basic/apply_cont_rewrite_id.cmi \
     middle_end/flambda/simplify/basic/apply_cont_rewrite.cmi \
     middle_end/flambda/simplify/simplify_let_cont_expr.rec.cmi
 middle_end/flambda/simplify/simplify_let_cont_expr.rec.cmx : \
@@ -6309,11 +6317,9 @@ middle_end/flambda/simplify/simplify_let_cont_expr.rec.cmx : \
     middle_end/flambda/naming/name_occurrences.cmx \
     utils/misc.cmx \
     middle_end/flambda/terms/flambda.cmx \
-    middle_end/flambda/simplify/env/continuation_uses_env.cmx \
     middle_end/flambda/basic/continuation_extra_params_and_args.cmx \
     middle_end/flambda/simplify/env/continuation_env_and_param_types.cmx \
     middle_end/flambda/basic/continuation.cmx \
-    middle_end/flambda/basic/apply_cont_rewrite_id.cmx \
     middle_end/flambda/simplify/basic/apply_cont_rewrite.cmx \
     middle_end/flambda/simplify/simplify_let_cont_expr.rec.cmi
 middle_end/flambda/simplify/simplify_let_cont_expr.rec.cmi : \
@@ -7312,16 +7318,28 @@ middle_end/flambda/terms/continuation_handlers.rec.cmi : \
     middle_end/flambda/naming/contains_names.cmo \
     middle_end/flambda/cmx/contains_ids.cmo
 middle_end/flambda/terms/continuation_params_and_handler.rec.cmo : \
+    middle_end/flambda/compilenv_deps/variable.cmi \
     utils/printing_cache.cmi \
+    middle_end/flambda/types/basic/or_unknown.cmi \
+    middle_end/flambda/naming/num_occurrences.cmi \
+    middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_abstraction.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/terms/continuation_params_and_handler.rec.cmi
 middle_end/flambda/terms/continuation_params_and_handler.rec.cmx : \
+    middle_end/flambda/compilenv_deps/variable.cmx \
     utils/printing_cache.cmx \
+    middle_end/flambda/types/basic/or_unknown.cmx \
+    middle_end/flambda/naming/num_occurrences.cmx \
+    middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_abstraction.cmx \
     middle_end/flambda/basic/kinded_parameter.cmx \
     middle_end/flambda/terms/continuation_params_and_handler.rec.cmi
 middle_end/flambda/terms/continuation_params_and_handler.rec.cmi : \
+    middle_end/flambda/compilenv_deps/variable.cmi \
+    middle_end/flambda/types/basic/or_unknown.cmi \
+    middle_end/flambda/naming/num_occurrences.cmi \
+    middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/basic/expr_std.cmo \
     middle_end/flambda/cmx/contains_ids.cmo
@@ -7389,8 +7407,10 @@ middle_end/flambda/terms/flambda.cmo : \
     middle_end/flambda/basic/recursive.cmi \
     utils/printing_cache.cmi \
     middle_end/flambda/basic/or_variable.cmi \
+    middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/basic/or_deleted.cmi \
     utils/numbers.cmi \
+    middle_end/flambda/naming/num_occurrences.cmi \
     middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
@@ -7442,8 +7462,10 @@ middle_end/flambda/terms/flambda.cmx : \
     middle_end/flambda/basic/recursive.cmx \
     utils/printing_cache.cmx \
     middle_end/flambda/basic/or_variable.cmx \
+    middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/basic/or_deleted.cmx \
     utils/numbers.cmx \
+    middle_end/flambda/naming/num_occurrences.cmx \
     middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
@@ -7494,8 +7516,10 @@ middle_end/flambda/terms/flambda.cmi : \
     middle_end/flambda/basic/recursive.cmi \
     utils/printing_cache.cmi \
     middle_end/flambda/basic/or_variable.cmi \
+    middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/basic/or_deleted.cmi \
     utils/numbers.cmi \
+    middle_end/flambda/naming/num_occurrences.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/basic/name.cmi \
     middle_end/flambda/basic/mutability.cmi \
@@ -7581,16 +7605,18 @@ middle_end/flambda/terms/flambda_primitive.cmi : \
     middle_end/flambda/basic/coeffects.cmi \
     middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/terms/flambda_unit.cmo : \
+    middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/naming/name_occurrences.cmi \
+    middle_end/flambda/types/basic/or_unknown.cmi \
     utils/misc.cmi \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/naming/bindable_let_bound.cmi \
     middle_end/flambda/terms/flambda_unit.cmi
 middle_end/flambda/terms/flambda_unit.cmx : \
+    middle_end/flambda/basic/var_within_closure.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
-    middle_end/flambda/naming/name_occurrences.cmx \
+    middle_end/flambda/types/basic/or_unknown.cmx \
     utils/misc.cmx \
     middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/basic/continuation.cmx \
@@ -7599,6 +7625,7 @@ middle_end/flambda/terms/flambda_unit.cmx : \
 middle_end/flambda/terms/flambda_unit.cmi : \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
+    middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/basic/code_id.cmi \
@@ -7647,6 +7674,8 @@ middle_end/flambda/terms/function_declarations.cmi : \
     middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/terms/function_params_and_body.rec.cmo : \
     utils/printing_cache.cmi \
+    middle_end/flambda/types/basic/or_unknown.cmi \
+    middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_abstraction.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
@@ -7659,6 +7688,8 @@ middle_end/flambda/terms/function_params_and_body.rec.cmo : \
     middle_end/flambda/terms/function_params_and_body.rec.cmi
 middle_end/flambda/terms/function_params_and_body.rec.cmx : \
     utils/printing_cache.cmx \
+    middle_end/flambda/types/basic/or_unknown.cmx \
+    middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_abstraction.cmx \
     middle_end/flambda/basic/kinded_parameter.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
@@ -7671,6 +7702,8 @@ middle_end/flambda/terms/function_params_and_body.rec.cmx : \
     middle_end/flambda/terms/function_params_and_body.rec.cmi
 middle_end/flambda/terms/function_params_and_body.rec.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
+    middle_end/flambda/types/basic/or_unknown.cmi \
+    middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/types/kinds/flambda_arity.cmi \
     middle_end/flambda/basic/expr_std.cmo \
@@ -7681,6 +7714,8 @@ middle_end/flambda/terms/function_params_and_body.rec.cmi : \
 middle_end/flambda/terms/let_cont_expr.rec.cmo : \
     middle_end/flambda/basic/recursive.cmi \
     utils/printing_cache.cmi \
+    middle_end/flambda/types/basic/or_unknown.cmi \
+    middle_end/flambda/naming/num_occurrences.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     utils/misc.cmi \
     middle_end/flambda/basic/continuation.cmi \
@@ -7689,23 +7724,30 @@ middle_end/flambda/terms/let_cont_expr.rec.cmo : \
 middle_end/flambda/terms/let_cont_expr.rec.cmx : \
     middle_end/flambda/basic/recursive.cmx \
     utils/printing_cache.cmx \
+    middle_end/flambda/types/basic/or_unknown.cmx \
+    middle_end/flambda/naming/num_occurrences.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     utils/misc.cmx \
     middle_end/flambda/basic/continuation.cmx \
     utils/clflags.cmx \
     middle_end/flambda/terms/let_cont_expr.rec.cmi
 middle_end/flambda/terms/let_cont_expr.rec.cmi : \
+    middle_end/flambda/types/basic/or_unknown.cmi \
+    middle_end/flambda/naming/num_occurrences.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/basic/expr_std.cmo \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/cmx/contains_ids.cmo
 middle_end/flambda/terms/let_expr.rec.cmo : \
+    middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
     middle_end/flambda/basic/symbol_scoping_rule.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/terms/set_of_closures.cmi \
     utils/printing_cache.cmi \
+    middle_end/flambda/types/basic/or_unknown.cmi \
+    middle_end/flambda/naming/num_occurrences.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/naming/name_abstraction.cmi \
@@ -7721,12 +7763,15 @@ middle_end/flambda/terms/let_expr.rec.cmo : \
     middle_end/flambda/naming/bindable_let_bound.cmi \
     middle_end/flambda/terms/let_expr.rec.cmi
 middle_end/flambda/terms/let_expr.rec.cmx : \
+    middle_end/flambda/compilenv_deps/variable.cmx \
     middle_end/flambda/naming/var_in_binding_pos.cmx \
     middle_end/flambda/basic/symbol_scoping_rule.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/terms/set_of_closures.cmx \
     utils/printing_cache.cmx \
+    middle_end/flambda/types/basic/or_unknown.cmx \
+    middle_end/flambda/naming/num_occurrences.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/naming/name_abstraction.cmx \
@@ -7742,6 +7787,10 @@ middle_end/flambda/terms/let_expr.rec.cmx : \
     middle_end/flambda/naming/bindable_let_bound.cmx \
     middle_end/flambda/terms/let_expr.rec.cmi
 middle_end/flambda/terms/let_expr.rec.cmi : \
+    middle_end/flambda/compilenv_deps/variable.cmi \
+    middle_end/flambda/types/basic/or_unknown.cmi \
+    middle_end/flambda/naming/num_occurrences.cmi \
+    middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/basic/expr_std.cmo \
     middle_end/flambda/cmx/contains_ids.cmo \
     middle_end/flambda/naming/bindable_let_bound.cmi
@@ -7986,8 +8035,9 @@ middle_end/flambda/to_cmm/un_cps.cmo : \
     utils/profile.cmi \
     asmcomp/printcmm.cmi \
     typing/primitive.cmi \
+    middle_end/flambda/types/basic/or_unknown.cmi \
     utils/numbers.cmi \
-    middle_end/flambda/naming/name_occurrences.cmi \
+    middle_end/flambda/naming/num_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/basic/name.cmi \
     utils/misc.cmi \
@@ -8049,8 +8099,9 @@ middle_end/flambda/to_cmm/un_cps.cmx : \
     utils/profile.cmx \
     asmcomp/printcmm.cmx \
     typing/primitive.cmx \
+    middle_end/flambda/types/basic/or_unknown.cmx \
     utils/numbers.cmx \
-    middle_end/flambda/naming/name_occurrences.cmx \
+    middle_end/flambda/naming/num_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/basic/name.cmx \
     utils/misc.cmx \
@@ -8099,6 +8150,7 @@ middle_end/flambda/to_cmm/un_cps.cmi : \
 middle_end/flambda/to_cmm/un_cps_closure.cmo : \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/terms/set_of_closures.cmi \
+    middle_end/flambda/types/basic/or_unknown.cmi \
     utils/numbers.cmi \
     utils/misc.cmi \
     middle_end/flambda/compilenv_deps/linkage_name.cmi \
@@ -8114,6 +8166,7 @@ middle_end/flambda/to_cmm/un_cps_closure.cmo : \
 middle_end/flambda/to_cmm/un_cps_closure.cmx : \
     middle_end/flambda/basic/var_within_closure.cmx \
     middle_end/flambda/terms/set_of_closures.cmx \
+    middle_end/flambda/types/basic/or_unknown.cmx \
     utils/numbers.cmx \
     utils/misc.cmx \
     middle_end/flambda/compilenv_deps/linkage_name.cmx \
@@ -8128,7 +8181,10 @@ middle_end/flambda/to_cmm/un_cps_closure.cmx : \
     middle_end/flambda/to_cmm/un_cps_closure.cmi
 middle_end/flambda/to_cmm/un_cps_closure.cmi : \
     middle_end/flambda/basic/var_within_closure.cmi \
+    middle_end/flambda/basic/simple.cmi \
+    middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/terms/flambda_unit.cmi \
+    middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/cmx/exported_offsets.cmi \
     middle_end/flambda/cmx/exported_code.cmi \
     middle_end/flambda/basic/closure_id.cmi
@@ -8137,6 +8193,8 @@ middle_end/flambda/to_cmm/un_cps_env.cmo : \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/to_cmm/un_cps_helper.cmi \
     middle_end/flambda/to_cmm/un_cps_closure.cmi \
+    middle_end/flambda/types/basic/or_unknown.cmi \
+    middle_end/flambda/naming/num_occurrences.cmi \
     utils/misc.cmi \
     lambda/lambda.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
@@ -8159,6 +8217,8 @@ middle_end/flambda/to_cmm/un_cps_env.cmx : \
     middle_end/flambda/basic/var_within_closure.cmx \
     middle_end/flambda/to_cmm/un_cps_helper.cmx \
     middle_end/flambda/to_cmm/un_cps_closure.cmx \
+    middle_end/flambda/types/basic/or_unknown.cmx \
+    middle_end/flambda/naming/num_occurrences.cmx \
     utils/misc.cmx \
     lambda/lambda.cmx \
     middle_end/flambda/basic/kinded_parameter.cmx \
@@ -8180,6 +8240,8 @@ middle_end/flambda/to_cmm/un_cps_env.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/to_cmm/un_cps_closure.cmi \
+    middle_end/flambda/types/basic/or_unknown.cmi \
+    middle_end/flambda/naming/num_occurrences.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/terms/function_declaration.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,53 +1,13 @@
 {
     "tasks": [
         {
-            "label": "Build world",
-            "type": "shell",
-            "command": "/Users/mark/dev/dune/dune.sh build @world",
-            "group": "build",
-            "problemMatcher": [
-                "$ocamlc"
-            ]
-        },
-        {
-            "label": "Build world (release profile)",
-            "type": "shell",
-            "command": "/Users/mark/dev/dune/dune.sh build @world --profile=release",
-            "group": "build",
-            "problemMatcher": [
-                "$ocamlc"
-            ]
-        },
-        {
             "label": "Build world (Flambda + release profile)",
             "type": "shell",
-            "command": "/Users/mark/dev/dune/dune-4.10-flambda.sh build @world --profile=release",
+            "command": "/Users/mark/dev/dune/dune-4.11.1-flambda.sh build @world --profile=release",
             "group": "build",
             "problemMatcher": [
                 "$ocamlc"
             ]
-        },
-        {
-            "label": "Build ilambdac",
-            "type": "shell",
-            "command": "/Users/mark/dev/dune/dune.sh build ilambdac.exe",
-            "group": {
-                "kind": "build",
-                "isDefault": true
-            },
-            "problemMatcher": [
-                "$ocamlc"
-            ]
-        },
-        {
-            "label": "runtest",
-            "type": "shell",
-            "command": "/Users/mark/dev/dune/dune.sh build @runtest",
-            "group": {
-                "kind": "build",
-                "isDefault": true
-            },
-            "problemMatcher": []
         }
     ]
 }

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -207,6 +207,7 @@ MIDDLE_END_FLAMBDA_BASIC=\
   middle_end/flambda/naming/name_mode.cmo \
   middle_end/flambda/naming/permutation.cmo \
   middle_end/flambda/naming/name_permutation.cmo \
+  middle_end/flambda/naming/num_occurrences.cmo \
   middle_end/flambda/naming/name_occurrences.cmo \
   middle_end/flambda/basic/or_variable.cmo \
   middle_end/flambda/basic/simple.cmo \

--- a/middle_end/flambda/cmx/exported_code.ml
+++ b/middle_end/flambda/cmx/exported_code.ml
@@ -42,11 +42,15 @@ module Calling_convention = struct
     Flambda_arity.equal params_arity1 params_arity2
 
   let compute ~params_and_body =
-    let f ~return_continuation:_ _exn_continuation params ~body ~my_closure =
-      let free_vars = Flambda.Expr.free_names body in
-      let needs_closure_arg = Name_occurrences.mem_var free_vars my_closure in
+    let f ~return_continuation:_ _exn_continuation params ~body:_
+          ~my_closure:_ ~(is_my_closure_used : _ Or_unknown.t) =
+      let is_my_closure_used =
+        match is_my_closure_used with
+        | Unknown -> true
+        | Known is_my_closure_used -> is_my_closure_used
+      in
       let params_arity = Kinded_parameter.List.arity params in
-      { needs_closure_arg; params_arity; }
+      { needs_closure_arg = is_my_closure_used; params_arity; }
     in
     P.pattern_match params_and_body ~f
 end

--- a/middle_end/flambda/from_lambda/lambda_to_flambda_primitives_helpers.ml
+++ b/middle_end/flambda/from_lambda/lambda_to_flambda_primitives_helpers.ml
@@ -230,6 +230,7 @@ let rec bind_rec ~backend exn_cont
       in
       let params_and_handler =
         Continuation_params_and_handler.create [] ~handler
+          ~free_names_of_handler:Unknown
       in
       Continuation_handler.create ~params_and_handler
         ~stub:false
@@ -243,6 +244,7 @@ let rec bind_rec ~backend exn_cont
       in
       let params_and_handler =
         Continuation_params_and_handler.create [] ~handler
+          ~free_names_of_handler:Unknown
       in
       Continuation_handler.create ~params_and_handler
         ~stub:false
@@ -254,6 +256,7 @@ let rec bind_rec ~backend exn_cont
           let condition_passed_cont_handler =
             let params_and_handler =
               Continuation_params_and_handler.create [] ~handler:rest
+                ~free_names_of_handler:Unknown
             in
             Continuation_handler.create ~params_and_handler
               ~stub:false
@@ -273,7 +276,8 @@ let rec bind_rec ~backend exn_cont
                   ])))
           in
           Let_cont.create_non_recursive condition_passed_cont
-            condition_passed_cont_handler ~body)
+            condition_passed_cont_handler ~body
+            ~free_names_of_body:Unknown)
         (Expr.create_apply_cont
            (Apply_cont.create primitive_cont ~args:[] ~dbg:Debuginfo.none))
         validity_conditions
@@ -283,7 +287,9 @@ let rec bind_rec ~backend exn_cont
       ~body:(
         Let_cont.create_non_recursive failure_cont
           failure_cont_handler
-          ~body:check_validity_conditions)
+          ~body:check_validity_conditions
+          ~free_names_of_body:Unknown)
+      ~free_names_of_body:Unknown
 
 and bind_rec_primitive ~backend exn_cont ~register_const_string
       (prim : simple_or_prim)

--- a/middle_end/flambda/inlining/inlining_cost.ml
+++ b/middle_end/flambda/inlining/inlining_cost.ml
@@ -442,7 +442,7 @@ let smaller' denv expr ~than:threshold =
           | Present params_and_body ->
             Function_params_and_body.pattern_match params_and_body
               ~f:(fun ~return_continuation:_ _exn_continuation _params
-                      ~body ~my_closure:_ ->
+                      ~body ~my_closure:_ ~is_my_closure_used:_ ->
                 expr_size denv body)
           | Deleted -> ())
         funs

--- a/middle_end/flambda/inlining/inlining_decision.ml
+++ b/middle_end/flambda/inlining/inlining_decision.ml
@@ -66,7 +66,8 @@ let make_decision_for_function_declaration denv ?params_and_body function_decl
       in
       Function_params_and_body.pattern_match params_and_body
         ~f:(fun ~return_continuation:_ _exn_continuation _params ~body
-                ~my_closure:_ : Function_declaration_decision.t ->
+                ~my_closure:_ ~is_my_closure_used:_
+                : Function_declaration_decision.t ->
           let inlining_threshold : Inlining_cost.Threshold.t =
             let round = DE.round denv in
             let unscaled =

--- a/middle_end/flambda/naming/bindable_let_bound.ml
+++ b/middle_end/flambda/naming/bindable_let_bound.ml
@@ -216,6 +216,11 @@ let must_be_singleton t =
   | Set_of_closures _ | Symbols _ ->
     Misc.fatal_errorf "Bound name is not a [Singleton]:@ %a" print t
 
+let must_be_singleton_opt t =
+  match t with
+  | Singleton var -> Some var
+  | Set_of_closures _ | Symbols _ -> None
+
 let must_be_set_of_closures t =
   match t with
   | Set_of_closures { closure_vars; _ } -> closure_vars

--- a/middle_end/flambda/naming/bindable_let_bound.mli
+++ b/middle_end/flambda/naming/bindable_let_bound.mli
@@ -47,6 +47,8 @@ val symbols : Bound_symbols.t -> Symbol_scoping_rule.t -> t
 
 val must_be_singleton : t -> Var_in_binding_pos.t
 
+val must_be_singleton_opt : t -> Var_in_binding_pos.t option
+
 val must_be_set_of_closures : t -> Var_in_binding_pos.t list
 
 val must_be_symbols : t -> symbols

--- a/middle_end/flambda/naming/name_occurrences.mli
+++ b/middle_end/flambda/naming/name_occurrences.mli
@@ -25,15 +25,6 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
-module Num_occurrences : sig
-  type t = private
-    | Zero
-    | One
-    | More_than_one
-
-  val print : Format.formatter -> t -> unit
-end
-
 type t
 
 val empty : t
@@ -57,6 +48,8 @@ val add_continuation_in_trap_action : t -> Continuation.t -> t
 val count_continuation : t -> Continuation.t -> Num_occurrences.t
 
 val count_variable : t -> Variable.t -> Num_occurrences.t
+
+val count_variable_normal_mode : t -> Variable.t -> Num_occurrences.t
 
 val singleton_variable : Variable.t -> Name_mode.t -> t
 

--- a/middle_end/flambda/naming/num_occurrences.ml
+++ b/middle_end/flambda/naming/num_occurrences.ml
@@ -1,0 +1,28 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Pierre Chambart, OCamlPro                        *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2019--2020 OCamlPro SAS                                    *)
+(*   Copyright 2019--2020 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+type t =
+  | Zero
+  | One
+  | More_than_one
+
+let print ppf t =
+  match t with
+  | Zero -> Format.fprintf ppf "Zero"
+  | One -> Format.fprintf ppf "One"
+  | More_than_one -> Format.fprintf ppf "More_than_one"

--- a/middle_end/flambda/naming/num_occurrences.mli
+++ b/middle_end/flambda/naming/num_occurrences.mli
@@ -5,8 +5,8 @@
 (*                       Pierre Chambart, OCamlPro                        *)
 (*           Mark Shinwell and Leo White, Jane Street Europe              *)
 (*                                                                        *)
-(*   Copyright 2013--2019 OCamlPro SAS                                    *)
-(*   Copyright 2014--2019 Jane Street Group LLC                           *)
+(*   Copyright 2019--2020 OCamlPro SAS                                    *)
+(*   Copyright 2019--2020 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -14,44 +14,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** The Flambda representation of a single compilation unit's code. *)
-
 [@@@ocaml.warning "+a-30-40-41-42"]
 
-type t
+type t =
+  | Zero
+  | One
+  | More_than_one
 
-(** Perform well-formedness checks on the unit. *)
-val invariant : t -> unit
-
-(** Print a unit to a formatter. *)
 val print : Format.formatter -> t -> unit
-
-(** Create a unit. *)
-val create
-   : return_continuation:Continuation.t
-  -> exn_continuation:Continuation.t
-  -> body:Flambda.Expr.t
-  -> module_symbol:Symbol.t
-  -> used_closure_vars:Var_within_closure.Set.t Or_unknown.t
-  -> t
-
-val return_continuation : t -> Continuation.t
-
-val exn_continuation : t -> Continuation.t
-
-val module_symbol : t -> Symbol.t
-
-(** All closure variables used in the given unit. *)
-val used_closure_vars : t -> Var_within_closure.Set.t Or_unknown.t
-
-val body : t -> Flambda.Expr.t
-
-val iter
-   : ?code:(id:Code_id.t
-     -> Flambda.Code.t
-     -> unit)
-  -> ?set_of_closures:(closure_symbols:Symbol.t Closure_id.Lmap.t option
-     -> Flambda.Set_of_closures.t
-     -> unit)
-  -> t
-  -> unit

--- a/middle_end/flambda/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda/parser/fexpr_to_flambda.ml
@@ -484,6 +484,7 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
       in
       let params_and_handler =
         Flambda.Continuation_params_and_handler.create params ~handler
+          ~free_names_of_handler:Unknown
       in
       let handler =
         Flambda.Continuation_handler.create ~params_and_handler
@@ -493,6 +494,7 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
       match recursive with
       | Nonrecursive ->
         Flambda.Let_cont.create_non_recursive name handler ~body
+          ~free_names_of_body:Unknown
       | Recursive ->
         let handlers = Continuation.Map.singleton name handler in
         Flambda.Let_cont.create_recursive handlers ~body
@@ -650,6 +652,7 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
               Flambda.Function_params_and_body.create
                 ~return_continuation
                 exn_continuation params ~body ~my_closure ~dbg
+                ~free_names_of_body:Unknown
             in
             Present params_and_body
         in
@@ -765,3 +768,4 @@ let conv ~backend ~module_ident (fexpr : Fexpr.flambda_unit) : Flambda_unit.t =
     ~exn_continuation
     ~body
     ~module_symbol
+    ~used_closure_vars:Unknown

--- a/middle_end/flambda/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda/parser/flambda_to_fexpr.ml
@@ -610,7 +610,7 @@ and static_let_expr env bound_symbols defining_expr body : Fexpr.expr =
           let params_and_body =
             Flambda.Function_params_and_body.pattern_match params_and_body
               ~f:(fun ~return_continuation exn_continuation params ~body
-                  ~my_closure : Fexpr.params_and_body ->
+                  ~my_closure ~is_my_closure_used:_ : Fexpr.params_and_body ->
                 let ret_cont, env =
                   Env.bind_named_continuation env return_continuation
                 in

--- a/middle_end/flambda/simplify/simplify_apply_expr.rec.ml
+++ b/middle_end/flambda/simplify/simplify_apply_expr.rec.ml
@@ -241,6 +241,7 @@ let simplify_direct_partial_application dacc apply ~callee's_code_id
         ~body
         ~dbg
         ~my_closure
+        ~free_names_of_body:Unknown
     in
     let code_id =
       Code_id.create

--- a/middle_end/flambda/simplify/simplify_let_cont_expr.rec.ml
+++ b/middle_end/flambda/simplify/simplify_let_cont_expr.rec.ml
@@ -66,7 +66,8 @@ let rebuild_one_continuation_handler cont ~at_unit_toplevel
   in
   let params' = used_params @ used_extra_params in
   let handler =
-    CH.with_params_and_handler cont_handler (CPH.create params' ~handler)
+    CH.with_params_and_handler cont_handler
+      (CPH.create params' ~handler ~free_names_of_handler:(Known free_names))
   in
   let rewrite =
     Apply_cont_rewrite.create ~original_params:params
@@ -255,7 +256,11 @@ let rebuild_non_recursive_let_cont cont ~body handler ~uenv_without_cont uacc
   (* The upwards environment of [uacc] is replaced so that out-of-scope
      continuation bindings do not end up in the accumulator. *)
   let uacc = UA.with_uenv uacc uenv_without_cont in
-  let expr = Let_cont.create_non_recursive cont handler ~body in
+  let free_names_of_body = Expr.free_names body in
+  let expr =
+    Let_cont.create_non_recursive cont handler ~body
+      ~free_names_of_body:(Known free_names_of_body)
+  in
   after_rebuild expr uacc
 
 let simplify_non_recursive_let_cont dacc non_rec ~down_to_up =

--- a/middle_end/flambda/simplify/simplify_set_of_closures.rec.ml
+++ b/middle_end/flambda/simplify/simplify_set_of_closures.rec.ml
@@ -345,7 +345,7 @@ let simplify_function context ~used_closure_vars ~shareable_constants
     let params_and_body, dacc_after_body, uacc_after_upwards_traversal =
       Function_params_and_body.pattern_match params_and_body
         ~f:(fun ~return_continuation exn_continuation params ~body
-                ~my_closure ->
+                ~my_closure ~is_my_closure_used:_ ->
           let dacc =
             dacc_inside_function context ~used_closure_vars ~shareable_constants
               ~params ~my_closure closure_id
@@ -384,9 +384,12 @@ let simplify_function context ~used_closure_vars ~shareable_constants
             let dacc_after_body = UA.creation_dacc uacc in
             let dbg = Function_params_and_body.debuginfo params_and_body in
             (* CR mshinwell: Should probably look at [cont_uses]? *)
+            let free_names_of_body = Expr.free_names body in
             let params_and_body =
-              Function_params_and_body.create ~return_continuation
-                exn_continuation params ~dbg ~body ~my_closure
+              Function_params_and_body.create
+                ~free_names_of_body:(Known free_names_of_body)
+                ~return_continuation exn_continuation params ~dbg ~body
+                ~my_closure
             in
             params_and_body, dacc_after_body, uacc
           | exception Misc.Fatal_error ->

--- a/middle_end/flambda/simplify/simplify_switch_expr.rec.ml
+++ b/middle_end/flambda/simplify/simplify_switch_expr.rec.ml
@@ -184,7 +184,8 @@ let rebuild_switch dacc ~arms ~scrutinee ~scrutinee_ty uacc
   in
   let expr =
     List.fold_left (fun body (new_cont, new_handler) ->
-        Let_cont.create_non_recursive new_cont new_handler ~body)
+        Let_cont.create_non_recursive new_cont new_handler ~body
+          ~free_names_of_body:(Known (Expr.free_names body)))
       body
       new_let_conts
   in

--- a/middle_end/flambda/simplify/template/simplify.templ.ml
+++ b/middle_end/flambda/simplify/template/simplify.templ.ml
@@ -101,6 +101,7 @@ let run ~backend ~round unit =
   in
   let unit =
     FU.create ~return_continuation ~exn_continuation ~module_symbol ~body
+      ~used_closure_vars:(Known used_closure_vars)
   in
   { cmx;
     unit;

--- a/middle_end/flambda/terms/continuation_params_and_handler.rec.mli
+++ b/middle_end/flambda/terms/continuation_params_and_handler.rec.mli
@@ -31,11 +31,20 @@ include Contains_ids.S with type t := t
 val create
    : Kinded_parameter.t list
   -> handler:Expr.t
+  -> free_names_of_handler:Name_occurrences.t Or_unknown.t
   -> t
 
 (** Choose a member of the alpha-equivalence class to enable examination
     of the parameters, relations thereon and the code over which they
     are scoped. *)
+val pattern_match'
+   : t
+  -> f:(Kinded_parameter.t list
+    -> num_normal_occurrences_of_params:Num_occurrences.t Variable.Map.t
+    -> handler:Expr.t
+    -> 'a)
+  -> 'a
+
 val pattern_match
    : t
   -> f:(Kinded_parameter.t list

--- a/middle_end/flambda/terms/expr.rec.ml
+++ b/middle_end/flambda/terms/expr.rec.ml
@@ -277,7 +277,10 @@ let create_singleton_let (bound_var : Var_in_binding_pos.t) defining_expr body
   if not keep_binding then body, let_creation_result
   else
     let bound_vars = Bindable_let_bound.singleton bound_var in
-    let let_expr = Let_expr.create bound_vars ~defining_expr ~body in
+    let let_expr =
+      Let_expr.create bound_vars ~defining_expr ~body
+        ~free_names_of_body:(Known free_names_of_body)
+    in
     let free_names =
       let from_defining_expr =
         let from_defining_expr = Named.free_names defining_expr in
@@ -320,7 +323,10 @@ let create_set_of_closures_let ~closure_vars defining_expr body
   then
     body, Have_deleted defining_expr
   else
-    let let_expr = Let_expr.create bound_vars ~defining_expr ~body in
+    let let_expr =
+      Let_expr.create bound_vars ~defining_expr ~body
+        ~free_names_of_body:(Known free_names_of_body)
+    in
     let free_names =
       let from_defining_expr = Named.free_names defining_expr in
       Name_occurrences.union from_defining_expr
@@ -337,7 +343,10 @@ let create_set_of_closures_let ~closure_vars defining_expr body
 let create_let_symbol bindable defining_expr body =
   let free_names_of_body = free_names body in
   let free_names_of_bindable = Bindable_let_bound.free_names bindable in
-  let let_expr = Let_expr.create bindable ~defining_expr ~body in
+  let let_expr =
+    Let_expr.create bindable ~defining_expr ~body
+      ~free_names_of_body:(Known free_names_of_body)
+  in
   let free_names =
     let from_defining_expr = Named.free_names defining_expr in
     Name_occurrences.union from_defining_expr
@@ -383,7 +392,7 @@ let create_invalid ?semantics () =
     match semantics with
     | Some semantics ->
       semantics
-    | None -> 
+    | None ->
       if !Clflags.treat_invalid_code_as_unreachable then
         Treat_as_unreachable
       else

--- a/middle_end/flambda/terms/flambda.mli
+++ b/middle_end/flambda/terms/flambda.mli
@@ -234,6 +234,14 @@ end and Let_expr : sig
     -> f:(Bindable_let_bound.t -> body:Expr.t -> 'a)
     -> 'a
 
+  val pattern_match'
+     : t
+    -> f:(Bindable_let_bound.t
+      -> num_normal_occurrences_of_bound_vars:Num_occurrences.t Variable.Map.t
+      -> body:Expr.t
+      -> 'a)
+    -> 'a
+
   module Pattern_match_pair_error : sig
     type t = Mismatched_let_bindings
 
@@ -282,7 +290,7 @@ end and Let_cont_expr : sig
   type t = private
     | Non_recursive of {
         handler : Non_recursive_let_cont_handler.t;
-        num_free_occurrences : Name_occurrences.Num_occurrences.t;
+        num_free_occurrences : Num_occurrences.t Or_unknown.t;
         (** [num_free_occurrences] can be used, for example, to decide whether
             to inline out a linearly-used continuation.  It will always be
             strictly greater than zero. *)
@@ -299,6 +307,7 @@ end and Let_cont_expr : sig
      : Continuation.t
     -> Continuation_handler.t
     -> body:Expr.t
+    -> free_names_of_body:Name_occurrences.t Or_unknown.t
     -> Expr.t
 
   (** Create a definition of a set of possibly-recursive continuations. *)
@@ -399,11 +408,20 @@ end and Continuation_params_and_handler : sig
   val create
      : Kinded_parameter.t list
     -> handler:Expr.t
+    -> free_names_of_handler:Name_occurrences.t Or_unknown.t
     -> t
 
   (** Choose a member of the alpha-equivalence class to enable examination
       of the parameters, relations thereon and the code over which they
       are scoped. *)
+  val pattern_match'
+     : t
+    -> f:(Kinded_parameter.t list
+      -> num_normal_occurrences_of_params:Num_occurrences.t Variable.Map.t
+      -> handler:Expr.t
+      -> 'a)
+    -> 'a
+
   val pattern_match
      : t
     -> f:(Kinded_parameter.t list
@@ -496,6 +514,7 @@ end and Function_params_and_body : sig
     -> Kinded_parameter.t list
     -> dbg:Debuginfo.t
     -> body:Expr.t
+    -> free_names_of_body:Name_occurrences.t Or_unknown.t
     -> my_closure:Variable.t
     -> t
 
@@ -515,6 +534,7 @@ end and Function_params_and_body : sig
       -> Kinded_parameter.t list
       -> body:Expr.t
       -> my_closure:Variable.t
+      -> is_my_closure_used:bool Or_unknown.t
       -> 'a)
     -> 'a
 

--- a/middle_end/flambda/terms/function_params_and_body.rec.mli
+++ b/middle_end/flambda/terms/function_params_and_body.rec.mli
@@ -40,6 +40,7 @@ val create
   -> Kinded_parameter.t list
   -> dbg:Debuginfo.t
   -> body:Expr.t
+  -> free_names_of_body:Name_occurrences.t Or_unknown.t
   -> my_closure:Variable.t
   -> t
 
@@ -58,6 +59,7 @@ val pattern_match
     -> Kinded_parameter.t list
     -> body:Expr.t
     -> my_closure:Variable.t
+    -> is_my_closure_used:bool Or_unknown.t
     -> 'a)
   -> 'a
 

--- a/middle_end/flambda/terms/let_cont_expr.rec.mli
+++ b/middle_end/flambda/terms/let_cont_expr.rec.mli
@@ -40,7 +40,7 @@
 type t = private
   | Non_recursive of {
       handler : Non_recursive_let_cont_handler.t;
-      num_free_occurrences : Name_occurrences.Num_occurrences.t;
+      num_free_occurrences : Num_occurrences.t Or_unknown.t;
       (** [num_free_occurrences] can be used, for example, to decide whether
           to inline out a linearly-used continuation. *)
     }
@@ -58,6 +58,7 @@ val create_non_recursive
    : Continuation.t
   -> Continuation_handler.t
   -> body:Expr.t
+  -> free_names_of_body:Name_occurrences.t Or_unknown.t
   -> Expr.t
 
 (** Create a definition of a set of possibly-recursive continuations. *)

--- a/middle_end/flambda/terms/let_expr.rec.mli
+++ b/middle_end/flambda/terms/let_expr.rec.mli
@@ -24,6 +24,13 @@ include Expr_std.S with type t := t
 
 include Contains_ids.S with type t := t
 
+val create
+   : Bindable_let_bound.t
+  -> defining_expr:Named.t
+  -> body:Expr.t
+  -> free_names_of_body:Name_occurrences.t Or_unknown.t
+  -> t
+
 (** The defining expression of the [Let]. *)
 val defining_expr : t -> Named.t
 
@@ -32,6 +39,14 @@ val defining_expr : t -> Named.t
 val pattern_match
    : t
   -> f:(Bindable_let_bound.t -> body:Expr.t -> 'a)
+  -> 'a
+
+val pattern_match'
+   : t
+  -> f:(Bindable_let_bound.t
+    -> num_normal_occurrences_of_bound_vars:Num_occurrences.t Variable.Map.t
+    -> body:Expr.t
+    -> 'a)
   -> 'a
 
 module Pattern_match_pair_error : sig
@@ -57,5 +72,3 @@ val pattern_match_pair
        -> body2:Expr.t
        -> 'a)
   -> ('a, Pattern_match_pair_error.t) Result.t
-
-val create : Bindable_let_bound.t -> defining_expr:Named.t -> body:Expr.t -> t

--- a/middle_end/flambda/to_cmm/un_cps.ml
+++ b/middle_end/flambda/to_cmm/un_cps.ml
@@ -597,16 +597,6 @@ let wrap_extcall_result (l : Flambda_kind.t list) =
     Misc.fatal_errorf
       "C functions are currently limited to a single return value"
 
-(* Closure variables *)
-
-let filter_closure_vars env s =
-  let used_closure_vars = Env.used_closure_vars env in
-  let aux clos_var _bound_to =
-    Var_within_closure.Set.mem clos_var used_closure_vars
-  in
-  Var_within_closure.Map.filter aux s
-
-
 (* Function calls and continuations *)
 
 let var_list env l =
@@ -627,23 +617,28 @@ let split_exn_cont_args k = function
 
 (* effects and co-effects *)
 
-let cont_has_one_occurrence k num =
-  match (num : Name_occurrences.Num_occurrences.t) with
-  | One -> true
-  | More_than_one -> false
-  | Zero ->
-    Misc.fatal_errorf
-      "Found unused let-bound continuation %a, this should not happen"
-      Continuation.print k
+let cont_is_known_to_have_exactly_one_occurrence k (num : _ Or_unknown.t) =
+  match num with
+  | Unknown -> false
+  | Known num ->
+    match (num : Num_occurrences.t) with
+    | One -> true
+    | More_than_one -> false
+    | Zero ->
+      Misc.fatal_errorf
+        "Found unused let-bound continuation %a, this should not happen"
+        Continuation.print k
 
 type inlining_decision =
   | Skip (* no use, the bound variable can be skipped/ignored *)
   | Inline (* the variable is used once, we can try and inline its use *)
   | Regular (* the variable is used multiple times, do not try and inline it. *)
 
-let decide_inline_let effs v body =
-  let free_names = Expr.free_names body in
-  match Name_occurrences.count_variable free_names v with
+let decide_inline_let effs
+      ~(num_normal_occurrences_of_bound_vars : Num_occurrences.t Variable.Map.t)
+      var =
+  match Variable.Map.find var num_normal_occurrences_of_bound_vars with
+  | exception Not_found -> Regular
   | Zero ->
     begin match Env.classify effs with
     | Coeffect | Pure -> Skip
@@ -652,19 +647,21 @@ let decide_inline_let effs v body =
     end
   | One ->
     begin match Env.classify effs with
-    | Effect when not (Flambda_features.Expert.inline_effects_in_cmm ()) -> Regular
+    | Effect when not (Flambda_features.Expert.inline_effects_in_cmm ()) ->
+      Regular
     | _ -> Inline
     end
   | More_than_one -> Regular
 
 (* Helpers for translating functions *)
 
-let is_var_used v e =
-  let free_names = Expr.free_names e in
-  Name_occurrences.mem_var free_names v
-
-let function_args vars my_closure body =
-  if is_var_used my_closure body then begin
+let function_args vars my_closure ~(is_my_closure_used : _ Or_unknown.t) =
+  let is_my_closure_used =
+    match is_my_closure_used with
+    | Unknown -> true
+    | Known is_my_closure_used -> is_my_closure_used
+  in
+  if is_my_closure_used then begin
     let last_arg =
       Kinded_parameter.create my_closure Flambda_kind.With_subkind.any_value
     in
@@ -690,41 +687,44 @@ let rec expr env res e =
   | Invalid e' -> invalid env res e'
 
 and let_expr env res t =
-  Let.pattern_match t ~f:(fun bindable_let_bound ~body ->
-    let mode = Bindable_let_bound.name_mode bindable_let_bound in
-    begin match Name_mode.descr mode with
-    | In_types ->
-      Misc.fatal_errorf
-        "Binding in terms a variable of mode In_types is forbidden"
-    | Phantom ->
-      expr env res body
-    | Normal ->
-      let e = Let.defining_expr t in
-      begin match bindable_let_bound, e with
-      (* Correct cases *)
-      | Singleton v, Simple s ->
-        let_expr_simple body env res v s
-      | Singleton v, Prim (p, dbg) ->
-        let_expr_prim body env res v p dbg
-      | Set_of_closures { closure_vars; _ }, Set_of_closures soc ->
-        let_set_of_closures env res body closure_vars soc
-      | Symbols { bound_symbols; scoping_rule; }, Static_consts consts ->
-        let_symbol env res bound_symbols scoping_rule consts body
-      (* Error cases *)
-      | Singleton _, (Set_of_closures _ | Static_consts _) ->
+  Let.pattern_match' t
+    ~f:(fun bindable_let_bound ~num_normal_occurrences_of_bound_vars ~body ->
+      let mode = Bindable_let_bound.name_mode bindable_let_bound in
+      begin match Name_mode.descr mode with
+      | In_types ->
         Misc.fatal_errorf
-          "Singleton binding to a set of closure or static const if forbidden:@ %a"
-          Let.print t
-      | Set_of_closures _, (Simple _ | Prim _ | Static_consts _) ->
-        Misc.fatal_errorf
-          "Set_of_closures binding a non-Set_of_closures:@ %a"
-          Let.print t
-      | Symbols _, (Simple _ | Prim _ | Set_of_closures _) ->
-        Misc.fatal_errorf
-          "Symbols binding a non-Static const:@ %a"
-          Let.print t
-      end
-    end)
+          "Binding in terms a variable of mode In_types is forbidden"
+      | Phantom ->
+        expr env res body
+      | Normal ->
+        let e = Let.defining_expr t in
+        begin match bindable_let_bound, e with
+        (* Correct cases *)
+        | Singleton v, Simple s ->
+          let_expr_simple body env res v ~num_normal_occurrences_of_bound_vars s
+        | Singleton v, Prim (p, dbg) ->
+          let_expr_prim body env res v ~num_normal_occurrences_of_bound_vars
+            p dbg
+        | Set_of_closures { closure_vars; _ }, Set_of_closures soc ->
+          let_set_of_closures env res body closure_vars
+            ~num_normal_occurrences_of_bound_vars soc
+        | Symbols { bound_symbols; scoping_rule; }, Static_consts consts ->
+          let_symbol env res bound_symbols scoping_rule consts body
+        (* Error cases *)
+        | Singleton _, (Set_of_closures _ | Static_consts _) ->
+          Misc.fatal_errorf
+            "Singleton binding to a set of closure or static const if forbidden:@ %a"
+            Let.print t
+        | Set_of_closures _, (Simple _ | Prim _ | Static_consts _) ->
+          Misc.fatal_errorf
+            "Set_of_closures binding a non-Set_of_closures:@ %a"
+            Let.print t
+        | Symbols _, (Simple _ | Prim _ | Set_of_closures _) ->
+          Misc.fatal_errorf
+            "Symbols binding a non-Static const:@ %a"
+            Let.print t
+        end
+      end)
 
 and let_symbol env res bound_symbols _scoping_rule consts body =
   let env =
@@ -747,48 +747,57 @@ and let_symbol env res bound_symbols _scoping_rule consts body =
     let body, res = expr env res body in
     wrap (C.sequence update body), res
 
-and let_set_of_closures env res body closure_vars s =
+and let_set_of_closures env res body closure_vars
+      ~num_normal_occurrences_of_bound_vars s =
   let fun_decls = Set_of_closures.function_decls s in
   let decls = Function_declarations.funs_in_order fun_decls in
-  let elts = filter_closure_vars env (Set_of_closures.closure_elements s) in
+  let elts =
+    Un_cps_closure.filter_closure_vars s
+      ~used_closure_vars:(Env.used_closure_vars env)
+  in
   if Var_within_closure.Map.is_empty elts then
     let_static_set_of_closures env res body closure_vars s
   else
-    let_dynamic_set_of_closures env res body closure_vars decls elts
+    let_dynamic_set_of_closures env res body closure_vars
+      ~num_normal_occurrences_of_bound_vars decls elts
 
 
-and let_expr_bind ?extra body env v cmm_expr effs =
-  match decide_inline_let effs v body with
+and let_expr_bind ?extra env v ~num_normal_occurrences_of_bound_vars cmm_expr effs =
+  match decide_inline_let effs ~num_normal_occurrences_of_bound_vars v with
   | Skip -> env
   | Inline -> Env.bind_variable env v ?extra effs true cmm_expr
   | Regular -> Env.bind_variable env v ?extra effs false cmm_expr
 
-and bind_simple body (env, res) v s =
+and bind_simple (env, res) v ~num_normal_occurrences_of_bound_vars s =
   let cmm_expr, env, effs = simple env s in
-  let_expr_bind body env v cmm_expr effs, res
+  let_expr_bind env v ~num_normal_occurrences_of_bound_vars cmm_expr effs, res
 
-and let_expr_simple body env res v s =
+and let_expr_simple body env res v ~num_normal_occurrences_of_bound_vars s =
   let v = Var_in_binding_pos.var v in
-  let env, res = bind_simple body (env, res) v s in
+  let env, res =
+    bind_simple (env, res) v ~num_normal_occurrences_of_bound_vars s
+  in
   expr env res body
 
-and let_expr_prim body env res v p dbg =
+and let_expr_prim body env res v ~num_normal_occurrences_of_bound_vars p dbg =
   let v = Var_in_binding_pos.var v in
   let cmm_expr, extra, env, effs = prim env dbg p in
   let effs = Ece.join effs (Flambda_primitive.effects_and_coeffects p) in
-  let env = let_expr_bind ?extra body env v cmm_expr effs in
+  let env =
+    let_expr_bind ?extra env v ~num_normal_occurrences_of_bound_vars cmm_expr effs
+  in
   expr env res body
 
-and decide_inline_cont h k num_free_occurrences =
+and decide_inline_cont h k ~num_free_occurrences =
   not (Continuation_handler.is_exn_handler h)
   && (Continuation_handler.stub h
-      || cont_has_one_occurrence k num_free_occurrences)
+      || cont_is_known_to_have_exactly_one_occurrence k num_free_occurrences)
 
 and let_cont env res = function
   | Let_cont.Non_recursive { handler; num_free_occurrences; } ->
     Non_recursive_let_cont_handler.pattern_match handler ~f:(fun k ~body ->
       let h = Non_recursive_let_cont_handler.handler handler in
-      if decide_inline_cont h k num_free_occurrences then begin
+      if decide_inline_cont h k ~num_free_occurrences then begin
         let_cont_inline env res k h body
       end else
         let_cont_jump env res k h body
@@ -801,8 +810,12 @@ and let_cont env res = function
 
 (* The bound continuation [k] will be inlined. *)
 and let_cont_inline env res k h body =
-  let args, handler = continuation_handler_split h in
-  let env = Env.add_inline_cont env k args handler in
+  let params, handler_params_occurrences, handler =
+    continuation_handler_split h
+  in
+  let env =
+    Env.add_inline_cont env k params ~handler_params_occurrences handler
+  in
   expr env res body
 
 (* Continuations that are not inlined are translated using a jump:
@@ -884,16 +897,16 @@ and let_cont_rec env res conts body =
 
 and continuation_handler_split h =
   let h = Continuation_handler.params_and_handler h in
-  Continuation_params_and_handler.pattern_match h ~f:(fun args ~handler ->
-    args, handler
-  )
+  Continuation_params_and_handler.pattern_match' h
+    ~f:(fun params ~num_normal_occurrences_of_params ~handler ->
+      params, num_normal_occurrences_of_params, handler)
 
 and continuation_arg_tys h =
-  let args, _ = continuation_handler_split h in
+  let args, _, _ = continuation_handler_split h in
   List.map machtype_of_kinded_parameter args
 
 and continuation_handler env res h =
-  let args, handler = continuation_handler_split h in
+  let args, _, handler = continuation_handler_split h in
   let env, vars = var_list env args in
   let e, res = expr env res handler in
   vars, e, res
@@ -1021,13 +1034,24 @@ and wrap_cont env res effs call e =
     | Jump { types = [_]; cont; } ->
       let wrap, _ = Env.flush_delayed_lets env in
       wrap (C.cexit cont [call] []), res
-    | Inline { handler_params = []; handler_body = body; _ } ->
+    | Inline { handler_params = []; handler_body = body;
+               handler_params_occurrences = _; } ->
       let var = Variable.create "*apply_res*" in
-      let env = let_expr_bind body env var call effs in
+      let num_normal_occurrences_of_bound_vars =
+        Variable.Map.singleton var Num_occurrences.Zero
+      in
+      let env =
+        let_expr_bind env var ~num_normal_occurrences_of_bound_vars call effs
+      in
       expr env res body
-    | Inline { handler_params = [v]; handler_body = body; _ } ->
-      let var = Kinded_parameter.var v in
-      let env = let_expr_bind body env var call effs in
+    | Inline { handler_params = [param]; handler_body = body;
+               handler_params_occurrences; } ->
+      let var = Kinded_parameter.var param in
+      let env =
+        let_expr_bind env var
+          ~num_normal_occurrences_of_bound_vars:handler_params_occurrences
+          call effs
+      in
       expr env res body
     | Jump _
     | Inline _ ->
@@ -1105,24 +1129,29 @@ and apply_cont_ret env res e k = function
 
 and apply_cont_regular env res e k args =
   match Env.get_k env k with
-  | Inline { handler_params; handler_body; } ->
+  | Inline { handler_params; handler_body; handler_params_occurrences; } ->
     if not (Apply_cont_expr.trap_action e = None) then begin
       Misc.fatal_errorf "This [Apply_cont] should not have a trap \
                          action:@ %a"
         Apply_cont_expr.print e
     end;
     apply_cont_inline env res e k args handler_body handler_params
+      ~handler_params_occurrences
   | Jump { types; cont; } ->
     apply_cont_jump env res e types cont args
 
 (* Inlining a continuation call simply needs to bind the arguments to the
    variables that the continuation's body expects. The delayed lets in the
    environment enables that translation to be tail-rec. *)
-and apply_cont_inline env res e k args handler_body handler_params =
+and apply_cont_inline env res e k args handler_body handler_params
+      ~handler_params_occurrences =
   if List.compare_lengths args handler_params = 0 then begin
-    let vars = List.map Kinded_parameter.var handler_params in
     let env, res =
-      List.fold_left2 (bind_simple handler_body) (env, res) vars args
+      List.fold_left2 (fun env_and_res param ->
+          bind_simple env_and_res (Kinded_parameter.var param)
+            ~num_normal_occurrences_of_bound_vars:handler_params_occurrences)
+        (env, res)
+        handler_params args
     in
     expr env res handler_body
   end else
@@ -1313,7 +1342,8 @@ and let_static_set_of_closures env res body closure_vars s =
   expr env res body
 
 (* Sets of closures with a non-empty environment are allocated *)
-and let_dynamic_set_of_closures env res body closure_vars decls elts =
+and let_dynamic_set_of_closures env res body closure_vars
+      ~num_normal_occurrences_of_bound_vars decls elts =
   (* Create the allocation block for the set of closures *)
   let layout = Env.layout env
                  (List.map fst (Closure_id.Lmap.bindings decls))
@@ -1338,7 +1368,7 @@ and let_dynamic_set_of_closures env res body closure_vars decls elts =
     List.fold_left2 (fun acc cid v ->
       let v = Var_in_binding_pos.var v in
       let e, effs = get_closure_by_offset env soc_cmm_var cid in
-      let_expr_bind body acc v e effs
+      let_expr_bind acc v ~num_normal_occurrences_of_bound_vars e effs
     ) env (Closure_id.Lmap.keys decls) closure_vars in
   (* The set of closures, as well as the individual closures variables
      are correctly set in the env, go on translating the body. *)
@@ -1403,9 +1433,10 @@ and fill_up_to j acc i =
 
 and params_and_body env res fun_name p =
   Function_params_and_body.pattern_match p
-    ~f:(fun ~return_continuation:k k_exn vars ~body ~my_closure ->
+    ~f:(fun ~return_continuation:k k_exn vars ~body ~my_closure
+          ~is_my_closure_used ->
       try
-        let args = function_args vars my_closure body in
+        let args = function_args vars my_closure ~is_my_closure_used in
         let k_exn = Exn_continuation.exn_handler k_exn in
         (* Init the env and create a jump id for the ret closure
            in case a trap action is attached to one of tis call *)
@@ -1466,7 +1497,7 @@ let unit (middle_end_result : Flambda_middle_end.middle_end_result) =
     let env =
       Env.mk offsets functions_info dummy_k
         (Flambda_unit.exn_continuation unit)
-        used_closure_vars
+        ~used_closure_vars
     in
     let _env, return_cont_params =
       (* Note: the environment would be used if we needed to compile the

--- a/middle_end/flambda/to_cmm/un_cps_closure.mli
+++ b/middle_end/flambda/to_cmm/un_cps_closure.mli
@@ -26,6 +26,16 @@ val closure_code : string -> string
 (** Returns the address for a function code from the global name of
     a closure. *)
 
+val filter_closure_vars
+   : Flambda.Set_of_closures.t
+  -> used_closure_vars:Var_within_closure.Set.t Or_unknown.t
+  -> Simple.t Var_within_closure.Map.t
+(** Returns the assignments of closure variables to [Simple]s from the
+    given set of closures, but ignoring any closure variable that does not
+    occur in [used_closure_vars], so long as [used_closure_vars] is [Known].
+    If [used_closure_vars] is [Unknown] then assignments for all closure
+    variables are returned. *)
+
 (* val map_on_function_decl :
  *   (string -> Closure_id.t -> Flambda.Function_declaration.t -> 'a) ->
  *   Flambda_unit.t -> 'a Closure_id.Map.t

--- a/middle_end/flambda/to_cmm/un_cps_env.ml
+++ b/middle_end/flambda/to_cmm/un_cps_env.ml
@@ -21,7 +21,9 @@
 type cont =
   | Jump of { types: Cmm.machtype list; cont: int; }
   | Inline of { handler_params: Kinded_parameter.t list;
-                handler_body: Flambda.Expr.t; }
+                handler_body: Flambda.Expr.t;
+                handler_params_occurrences: Num_occurrences.t Variable.Map.t;
+              }
 
 (* Extra information about bound variables. These extra information
    help keep track of some extra semantics that are useful to
@@ -87,7 +89,7 @@ type t = {
 
   offsets : Exported_offsets.t;
   (* Offsets for closure_ids and var_within_closures. *)
-  used_closure_vars : Var_within_closure.Set.t;
+  used_closure_vars : Var_within_closure.Set.t Or_unknown.t;
   (* Closure variables that are used by the context begin translated.
      (used to remove unused closure variables). *)
   functions_info: Exported_code.t;
@@ -142,7 +144,7 @@ type t = {
 
 }
 
-let mk offsets functions_info k_return k_exn used_closure_vars = {
+let mk offsets functions_info k_return k_exn ~used_closure_vars = {
   k_return; k_exn; used_closure_vars; offsets;
   functions_info;
   stages = [];
@@ -254,10 +256,11 @@ let add_jump_cont env types k =
   let conts = Continuation.Map.add k (Jump { types; cont; }) env.conts in
   cont, { env with conts }
 
-let add_inline_cont env k vars e =
+let add_inline_cont env k vars ~handler_params_occurrences e =
   let info = Inline {
       handler_params = vars;
       handler_body = e;
+      handler_params_occurrences;
     } in
   let conts = Continuation.Map.add k info env.conts in
   { env with conts }

--- a/middle_end/flambda/to_cmm/un_cps_static.ml
+++ b/middle_end/flambda/to_cmm/un_cps_static.ml
@@ -43,13 +43,6 @@ let nativeint_of_targetint t =
   | Int32 i -> Nativeint.of_int32 i
   | Int64 i -> Int64.to_nativeint i
 
-let filter_closure_vars env s =
-  let used_closure_vars = Env.used_closure_vars env in
-  let aux clos_var _bound_to =
-    Var_within_closure.Set.mem clos_var used_closure_vars
-  in
-  Var_within_closure.Map.filter aux s
-
 let todo () = failwith "Not yet implemented"
 (* ----- End of functions to share ----- *)
 
@@ -158,7 +151,10 @@ let rec static_set_of_closures env symbs set prev_update =
   let clos_symb = ref None in
   let fun_decls = Set_of_closures.function_decls set in
   let decls = Function_declarations.funs fun_decls in
-  let elts = filter_closure_vars env (Set_of_closures.closure_elements set) in
+  let elts =
+    Un_cps_closure.filter_closure_vars set
+      ~used_closure_vars:(Env.used_closure_vars env)
+  in
   let layout = Env.layout env
       (List.map fst (Closure_id.Map.bindings decls))
       (List.map fst (Var_within_closure.Map.bindings elts))


### PR DESCRIPTION
This is the first stage in removing the free name caches from terms, which I suspect is causing performance problems.  (It's potentially possible to rectify it by only populating the caches when terms are being reconstructed after simplification, but the code to do this seems fragile.)

This needs a bit of tidying but review and testing would be appreciated, in particular to make sure that Un_cps is still doing the expected inlining (for let expressions, linearly-used continuation parameters and linearly-used results of applications).

The next step will be to remove the call to `Expr.free_names` from `Closure_conversion`, which I'll do by removing the denesting code, that I don't think we actually need.  After that, we should be in a position to propagate the free name set through `UA` in the simplifier, which I hope will be straightforward.  Then the new optional arguments to the various term creation functions can be provided from that set, rather than the caches.