### PR TITLE
Various improvements related to unboxing and meet

### DIFF
--- a/middle_end/flambda/types/env/typing_env_extension.rec.ml
+++ b/middle_end/flambda/types/env/typing_env_extension.rec.ml
@@ -95,6 +95,17 @@ let meet env (t1 : t) (t2 : t) : t =
   let abst = A.pattern_match t1.abst ~f in
   { abst; }
 
+let extend env (t1 : t) ~ext:(t2 : t) : t =
+  let [@inline always] f level_1 =
+    let [@inline always] f level_2 =
+      let level = Typing_env_level.extend env level_1 ~ext:level_2 in
+      A.create (Typing_env_level.defined_vars level) level
+    in
+    A.pattern_match t2.abst ~f
+  in
+  let abst = A.pattern_match t1.abst ~f in
+  { abst; }
+
 let rec n_way_meet env ts =
   match ts with
   | [] -> empty ()

--- a/middle_end/flambda/types/env/typing_env_extension.rec.mli
+++ b/middle_end/flambda/types/env/typing_env_extension.rec.mli
@@ -45,6 +45,10 @@ val add_cse
 
 val meet : Meet_env.t -> t -> t -> t
 
+(** Same as [meet], but more efficient when the domains are disjoint.
+    Optimised for when the [ext] argument is smaller. *)
+val extend : Meet_env.t -> t -> ext:t -> t
+
 val n_way_meet : Meet_env.t -> t list -> t
 
 (* val n_way_join

--- a/middle_end/flambda/types/env/typing_env_level.rec.mli
+++ b/middle_end/flambda/types/env/typing_env_level.rec.mli
@@ -68,6 +68,10 @@ val concat : t -> t -> t
 
 val meet : Meet_env.t -> t -> t -> t
 
+(** Same as [meet], but more efficient when the domains are disjoint.
+    Optimised for when the [ext] argument is smaller. *)
+val extend : Meet_env.t -> t -> ext:t -> t
+
 val n_way_join
    : env_at_fork:Typing_env.t
   -> (Typing_env.t * Apply_cont_rewrite_id.t * Continuation_use_kind.t

--- a/middle_end/flambda/types/flambda_type.mli
+++ b/middle_end/flambda/types/flambda_type.mli
@@ -550,6 +550,12 @@ val prove_single_closures_entry'
 
 val prove_strings : Typing_env.t -> t -> String_info.Set.t proof
 
+val prove_block_field_simple
+   : Typing_env.t
+  -> t
+  -> Target_imm.t
+  -> Simple.t proof
+
 type var_or_symbol_or_tagged_immediate = private
   | Var of Variable.t
   | Symbol of Symbol.t

--- a/middle_end/flambda/types/structures/product_intf.ml
+++ b/middle_end/flambda/types/structures/product_intf.ml
@@ -35,6 +35,8 @@ module type S_base = sig
     -> f:(flambda_type -> flambda_type Or_bottom.t)
     -> t Or_bottom.t
 
+  val project : t -> Index.t -> flambda_type Or_unknown.t
+
   include Type_structure_intf.S
     with type t := t
     with type flambda_type := flambda_type

--- a/middle_end/flambda/types/structures/row_like.rec.ml
+++ b/middle_end/flambda/types/structures/row_like.rec.ml
@@ -535,7 +535,7 @@ struct
             in
             let maps_to =
               Product.Int_indexed.create_from_list field_kind field_tys
-            in 
+            in
             let size = Targetint.OCaml.of_int (List.length field_tys) in
             { maps_to;
               index = Known size;

--- a/middle_end/flambda/types/structures/row_like.rec.ml
+++ b/middle_end/flambda/types/structures/row_like.rec.ml
@@ -565,6 +565,13 @@ struct
         else
           Known by_tag
 
+    let get_field t field_index : _ Or_unknown.t =
+      match get_singleton t with
+      | None -> Unknown
+      | Some ((_tag, size), maps_to) ->
+        let index = Target_imm.to_targetint field_index in
+        if Targetint.OCaml.(<=) size index then Unknown
+        else Product.Int_indexed.project maps_to (Targetint.OCaml.to_int index)
   end
 
   module For_closures_entry_by_set_of_closures_contents = struct

--- a/middle_end/flambda/types/structures/row_like.rec.mli
+++ b/middle_end/flambda/types/structures/row_like.rec.mli
@@ -47,6 +47,28 @@ module For_blocks : sig
 
   val get_singleton : t -> (Tag_and_size.t * Product.Int_indexed.t) option
 
+  (** Get the nth field of the block if it is unambiguous.
+      This can be done precisely using Type_grammar.meet_shape, but this meet
+      can be expensive. This function allows to give a precise answer quickly
+      in the common case where the block type is known exactly (for example,
+      it is the result of a previous record or module allocation).
+
+      This will return Unknown if:
+      - There is no nth field (the read is invalid, and will produce bottom)
+      - The block type represents a disjunction (several possible tags)
+      - The tag or size is not exactly known
+      - The nth field exists, is unique, but has Unknown type
+
+      The handling of those cases could be improved:
+      - When there is no valid field, Bottom could be returned instead
+      - In the case of disjunctions, if all possible nth fields point to the
+      same type, this type could be returned directly.
+      - When the tag or size is not known but there is a unique possible value,
+      it could be returned anyway
+      - There could be a distinction between the first three cases (where we
+      expect that doing the actual meet could give us a better result) and the
+      last case where we already know what the result of the meet will be.
+  *)
   val get_field : t -> Target_imm.t -> Type_grammar.t Or_unknown.t
 
   val is_bottom : t -> bool

--- a/middle_end/flambda/types/structures/row_like.rec.mli
+++ b/middle_end/flambda/types/structures/row_like.rec.mli
@@ -47,6 +47,8 @@ module For_blocks : sig
 
   val get_singleton : t -> (Tag_and_size.t * Product.Int_indexed.t) option
 
+  val get_field : t -> Target_imm.t -> Type_grammar.t Or_unknown.t
+
   val is_bottom : t -> bool
 
   (** The [Maps_to] value which [meet] returns contains the join of all

--- a/middle_end/flambda/types/template/flambda_type.templ.ml
+++ b/middle_end/flambda/types/template/flambda_type.templ.ml
@@ -715,12 +715,13 @@ let prove_block_field_simple env t field_index : Simple.t proof =
     begin match immediates with
     | Unknown -> Unknown
     | Known imms ->
-      if not (is_obviously_bottom imms) then
-        Unknown
-      else
-        begin match blocks with
-        | Unknown -> Unknown
-        | Known blocks ->
+      begin match blocks with
+      | Unknown -> Unknown
+      | Known blocks ->
+        if Row_like.For_blocks.is_bottom blocks then Invalid
+        else if not (is_obviously_bottom imms) then
+          Unknown
+        else
           begin match Row_like.For_blocks.get_field blocks field_index with
           | Unknown -> Unknown
           | Known ty ->

--- a/middle_end/flambda/types/template/flambda_type.templ.ml
+++ b/middle_end/flambda/types/template/flambda_type.templ.ml
@@ -703,6 +703,44 @@ let prove_strings env t : String_info.Set.t proof =
   | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ -> wrong_kind ()
 
+let prove_block_field_simple env t field_index : Simple.t proof =
+  let wrong_kind () =
+    Misc.fatal_errorf "Kind error: expected [Value]:@ %a" print t
+  in
+  match expand_head t env with
+  | Const _ ->
+    if K.equal (kind t) K.value then Invalid
+    else wrong_kind ()
+  | Value (Ok (Variant { immediates; blocks; is_unique = _; })) ->
+    begin match immediates with
+    | Unknown -> Unknown
+    | Known imms ->
+      if not (is_obviously_bottom imms) then
+        Unknown
+      else
+        begin match blocks with
+        | Unknown -> Unknown
+        | Known blocks ->
+          begin match Row_like.For_blocks.get_field blocks field_index with
+          | Unknown -> Unknown
+          | Known ty ->
+            begin match get_alias_exn ty with
+            | simple ->
+              begin match Typing_env.get_canonical_simple_exn env simple with
+              | simple -> Proved simple
+              | exception Not_found -> Unknown
+              end
+            | exception Not_found -> Unknown
+            end
+          end
+        end
+    end
+  | Value (Ok _) -> Invalid
+  | Value Unknown -> Unknown
+  | Value Bottom -> Invalid
+  | Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
+  | Naked_nativeint _ -> wrong_kind ()
+
 type to_lift =
   | Immutable_block of
       { tag : Tag.Scannable.t;


### PR DESCRIPTION
This avoids some quadratic behaviour, where each successive meet with the shape for the fields of a block would end up taking time proportional to the index of the field.

There's also a fix to the initial depth parameter, so that a maximum depth of one (the current value) will unbox the arguments themselves but not their sub-fields.