### PR TITLE
Add inlining report for flambda2

### DIFF
--- a/.depend
+++ b/.depend
@@ -3775,6 +3775,7 @@ middle_end/flambda/flambda_middle_end.cmo : \
     middle_end/flambda/parser/print_fexpr.cmi \
     middle_end/flambda/from_lambda/prepare_lambda.cmi \
     utils/misc.cmi \
+    middle_end/flambda/inlining/inlining_report.cmi \
     middle_end/flambda/from_lambda/ilambda.cmi \
     middle_end/flambda/terms/flambda_unit.cmi \
     middle_end/flambda/parser/flambda_to_fexpr.cmi \
@@ -3795,6 +3796,7 @@ middle_end/flambda/flambda_middle_end.cmx : \
     middle_end/flambda/parser/print_fexpr.cmx \
     middle_end/flambda/from_lambda/prepare_lambda.cmx \
     utils/misc.cmx \
+    middle_end/flambda/inlining/inlining_report.cmx \
     middle_end/flambda/from_lambda/ilambda.cmx \
     middle_end/flambda/terms/flambda_unit.cmx \
     middle_end/flambda/parser/flambda_to_fexpr.cmx \
@@ -4058,6 +4060,7 @@ middle_end/flambda/flambda_middle_end.cmo : \
     middle_end/flambda/parser/print_fexpr.cmi \
     middle_end/flambda/from_lambda/prepare_lambda.cmi \
     utils/misc.cmi \
+    middle_end/flambda/inlining/inlining_report.cmi \
     middle_end/flambda/from_lambda/ilambda.cmi \
     middle_end/flambda/terms/flambda_unit.cmi \
     middle_end/flambda/parser/flambda_to_fexpr.cmi \
@@ -4078,6 +4081,7 @@ middle_end/flambda/flambda_middle_end.cmx : \
     middle_end/flambda/parser/print_fexpr.cmx \
     middle_end/flambda/from_lambda/prepare_lambda.cmx \
     utils/misc.cmx \
+    middle_end/flambda/inlining/inlining_report.cmx \
     middle_end/flambda/from_lambda/ilambda.cmx \
     middle_end/flambda/terms/flambda_unit.cmx \
     middle_end/flambda/parser/flambda_to_fexpr.cmx \
@@ -4794,7 +4798,6 @@ middle_end/flambda/from_lambda/closure_conversion.cmo : \
     middle_end/flambda/compilenv_deps/target_imm.cmi \
     lambda/tag.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
-    utils/strongly_connected_components.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/terms/set_of_closures.cmi \
     middle_end/flambda/basic/reg_width_const.cmi \
@@ -4820,7 +4823,6 @@ middle_end/flambda/from_lambda/closure_conversion.cmo : \
     middle_end/flambda/terms/flambda_unit.cmi \
     middle_end/flambda/terms/flambda_primitive.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
-    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/flambda_backend_intf.cmi \
     middle_end/flambda/terms/flambda.cmi \
@@ -4847,7 +4849,6 @@ middle_end/flambda/from_lambda/closure_conversion.cmx : \
     middle_end/flambda/compilenv_deps/target_imm.cmx \
     lambda/tag.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
-    utils/strongly_connected_components.cmx \
     middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/terms/set_of_closures.cmx \
     middle_end/flambda/basic/reg_width_const.cmx \
@@ -4873,7 +4874,6 @@ middle_end/flambda/from_lambda/closure_conversion.cmx : \
     middle_end/flambda/terms/flambda_unit.cmx \
     middle_end/flambda/terms/flambda_primitive.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
-    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/flambda_backend_intf.cmi \
     middle_end/flambda/terms/flambda.cmx \
@@ -5225,9 +5225,28 @@ middle_end/flambda/inlining/inlining_decision.cmx : \
 middle_end/flambda/inlining/inlining_decision.cmi : \
     middle_end/flambda/simplify/env/simplify_envs.cmi \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
+    middle_end/flambda/inlining/inlining_cost.cmi \
     middle_end/flambda/basic/inline_attribute.cmi \
     middle_end/flambda/terms/function_declaration.cmi \
     middle_end/flambda/terms/flambda.cmi
+middle_end/flambda/inlining/inlining_report.cmo : \
+    utils/misc.cmi \
+    middle_end/flambda/inlining/inlining_decision.cmi \
+    lambda/debuginfo.cmi \
+    middle_end/flambda/basic/code_id.cmi \
+    utils/clflags.cmi \
+    middle_end/flambda/inlining/inlining_report.cmi
+middle_end/flambda/inlining/inlining_report.cmx : \
+    utils/misc.cmx \
+    middle_end/flambda/inlining/inlining_decision.cmx \
+    lambda/debuginfo.cmx \
+    middle_end/flambda/basic/code_id.cmx \
+    utils/clflags.cmx \
+    middle_end/flambda/inlining/inlining_report.cmi
+middle_end/flambda/inlining/inlining_report.cmi : \
+    middle_end/flambda/inlining/inlining_decision.cmi \
+    lambda/debuginfo.cmi \
+    middle_end/flambda/basic/code_id.cmi
 middle_end/flambda/inlining/inlining_transforms.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
@@ -5913,6 +5932,7 @@ middle_end/flambda/simplify/simplify.cmo : \
     middle_end/flambda/compilenv_deps/linkage_name.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/inlining/inlining_transforms.cmi \
+    middle_end/flambda/inlining/inlining_report.cmi \
     middle_end/flambda/inlining/inlining_decision.cmi \
     middle_end/flambda/terms/function_declarations.cmi \
     middle_end/flambda/terms/function_declaration.cmi \
