### PR TITLE
Max block size limit for projections

### DIFF
--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -984,6 +984,12 @@ let mk_flambda_expert_max_inlining_depth f =
   " Set maximum inlining depth"
 ;;
 
+let mk_flambda_expert_max_block_size_for_projections f =
+  "-flambda-expert-max-block-size-for-projections", Arg.Int f,
+  " Do not simplify projections from blocks if the block size exceeds \
+    this value"
+;;
+
 let mk_flambda_debug_concrete_types_only_on_canonicals f =
   "-flambda-debug-concrete-types-only-on-canonicals", Arg.Unit f,
     " Check that concrete types are only assigned to canonical names"
@@ -1230,6 +1236,7 @@ module type Optcommon_options = sig
   val _flambda_expert_phantom_lets : unit -> unit
   val _no_flambda_expert_phantom_lets : unit -> unit
   val _flambda_expert_max_inlining_depth : int -> unit
+  val _flambda_expert_max_block_size_for_projections : int -> unit
   val _flambda_debug_concrete_types_only_on_canonicals : unit -> unit
   val _no_flambda_debug_concrete_types_only_on_canonicals : unit -> unit
 
@@ -1592,6 +1599,8 @@ struct
       F._no_flambda_expert_phantom_lets;
     mk_flambda_expert_max_inlining_depth
       F._flambda_expert_max_inlining_depth;
+    mk_flambda_expert_max_block_size_for_projections
+      F._flambda_expert_max_block_size_for_projections;
     mk_flambda_debug_concrete_types_only_on_canonicals
       F._flambda_debug_concrete_types_only_on_canonicals;
     mk_no_flambda_debug_concrete_types_only_on_canonicals
@@ -1751,6 +1760,8 @@ module Make_opttop_options (F : Opttop_options) = struct
       F._no_flambda_expert_phantom_lets;
     mk_flambda_expert_max_inlining_depth
       F._flambda_expert_max_inlining_depth;
+    mk_flambda_expert_max_block_size_for_projections
+      F._flambda_expert_max_block_size_for_projections;
     mk_flambda_debug_concrete_types_only_on_canonicals
       F._flambda_debug_concrete_types_only_on_canonicals;
     mk_no_flambda_debug_concrete_types_only_on_canonicals
@@ -2059,7 +2070,8 @@ module Default = struct
       clear Flambda.Expert.phantom_lets
     let _flambda_expert_max_inlining_depth depth =
       Flambda.Expert.max_inlining_depth := depth
-
+    let _flambda_expert_max_block_size_for_projections size =
+      Flambda.Expert.max_block_size_for_projections := Some size
     let _flambda_debug_concrete_types_only_on_canonicals =
       set Flambda.Debug.concrete_types_only_on_canonicals
     let _no_flambda_debug_concrete_types_only_on_canonicals =

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -242,6 +242,7 @@ module type Optcommon_options = sig
   val _flambda_expert_phantom_lets : unit -> unit
   val _no_flambda_expert_phantom_lets : unit -> unit
   val _flambda_expert_max_inlining_depth : int -> unit
+  val _flambda_expert_max_block_size_for_projections : int -> unit
   val _flambda_debug_concrete_types_only_on_canonicals : unit -> unit
   val _no_flambda_debug_concrete_types_only_on_canonicals : unit -> unit
 

--- a/middle_end/flambda/compilenv_deps/flambda_features.ml
+++ b/middle_end/flambda/compilenv_deps/flambda_features.ml
@@ -28,4 +28,6 @@ module Expert = struct
     !Clflags.Flambda.Expert.fallback_inlining_heuristic
   let inline_effects_in_cmm () =
     !Clflags.Flambda.Expert.inline_effects_in_cmm
+  let max_block_size_for_projections () =
+    !Clflags.Flambda.Expert.max_block_size_for_projections
 end

--- a/middle_end/flambda/compilenv_deps/flambda_features.mli
+++ b/middle_end/flambda/compilenv_deps/flambda_features.mli
@@ -24,4 +24,5 @@ module Expert : sig
   val code_id_and_symbol_scoping_checks : unit -> bool
   val fallback_inlining_heuristic : unit -> bool
   val inline_effects_in_cmm : unit -> bool
+  val max_block_size_for_projections : unit -> int option
 end

--- a/middle_end/flambda/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda/simplify/simplify_binary_primitive.ml
@@ -853,32 +853,48 @@ let simplify_immutable_block_load (access_kind : P.Block_access_kind.t)
   | Invalid -> invalid ()
   | Unknown -> unchanged ()
   | Proved index ->
