### PR TITLE
FLAMBDA_COLUMNS support (terminal width setting)

### DIFF
--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -35,6 +35,17 @@ let usage = "Usage: ocamlopt <options> <files>\nOptions are:"
 module Options = Main_args.Make_optcomp_options (Main_args.Default.Optmain)
 let main argv ppf =
   native_code := true;
+  begin match Sys.getenv_opt "FLAMBDA_COLUMNS" with
+  | None -> ()
+  | Some i ->
+    match int_of_string i with
+    | exception _ -> ()
+    | i ->
+      if i >= 40 then begin
+        Format.pp_set_margin Format.std_formatter i;
+        Format.pp_set_margin Format.err_formatter i
+      end
+  end;
   match
     readenv ppf Before_args;
     Clflags.add_arguments __LOC__ (Arch.command_line_options @ Options.list);


### PR DESCRIPTION
This got lost at some point recently, possibly when the memtrace changes were made.  We now use `FLAMBDA_COLUMNS` not `COLUMNS`.