@@ -5979,6 +5999,7 @@ middle_end/flambda/simplify/simplify.cmx : \
     middle_end/flambda/compilenv_deps/linkage_name.cmx \
     middle_end/flambda/basic/kinded_parameter.cmx \
     middle_end/flambda/inlining/inlining_transforms.cmx \
+    middle_end/flambda/inlining/inlining_report.cmx \
     middle_end/flambda/inlining/inlining_decision.cmx \
     middle_end/flambda/terms/function_declarations.cmx \
     middle_end/flambda/terms/function_declaration.cmx \
@@ -6050,6 +6071,7 @@ middle_end/flambda/simplify/simplify_apply_expr.rec.cmo : \
     parsing/location.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/inlining/inlining_transforms.cmi \
+    middle_end/flambda/inlining/inlining_report.cmi \
     middle_end/flambda/inlining/inlining_decision.cmi \
     middle_end/flambda/terms/function_declarations.cmi \
     middle_end/flambda/terms/function_declaration.cmi \
@@ -6080,6 +6102,7 @@ middle_end/flambda/simplify/simplify_apply_expr.rec.cmx : \
     parsing/location.cmx \
     middle_end/flambda/basic/kinded_parameter.cmx \
     middle_end/flambda/inlining/inlining_transforms.cmx \
+    middle_end/flambda/inlining/inlining_report.cmx \
     middle_end/flambda/inlining/inlining_decision.cmx \
     middle_end/flambda/terms/function_declarations.cmx \
     middle_end/flambda/terms/function_declaration.cmx \
@@ -6437,6 +6460,7 @@ middle_end/flambda/simplify/simplify_set_of_closures.rec.cmo : \
     utils/misc.cmi \
     middle_end/flambda/compilenv_deps/linkage_name.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
+    middle_end/flambda/inlining/inlining_report.cmi \
     middle_end/flambda/inlining/inlining_decision.cmi \
     middle_end/flambda/terms/function_declarations.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
@@ -6471,6 +6495,7 @@ middle_end/flambda/simplify/simplify_set_of_closures.rec.cmx : \
     utils/misc.cmx \
     middle_end/flambda/compilenv_deps/linkage_name.cmx \
     middle_end/flambda/basic/kinded_parameter.cmx \
+    middle_end/flambda/inlining/inlining_report.cmx \
     middle_end/flambda/inlining/inlining_decision.cmx \
     middle_end/flambda/terms/function_declarations.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
@@ -7748,6 +7773,7 @@ middle_end/flambda/terms/let_expr.rec.cmo : \
     utils/printing_cache.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/naming/num_occurrences.cmi \
+    middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/naming/name_abstraction.cmi \
@@ -7772,6 +7798,7 @@ middle_end/flambda/terms/let_expr.rec.cmx : \
     utils/printing_cache.cmx \
     middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/naming/num_occurrences.cmx \
+    middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/naming/name_abstraction.cmx \

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -313,6 +313,7 @@ MIDDLE_END_FLAMBDA_SIMPLIFY=\
   middle_end/flambda/simplify/env/upwards_acc.cmo \
   middle_end/flambda/inlining/inlining_cost.cmo \
   middle_end/flambda/inlining/inlining_decision.cmo \
+  middle_end/flambda/inlining/inlining_report.cmo \
   middle_end/flambda/inlining/inlining_transforms.cmo \
   middle_end/flambda/simplify/simplify_simple.cmo \
   middle_end/flambda/simplify/simplify_import.cmo \

--- a/middle_end/flambda/inlining/inlining_cost.ml
+++ b/middle_end/flambda/inlining/inlining_cost.ml
@@ -479,6 +479,12 @@ module Threshold = struct
     | Never_inline
     | Can_inline_if_no_larger_than of int
 
+  let print fmt = function
+    | Never_inline ->
+      Format.fprintf fmt "Never_inline"
+    | Can_inline_if_no_larger_than max_size ->
+      Format.fprintf fmt "Can_inline_if_no_larger_than %d" max_size
+
   let add t1 t2 =
     match t1, t2 with
     | Never_inline, t -> t
@@ -502,16 +508,24 @@ module Threshold = struct
       Can_inline_if_no_larger_than (min i1 i2)
 end
 
-let smaller denv lam ~than =
-  smaller' denv lam ~than <> None
+module Inline_res = struct
 
-let can_inline denv lam inlining_threshold ~bonus =
+  type t =
+    | Cannot_inline
+    | Can_inline of int
+    (* size of the inlinable expression, used in inlining reports *)
+
+end
+
+let can_inline denv lam inlining_threshold ~bonus : Inline_res.t =
   match inlining_threshold with
-  | Threshold.Never_inline -> false
+  | Threshold.Never_inline -> Cannot_inline
   | Threshold.Can_inline_if_no_larger_than inlining_threshold ->
-     smaller denv
-       lam
-       ~than:(inlining_threshold + bonus)
+    begin match smaller' denv lam
+                  ~than:(inlining_threshold + bonus) with
+    | None -> Cannot_inline
+    | Some size -> Can_inline size
+    end
 
 let cost (flag : Clflags.Int_arg_helper.parsed) ~round =
   Clflags.Int_arg_helper.get ~key:round flag

--- a/middle_end/flambda/inlining/inlining_cost.ml
+++ b/middle_end/flambda/inlining/inlining_cost.ml
@@ -508,16 +508,12 @@ module Threshold = struct
       Can_inline_if_no_larger_than (min i1 i2)
 end
 