-    let n =
-      Targetint.OCaml.add (Target_imm.to_targetint index) Targetint.OCaml.one
+    let skip_simplification =
+      let size =
+        match access_kind with
+        | Values { size; _ } | Naked_floats { size; } -> size
+      in
+      match size with
+      | Unknown -> false
+      | Known size ->
+        match Flambda_features.Expert.max_block_size_for_projections () with
+        | None -> false
+        | Some max_size ->
+          let max_size = Targetint.OCaml.of_int max_size in
+          not (Targetint.OCaml.(<=) size max_size)
     in
-    (* CR mshinwell: We should be able to use the size in the [access_kind]
-       to constrain the type of the block *)
-    let tag : _ Or_unknown.t =
-      match access_kind with
-      | Values { tag; _ } -> Known (Tag.Scannable.to_tag tag)
-      | Naked_floats { size; } ->
-        match size with
-        | Known size ->
-          (* We don't expect blocks of naked floats of size zero (it doesn't
-             seem that the frontend currently emits code to create such blocks)
-             and so it isn't clear whether such blocks should have tag zero
-             (like zero-sized naked float arrays) or another tag. *)
-          if Targetint.OCaml.equal size Targetint.OCaml.zero then
-            Unknown
-          else
-            Known Tag.double_array_tag
-        | Unknown -> Unknown
-    in
-    Simplify_common.simplify_projection
-      dacc ~original_term ~deconstructing:block_ty
-      ~shape:(T.immutable_block_with_size_at_least ~tag ~n
-        ~field_kind:result_kind ~field_n_minus_one:result_var')
-      ~result_var ~result_kind
+    if skip_simplification then unchanged ()
+    else
+      let n =
+        Targetint.OCaml.add (Target_imm.to_targetint index) Targetint.OCaml.one
+      in
+      (* CR mshinwell: We should be able to use the size in the [access_kind]
+         to constrain the type of the block *)
+      let tag : _ Or_unknown.t =
+        match access_kind with
+        | Values { tag; _ } -> Known (Tag.Scannable.to_tag tag)
+        | Naked_floats { size; } ->
+          match size with
+          | Known size ->
+            (* We don't expect blocks of naked floats of size zero (it doesn't
+               seem that the frontend currently emits code to create such
+               blocks) and so it isn't clear whether such blocks should have
+               tag zero (like zero-sized naked float arrays) or another tag. *)
+            if Targetint.OCaml.equal size Targetint.OCaml.zero then
+              Unknown
+            else
+              Known Tag.double_array_tag
+          | Unknown -> Unknown
+      in
+      Simplify_common.simplify_projection
+        dacc ~original_term ~deconstructing:block_ty
+        ~shape:(T.immutable_block_with_size_at_least ~tag ~n
+          ~field_kind:result_kind ~field_n_minus_one:result_var')
+        ~result_var ~result_kind
 
 let simplify_phys_equal (op : P.equality_comparison)
       (kind : K.t) dacc ~original_term dbg

--- a/middle_end/flambda/simplify/simplify_variadic_primitive.ml
+++ b/middle_end/flambda/simplify/simplify_variadic_primitive.ml
@@ -138,11 +138,9 @@ let simplify_variadic_primitive dacc ~original_named ~original_prim
             Named.create_prim (Variadic (prim, args)) dbg
           | Unchanged -> original_named
         in
-        let kind = P.result_kind_of_variadic_primitive' prim in
         let ty =
           match prim with
-          | Make_block _ ->
-            T.unknown kind
+          | Make_block _ -> T.any_block ()
           | Make_array _ ->
             let length =
               match Targetint.OCaml.of_int_option (List.length args) with

--- a/middle_end/flambda/types/flambda_type.mli
+++ b/middle_end/flambda/types/flambda_type.mli
@@ -344,6 +344,8 @@ val tag_immediate : t -> t
 val is_int_for_scrutinee : scrutinee:Simple.t -> t
 val get_tag_for_block : block:Simple.t -> t
 
+val any_block : unit -> t
+
 (* CR mshinwell: decide on exact strategy for mutable blocks *)
 
 (** The type of an immutable block with a known tag, size and field types. *)

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -437,6 +437,7 @@ module Flambda = struct
     let inline_effects_in_cmm = ref false
     let phantom_lets = ref true
     let max_inlining_depth = ref 1
+    let max_block_size_for_projections = ref None
   end
 
   module Debug = struct

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -257,6 +257,7 @@ module Flambda : sig
     val inline_effects_in_cmm : bool ref
     val phantom_lets : bool ref
     val max_inlining_depth : int ref
+    val max_block_size_for_projections : int option ref
   end
 
   module Debug : sig


### PR DESCRIPTION
We have a problematic source file at JS that involves a very large module (>4,000 fields) and an even larger number of projections from that module.  Compilation time and memory usage with Flambda 2 is not acceptable at present on this file.  I experimented with various ways of improving the situation and settled upon this one, which allows a limit on the size of blocks to be specified; projections from blocks exceeding the limit are not simplified.  With future improvements we might be able to remove this.