-module Inline_res = struct
+type inline_res =
+  | Cannot_inline
+  | Can_inline of int
+  (* size of the inlinable expression, used in inlining reports *)
 
-  type t =
-    | Cannot_inline
-    | Can_inline of int
-    (* size of the inlinable expression, used in inlining reports *)
-
-end
-
-let can_inline denv lam inlining_threshold ~bonus : Inline_res.t =
+let can_inline denv lam inlining_threshold ~bonus : inline_res =
   match inlining_threshold with
   | Threshold.Never_inline -> Cannot_inline
   | Threshold.Can_inline_if_no_larger_than inlining_threshold ->

--- a/middle_end/flambda/inlining/inlining_cost.mli
+++ b/middle_end/flambda/inlining/inlining_cost.mli
@@ -28,9 +28,26 @@ module Threshold : sig
     | Never_inline
     | Can_inline_if_no_larger_than of int
 
+  val print : Format.formatter -> t -> unit
+
   val add : t -> t -> t
   val sub : t -> t -> t
   val min : t -> t -> t
+end
+
+module Inline_res : sig
+  (** The result of checking whether some expression can be inlined,
+      i.e. whether its size is smaller than some threshold. *)
+
+  type t =
+    | Cannot_inline
+    (** The expression's size was larger than the given threshold.
+        Because in this case the size computation exits early,
+        the size of the expression is not available. *)
+    | Can_inline of int
+    (** The expressions's size was smaller than the inlining threshold,
+        and is represented by the given integer. *)
+
 end
 
 (* Determine whether the given Flambda expression has a sufficiently low space
@@ -41,7 +58,7 @@ val can_inline
   -> Expr.t
   -> Threshold.t
   -> bonus:int
-  -> bool
+  -> Inline_res.t
 
 module Benefit : sig
   (* A model of the benefit we gain by removing a particular combination

--- a/middle_end/flambda/inlining/inlining_cost.mli
+++ b/middle_end/flambda/inlining/inlining_cost.mli
@@ -35,20 +35,18 @@ module Threshold : sig
   val min : t -> t -> t
 end
 
-module Inline_res : sig
-  (** The result of checking whether some expression can be inlined,
-      i.e. whether its size is smaller than some threshold. *)
 
-  type t =
-    | Cannot_inline
-    (** The expression's size was larger than the given threshold.
-        Because in this case the size computation exits early,
-        the size of the expression is not available. *)
-    | Can_inline of int
-    (** The expressions's size was smaller than the inlining threshold,
-        and is represented by the given integer. *)
+type inline_res =
+  | Cannot_inline
+  (** The expression's size was larger than the given threshold.
+      Because in this case the size computation exits early,
+      the size of the expression is not available. *)
+  | Can_inline of int
+  (** The expressions's size was smaller than the inlining threshold,
+      and is represented by the given integer. *)
+(** The result of checking whether some expression can be inlined,
+    i.e. whether its size is smaller than some threshold. *)
 
-end
 
 (* Determine whether the given Flambda expression has a sufficiently low space
    cost so as to fit under the given [inlining_threshold].  The [bonus] is
@@ -58,7 +56,7 @@ val can_inline
   -> Expr.t
   -> Threshold.t
   -> bonus:int
-  -> Inline_res.t
+  -> inline_res
 
 module Benefit : sig
   (* A model of the benefit we gain by removing a particular combination

--- a/middle_end/flambda/inlining/inlining_decision.ml
+++ b/middle_end/flambda/inlining/inlining_decision.ml
@@ -33,16 +33,53 @@ module DE = Simplify_envs.Downwards_env
 module Function_declaration_decision = struct
   type t =
     | Never_inline_attribute
-    | Function_body_too_large
+    | Function_body_too_large of Inlining_cost.Threshold.t
     | Stub
-    | Inline
+    | Inline of (int * Inlining_cost.Threshold.t) option
 
   let can_inline t =
     match t with
     | Never_inline_attribute
-    | Function_body_too_large -> false
+    | Function_body_too_large _ -> false
     | Stub
-    | Inline -> true
+    | Inline _ -> true
+
+  let print fmt = function
+    | Never_inline_attribute ->
+      Format.fprintf fmt "Never_inline_attribute"
+    | Function_body_too_large threshold ->
+      Format.fprintf fmt "Function_body_too_large(%a)"
+        Inlining_cost.Threshold.print threshold
+    | Stub ->
+      Format.fprintf fmt "Stub"
+    | Inline None ->
+      Format.fprintf fmt "Inline_no_cost_computed"
+    | Inline Some (size, threshold) ->
+      Format.fprintf fmt "Inline(size=%d, %a)" size
+        Inlining_cost.Threshold.print threshold
+
+  let report_reason fmt = function
+    | Never_inline_attribute ->
+      Format.fprintf fmt "%a"
+        Format.pp_print_text "the function has an attribute preventing its inlining"
+    | Function_body_too_large threshold ->
+      Format.fprintf fmt "the@ function's@ body@ is@ too@ large,@ \
+                          more@ specifically,@ it@ is@ larger@ than@ the@ threshold:@ %a"
+        Inlining_cost.Threshold.print threshold
+    | Stub ->
+      Format.fprintf fmt "the@ function@ is@ a@ stub"
+    | Inline None ->
+      Format.fprintf fmt "the@ function@ has@ an@ attribute@ forcing@ its@ inlining"
+    | Inline Some (size, threshold) ->
+      Format.fprintf fmt "the@ function's@ body@ is@ smaller@ \
+                          than@ the@ threshold:@ size=%d < threshold=%a"
+        size Inlining_cost.Threshold.print threshold
+
+  let report fmt t =
+    Format.fprintf fmt "@[<v>The function %s be inlined at its use-sites@ \
+                        because @[<hov>%a@]@]"
+      (if can_inline t then "can" else "cannot") report_reason t
+
 end
 
 let make_decision_for_function_declaration denv ?params_and_body function_decl
@@ -53,7 +90,7 @@ let make_decision_for_function_declaration denv ?params_and_body function_decl
   let code = DE.find_code denv code_id in
   match Code.inline code with
   | Never_inline -> Never_inline_attribute
-  | Always_inline -> Inline
+  | Always_inline -> Inline None
   | Default_inline | Unroll _ ->
     if Code.stub code then Stub
     else
@@ -80,9 +117,9 @@ let make_decision_for_function_declaration denv ?params_and_body function_decl
                 (unscaled *.
                   (float_of_int Inlining_cost.scale_inline_threshold_by)))
           in
-          if Inlining_cost.can_inline denv body inlining_threshold ~bonus:0
-          then Inline
-          else Function_body_too_large)
+          match Inlining_cost.can_inline denv body inlining_threshold ~bonus:0 with
+          | Can_inline size -> Inline (Some (size, inlining_threshold))
+          | Cannot_inline -> Function_body_too_large inlining_threshold)
 
 module Call_site_decision = struct
   type attribute_causing_inlining =
@@ -137,6 +174,41 @@ module Call_site_decision = struct
     | Recursion_depth_exceeded
     | Never_inline_attribute -> Do_not_inline
     | Inline { attribute = _; unroll_to; } -> Inline { unroll_to; }
+
+
+  let report_reason fmt t =
+    match (t : t) with
+    | Environment_says_never_inline ->
+      Format.fprintf fmt "the@ environment@ says@ never@ to@ inline"
+    | Unrolling_depth_exceeded ->
+      Format.fprintf fmt "the@ maximum@ unrolling@ depth@ has@ been@ exceeded"
+    | Max_inlining_depth_exceeded ->
+      Format.fprintf fmt "the@ maximum@ inlining@ depth@ has@ been@ exceeded"
+    | Recursion_depth_exceeded ->
+      Format.fprintf fmt "the@ maximum@ recursion@ depth@ has@ been@ exceeded"
+    | Never_inline_attribute ->
+      Format.fprintf fmt "the@ call@ has@ an@ attribute@ forbidding@ inlining"
+    | Inline { attribute = None; unroll_to = None; } ->
+      Format.fprintf fmt "the@ decision@ at@ the@ function@ declaration"
+    | Inline { attribute = Some Always; unroll_to = _; } ->
+      Format.fprintf fmt "the@ [@inline always]@ attribute@ on@ the@ call"
+    | Inline { attribute = Some Unroll; unroll_to = Some n; } ->
+      Format.fprintf fmt "the@ [@unroll %d]@ attribute@ on@ the@ call" n
+
+    (* this should not happen *)
+    | Inline { attribute = None; unroll_to = Some _; }
+    | Inline { attribute = Some Unroll; unroll_to = None; }
+      ->
+      Misc.fatal_errorf "This should not happen (Inlining_decision.report is not in sync\
+                         with Inlining_decision.make_decision_for_call_site)"
+
+  let report fmt t =
+    Format.fprintf fmt "@[<v>The function call %s been inlined@ because of @[<hov>%a@]@]"
+      (match can_inline t with
+       | Inline _ -> "has"
+       | Do_not_inline -> "has not")
+      report_reason t
+
 end
 
 (* CR mshinwell: Overhaul handling of the inlining depth tracking so that

--- a/middle_end/flambda/inlining/inlining_decision.ml
+++ b/middle_end/flambda/inlining/inlining_decision.ml
@@ -189,11 +189,11 @@ module Call_site_decision = struct
     | Never_inline_attribute ->
       Format.fprintf fmt "the@ call@ has@ an@ attribute@ forbidding@ inlining"
     | Inline { attribute = None; unroll_to = None; } ->
-      Format.fprintf fmt "the@ decision@ at@ the@ function@ declaration"
+      Format.fprintf fmt "the@ function@ was@ deemed@ inlinable@ from@ its@ declaration"
     | Inline { attribute = Some Always; unroll_to = _; } ->
-      Format.fprintf fmt "the@ [@inline always]@ attribute@ on@ the@ call"
+      Format.fprintf fmt "the@ call@ has@ an@ [@@inline always]@ attribute"
     | Inline { attribute = Some Unroll; unroll_to = Some n; } ->
-      Format.fprintf fmt "the@ [@unroll %d]@ attribute@ on@ the@ call" n
+      Format.fprintf fmt "the@ call@ has@ an@ [@@unroll %d]@ attribute" n
 
     (* this should not happen *)
     | Inline { attribute = None; unroll_to = Some _; }
@@ -203,7 +203,7 @@ module Call_site_decision = struct
                          with Inlining_decision.make_decision_for_call_site)"
 
   let report fmt t =
-    Format.fprintf fmt "@[<v>The function call %s been inlined@ because of @[<hov>%a@]@]"
+    Format.fprintf fmt "@[<v>The function call %s been inlined@ because @[<hov>%a@]@]"
       (match can_inline t with
        | Inline _ -> "has"
        | Do_not_inline -> "has not")

--- a/middle_end/flambda/inlining/inlining_decision.mli
+++ b/middle_end/flambda/inlining/inlining_decision.mli
@@ -21,9 +21,13 @@ open! Flambda.Import
 module Function_declaration_decision : sig
   type t = private
     | Never_inline_attribute
-    | Function_body_too_large
+    | Function_body_too_large of Inlining_cost.Threshold.t
     | Stub
-    | Inline
+    | Inline of (int * Inlining_cost.Threshold.t) option
+
+  val print : Format.formatter -> t -> unit
+
+  val report : Format.formatter -> t -> unit
 
   val can_inline : t -> bool
 end
@@ -51,6 +55,8 @@ module Call_site_decision : sig
       }
 
   val print : Format.formatter -> t -> unit
+
+  val report : Format.formatter -> t -> unit
 
   type can_inline = private
     | Do_not_inline

--- a/middle_end/flambda/inlining/inlining_report.ml
+++ b/middle_end/flambda/inlining/inlining_report.ml
@@ -1,0 +1,176 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                        Guillaume Bury, OCamlPro                        *)
+(*                                                                        *)
+(*   Copyright 2020--2020 OCamlPro SAS                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Decisions related to inlining,
+
+   This includes deciding not to consider some function for inlining
+   (e.g. method, c-calls, or function with no precise enough type to
+   inline). *)
+
+module Decision = struct
+
+  module At_call_site = struct
+
+    type t =
+      | C_call
+      | Method
+      | Unknown_function
+      | Non_inlinable_function of {
+          code_id : Code_id.t;
+        }
+      | Inlinable_function of {
+          code_id : Code_id.t;
+          decision : Inlining_decision.Call_site_decision.t;
+        }
+
+  end
+
+  module At_function_declaration = struct
+
+    type pass =
+      | Before_simplify
+      | After_simplify
+
+    type t = {
+      pass : pass;
+      code_id : Code_id.t;
+      decision : Inlining_decision.Function_declaration_decision.t;
+    }
+
+  end
+
+  type t =
+    | At_call_site of At_call_site.t
+    | At_function_declaration of At_function_declaration.t
+
+end
+
+(* Log for a whole round
+
+   Currently, we make use of the precise ordering of decisions to print
+   the log in a somewhat hierarchical manner. More precisely, we rely on the
+   fact that there are two decisions for a function declarations: before and after
+   simplify. This make it possible to treat those two decisions as "entering"
+   and "exiting" the function's body, considering all decisions that occur in between
+   to pertain to the body of the function, using the order of the list insertions of
+   the {record_decision} function.
+
+   On the other hand, flambda1 had a non-mutable way of storing this information as
+   a closure_stack (see trunk:middle_end/flambda/inlining_stats.ml) in the environment
+   of the simplification process. This could be replicated here, i.e. we could store
+   something akin to flambda1's Closure_stack.t inside the denv if the current mutable
+   way proves to be too annoying.
+*)
+
+(* Individual decisions, with debuginfo *)
+type t = {
+  dbg : Debuginfo.t;
+  decision : Decision.t;
+}
+
+(* Actual log storage. During simplification, in order to be more efficient,
+   decisions are stored from the most recent one (in the head of the list),
+   to the oldest one (at the end of the list).
+   This means that one should rev the list before printing. *)
+let log : t list ref = ref []
+
+let stars fmt depth =
+  Format.fprintf fmt "%s" (String.make (depth + 1) '*')
+
+let rec print ~depth fmt = function
+  (* end of report log *)
+  | [] ->
+    if depth <> 0 then
+      Misc.fatal_errorf "incoherent depth at end of inlining report"
+
+  (* Entering a function declaration (possibly nested) *)
+  | { dbg; decision = At_function_declaration {
+      pass = Before_simplify; code_id; decision; } } :: r ->
+    Format.fprintf fmt "%a Definition of %s{%a}@\n"
+      stars depth (Code_id.name code_id) Debuginfo.print dbg;
+    Format.fprintf fmt "%a @[<v>Before simplification:@ @ %a@]@\n@\n"
+      stars (depth + 1)
+      Inlining_decision.Function_declaration_decision.report decision;
+    print ~depth:(depth + 1) fmt r
+
+  (* Function call *)
+  | { decision = At_call_site C_call; dbg; } :: r ->
+    Format.fprintf fmt "%a @[<v>%s of %s{%a}@ @ %s@ %s@]@\n@\n"
+      stars depth
+      (if depth = 0 then "Toplevel application" else "Application")
+      "<unknown function>" Debuginfo.print dbg
+      "The C function call has not been inlined"
+      "because the optimizer cannot inline C calls";
+    print ~depth fmt r
+  | { decision = At_call_site Method; dbg; } :: r ->
+    Format.fprintf fmt "%a @[<v>%s of %s{%a}@ @ %s@ %s@]@\n@\n"
+      stars depth
+      (if depth = 0 then "Toplevel application" else "Application")
+      "<unknown function>" Debuginfo.print dbg
+      "The method call has not been inlined"
+      "because the optimizer cannot inline method calls";
+    print ~depth fmt r
+  | { decision = At_call_site Unknown_function; dbg; } :: r ->
+    Format.fprintf fmt "%a @[<v>%s of %s{%a}@ @ %s@ %s@]@\n@\n"
+      stars depth
+      (if depth = 0 then "Toplevel application" else "Application")
+      "<unknown function>" Debuginfo.print dbg
+      "The function call has not been inlined"
+      "because the optimizer had not enough information about the function";
+    print ~depth fmt r
+  | { decision = At_call_site (Non_inlinable_function { code_id; });
+      dbg; } :: r ->
+    Format.fprintf fmt "%a @[<v>%s of %s{%a}@ @ %s@ %s@]@\n@\n"
+      stars depth
+      (if depth = 0 then "Toplevel application" else "Application")
+      (Code_id.name code_id) Debuginfo.print dbg
+      "The function call has not been inlined"
+      "because its definition was deemed not inlinable";
+    print ~depth fmt r
+  | { decision = At_call_site (Inlinable_function { code_id; decision; });
+      dbg; } :: r ->
+    Format.fprintf fmt "%a @[<v>%s of %s{%a}@ @ %a@]@\n@\n"
+      stars depth
+      (if depth = 0 then "Toplevel application" else "Application")
+      (Code_id.name code_id) Debuginfo.print dbg
+      Inlining_decision.Call_site_decision.report decision;
+    print ~depth fmt r
+
+  (* Exiting a function_declaration (possibly nested) *)
+  | { dbg ; decision = At_function_declaration {
+      pass = After_simplify; code_id; decision; } } :: r ->
+    Format.fprintf fmt "%a @[<v>After simplification of %s{%a}:@ @ %a@]@\n@\n@\n"
+      stars depth (Code_id.name code_id) Debuginfo.print dbg
+      Inlining_decision.Function_declaration_decision.report decision;
+    print ~depth:(depth - 1) fmt r
+
+
+
+(* Exposed interface *)
+
+let record_decision ~dbg decision =
+  if !Clflags.inlining_report then begin
+    log := { dbg; decision; } :: !log
+  end
+
+let output_then_forget_decisions ~output_prefix =
+  if !Clflags.inlining_report then begin
+    let out_channel = open_out (output_prefix ^ ".inlining.org") in
+    let fmt = Format.formatter_of_out_channel out_channel in
+    Format.fprintf fmt "%a@." (print ~depth:0) (List.rev !log);
+    close_out out_channel;
+    log := [];
+  end
+
+

--- a/middle_end/flambda/inlining/inlining_report.mli
+++ b/middle_end/flambda/inlining/inlining_report.mli
@@ -1,0 +1,76 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                        Guillaume Bury, OCamlPro                        *)
+(*                                                                        *)
+(*   Copyright 2020--2020 OCamlPro SAS                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Report inlining decisions *)
+
+module Decision : sig
+  (** This modules defines the various kinds of decisions related to
+      inlining that will be reported, together with some additional
+      information to better identify to what the decision refers to. *)
+
+  module At_call_site : sig
+
+    type t =
+      | C_call
+      | Method
+      | Unknown_function
+      (** Function call where the function's type is unknown. *)
+      | Non_inlinable_function of {
+          code_id : Code_id.t; (** code id of the callee *)
+        }
+      (** Function call where the function's type is known,
+          but was marked as non-inlinable. *)
+      | Inlinable_function of {
+          code_id : Code_id.t; (** code id of the callee *)
+          decision : Inlining_decision.Call_site_decision.t;
+        }
+      (** Function call where the function's type is known,
+          and was marked as inlinable. *)
+
+  end
+
+  module At_function_declaration : sig
+
+    type pass =
+      | Before_simplify
+      | After_simplify (**)
+    (** There are two decisions made for each function declaration:
+        one before simplifying the body, and one after (this is useful
+        for e.g. recursive functions). *)
+
+    type t = {
+      pass : pass;
+      code_id : Code_id.t; (** code id of the function being declared *)
+      decision : Inlining_decision.Function_declaration_decision.t;
+    }
+
+  end
+
+  type t =
+    | At_call_site of At_call_site.t
+    | At_function_declaration of At_function_declaration.t (**)
+
+end
+
+
+val record_decision : dbg:Debuginfo.t -> Decision.t -> unit
+(** Record a decision. *)
+
+val output_then_forget_decisions : output_prefix:string -> unit
+(** Output the report for all recorded decisions up to that point,
+    and clean/forget all decisions.
+    Note that this function should be called once for each round of
+    simplification. *)
+
+

--- a/middle_end/flambda/inlining/inlining_report.mli
+++ b/middle_end/flambda/inlining/inlining_report.mli
@@ -14,57 +14,42 @@
 
 (** Report inlining decisions *)
 
-module Decision : sig
-  (** This modules defines the various kinds of decisions related to
-      inlining that will be reported, together with some additional
-      information to better identify to what the decision refers to. *)
-
-  module At_call_site : sig
-
-    type t =
-      | C_call
-      | Method
-      | Unknown_function
-      (** Function call where the function's type is unknown. *)
-      | Non_inlinable_function of {
-          code_id : Code_id.t; (** code id of the callee *)
-        }
-      (** Function call where the function's type is known,
-          but was marked as non-inlinable. *)
-      | Inlinable_function of {
-          code_id : Code_id.t; (** code id of the callee *)
-          decision : Inlining_decision.Call_site_decision.t;
-        }
-      (** Function call where the function's type is known,
-          and was marked as inlinable. *)
-
-  end
-
-  module At_function_declaration : sig
-
-    type pass =
-      | Before_simplify
-      | After_simplify (**)
-    (** There are two decisions made for each function declaration:
-        one before simplifying the body, and one after (this is useful
-        for e.g. recursive functions). *)
-
-    type t = {
-      pass : pass;
-      code_id : Code_id.t; (** code id of the function being declared *)
-      decision : Inlining_decision.Function_declaration_decision.t;
+type at_call_site =
+  | Unknown_function
+  (** Function call where the function's type is unknown. *)
+  | Non_inlinable_function of {
+      code_id : Code_id.t; (** code id of the callee *)
     }
+  (** Function call where the function's type is known,
+      but was marked as non-inlinable. *)
+  | Inlinable_function of {
+      code_id : Code_id.t; (** code id of the callee *)
+      decision : Inlining_decision.Call_site_decision.t;
+    }
+  (** Function call where the function's type is known,
+      and was marked as inlinable. *)
 
-  end
+type fundecl_pass =
+  | Before_simplify
+  | After_simplify (**)
+(** There are two decisions made for each function declaration:
+    one before simplifying the body, and one after (this is useful
+    for e.g. recursive functions). *)
 
-  type t =
-    | At_call_site of At_call_site.t
-    | At_function_declaration of At_function_declaration.t (**)
+type at_function_declaration = {
+  pass : fundecl_pass;
+  code_id : Code_id.t; (** code id of the function being declared *)
+  decision : Inlining_decision.Function_declaration_decision.t;
+}
 
-end
+type decision =
+  | At_call_site of at_call_site
+  | At_function_declaration of at_function_declaration (**)
+(** This defines the various kinds of decisions related to
+    inlining that will be reported, together with some additional
+    information to better identify to what the decision refers to. *)
 
-
-val record_decision : dbg:Debuginfo.t -> Decision.t -> unit
+val record_decision : dbg:Debuginfo.t -> decision -> unit
 (** Record a decision. *)
 
 val output_then_forget_decisions : output_prefix:string -> unit

--- a/middle_end/flambda/simplify/simplify_apply_expr.rec.ml
+++ b/middle_end/flambda/simplify/simplify_apply_expr.rec.ml
@@ -754,12 +754,8 @@ let simplify_apply dacc apply ~down_to_up =
     | Function call ->
       simplify_function_call dacc apply ~callee_ty call ~arg_types ~down_to_up
     | Method { kind; obj; } ->
-      Inlining_report.record_decision (At_call_site Method)
-        ~dbg:(DE.add_inlined_debuginfo' (DA.denv dacc) (Apply.dbg apply));
       simplify_method_call dacc apply ~callee_ty ~kind ~obj ~arg_types
         ~down_to_up
     | C_call { alloc = _; param_arity; return_arity; } ->
-      Inlining_report.record_decision (At_call_site C_call)
-        ~dbg:(DE.add_inlined_debuginfo' (DA.denv dacc) (Apply.dbg apply));
       simplify_c_call dacc apply ~callee_ty ~param_arity ~return_arity
         ~arg_types ~down_to_up

--- a/middle_end/flambda/simplify/simplify_apply_expr.rec.ml
+++ b/middle_end/flambda/simplify/simplify_apply_expr.rec.ml
@@ -78,12 +78,16 @@ let rebuild_non_inlined_direct_full_application apply ~use_id ~exn_cont_use_id
   after_rebuild expr uacc
 
 let simplify_direct_full_application dacc apply function_decl_opt
-      ~result_arity ~down_to_up =
+      ~callee's_code_id ~result_arity ~down_to_up =
   let callee = Apply.callee apply in
   let args = Apply.args apply in
   let inlined =
     match function_decl_opt with
-    | None -> None
+    | None ->
+      Inlining_report.record_decision
+        (At_call_site (Non_inlinable_function { code_id = callee's_code_id; }))
+        ~dbg:(DE.add_inlined_debuginfo' (DA.denv dacc) (Apply.dbg apply));
+      None
     | Some (function_decl, function_decl_rec_info) ->
       let apply_inlining_depth = Apply.inlining_depth apply in
       let decision =
@@ -92,6 +96,10 @@ let simplify_direct_full_application dacc apply function_decl_opt
           ~apply_inlining_depth
           (Apply.inline apply)
       in
+      let code_id = T.Function_declaration_type.Inlinable.code_id function_decl in
+      Inlining_report.record_decision
+        (At_call_site (Inlinable_function { code_id; decision; }))
+        ~dbg:(DE.add_inlined_debuginfo' (DA.denv dacc) (Apply.dbg apply));
       match Inlining_decision.Call_site_decision.can_inline decision with
       | Do_not_inline ->
         None
@@ -368,7 +376,7 @@ let simplify_direct_function_call dacc apply ~callee's_code_id_from_type
       let num_params = List.length param_arity in
       if provided_num_args = num_params then
         simplify_direct_full_application dacc apply function_decl_opt
-          ~result_arity ~down_to_up
+          ~callee's_code_id ~result_arity ~down_to_up
       else if provided_num_args > num_params then
         simplify_direct_over_application dacc apply ~param_arity ~result_arity
           ~down_to_up
@@ -405,6 +413,8 @@ let simplify_function_call_where_callee's_type_unavailable dacc apply
     | Return continuation -> continuation
   in
   let denv = DA.denv dacc in
+  Inlining_report.record_decision (At_call_site Unknown_function)
+    ~dbg:(DE.add_inlined_debuginfo' denv (Apply.dbg apply));
   let env_at_use = denv in
   let dacc, exn_cont_use_id =
     DA.record_continuation_use dacc
@@ -744,8 +754,12 @@ let simplify_apply dacc apply ~down_to_up =
     | Function call ->
       simplify_function_call dacc apply ~callee_ty call ~arg_types ~down_to_up
     | Method { kind; obj; } ->
+      Inlining_report.record_decision (At_call_site Method)
+        ~dbg:(DE.add_inlined_debuginfo' (DA.denv dacc) (Apply.dbg apply));
       simplify_method_call dacc apply ~callee_ty ~kind ~obj ~arg_types
         ~down_to_up
     | C_call { alloc = _; param_arity; return_arity; } ->
+      Inlining_report.record_decision (At_call_site C_call)
+        ~dbg:(DE.add_inlined_debuginfo' (DA.denv dacc) (Apply.dbg apply));
       simplify_c_call dacc apply ~callee_ty ~param_arity ~return_arity
         ~arg_types ~down_to_up

--- a/middle_end/flambda/simplify/simplify_set_of_closures.rec.ml
+++ b/middle_end/flambda/simplify/simplify_set_of_closures.rec.ml
@@ -149,7 +149,7 @@ end = struct
                     old_to_new_code_ids_all_sets
                 in
                 function_decl_type
-                  ~pass:Before_simplify
+                  ~pass:Inlining_report.Before_simplify
                   denv function_decl
                   ~code_id:new_code_id
                   (Rec_info.create ~depth:1 ~unroll_to:None))
@@ -429,7 +429,7 @@ let simplify_function context ~used_closure_vars ~shareable_constants
       (* We need to use [dacc_after_body] to ensure that all [code_ids] in
          [params_and_body] are available for the inlining decision code. *)
       function_decl_type
-        ~pass:After_simplify
+        ~pass:Inlining_report.After_simplify
         (DA.denv dacc_after_body) function_decl
         ~params_and_body Rec_info.initial
     in

--- a/middle_end/flambda/simplify/simplify_set_of_closures.rec.ml
+++ b/middle_end/flambda/simplify/simplify_set_of_closures.rec.ml
@@ -26,12 +26,14 @@ open! Simplify_import
    file tail recursive, although it probably isn't necessary, as
    excessive levels of nesting of functions seems unlikely. *)
 
-let function_decl_type denv function_decl ?code_id ?params_and_body rec_info =
+let function_decl_type ~pass denv function_decl ?code_id ?params_and_body rec_info =
   let decision =
     Inlining_decision.make_decision_for_function_declaration
       denv ?params_and_body function_decl
   in
   let code_id = Option.value code_id ~default:(FD.code_id function_decl) in
+  Inlining_report.record_decision (At_function_declaration { code_id; pass; decision; })
+    ~dbg:(DE.add_inlined_debuginfo' denv (FD.dbg function_decl));
   if Inlining_decision.Function_declaration_decision.can_inline decision then
     T.create_inlinable_function_declaration
       ~code_id
@@ -146,7 +148,9 @@ end = struct
                   Code_id.Map.find (FD.code_id function_decl)
                     old_to_new_code_ids_all_sets
                 in
-                function_decl_type denv function_decl
+                function_decl_type
+                  ~pass:Before_simplify
+                  denv function_decl
                   ~code_id:new_code_id
                   (Rec_info.create ~depth:1 ~unroll_to:None))
               (Function_declarations.funs function_decls)
@@ -424,7 +428,9 @@ let simplify_function context ~used_closure_vars ~shareable_constants
     let function_type =
       (* We need to use [dacc_after_body] to ensure that all [code_ids] in
          [params_and_body] are available for the inlining decision code. *)
-      function_decl_type (DA.denv dacc_after_body) function_decl
+      function_decl_type
+        ~pass:After_simplify
+        (DA.denv dacc_after_body) function_decl
         ~params_and_body Rec_info.initial
     in
     { function_decl;


### PR DESCRIPTION
This PR adds inlining reports to flambda2. For now this follows roughly the same format as flambda1 (at least the structure of the file, the reports for each decisions are different).

On the following file:

```ocaml

let f x = x + 1

let g x y =
  let h z = f z + x in
  h y + h x

let () =
  print_int (f 0)
```

This produces the following report:
```
* Definition of f_0{inline.ml:2,6--15}
** Before simplification:
   
   The function can be inlined at its use-sites
   because the function's body is smaller than the threshold:
           size=3 < threshold=Can_inline_if_no_larger_than 10

** After simplification of f_0{inline.ml:2,6--15}:
   
   The function can be inlined at its use-sites
   because the function's body is smaller than the threshold:
           size=3 < threshold=Can_inline_if_no_larger_than 10


* Definition of g_1{inline.ml:4,6--46}
** Before simplification:
   
   The function cannot be inlined at its use-sites
   because the function's body is too large, more specifically, it is larger
           than the threshold: Can_inline_if_no_larger_than 10

** Definition of h_2{inline.ml:5,8--19}
*** Before simplification:
    
    The function cannot be inlined at its use-sites
    because the function's body is too large, more specifically, it is larger
            than the threshold: Can_inline_if_no_larger_than 10

*** Application of f_0{inline.ml:5,12--15}
    
    The function call has been inlined
    because of the decision at the function declaration

*** After simplification of h_2{inline.ml:5,8--19}:
    
    The function can be inlined at its use-sites
    because the function's body is smaller than the threshold:
            size=6 < threshold=Can_inline_if_no_larger_than 10


** Application of h_2{inline.ml:6,8--11}
   
   The function call has been inlined
   because of the decision at the function declaration

** Application of h_2{inline.ml:6,2--5}
   
   The function call has been inlined
   because of the decision at the function declaration

** After simplification of g_1{inline.ml:4,6--46}:
   
   The function cannot be inlined at its use-sites
   because the function's body is too large, more specifically, it is larger
           than the threshold: Can_inline_if_no_larger_than 10


* Toplevel application of f_0{inline.ml:9,12--17}
  
  The function call has been inlined
  because of the decision at the function declaration

```
