### PR TITLE
Implement Hint inline

### DIFF
--- a/middle_end/flambda/basic/inline_attribute.ml
+++ b/middle_end/flambda/basic/inline_attribute.ml
@@ -18,6 +18,7 @@
 
 type t =
   | Always_inline
+  | Hint_inline
   | Never_inline
   | Unroll of int
   | Default_inline
@@ -26,6 +27,7 @@ let print ppf t =
   let fprintf = Format.fprintf in
   match t with
   | Always_inline -> fprintf ppf "Always_inline"
+  | Hint_inline -> fprintf ppf "Hint_inline"
   | Never_inline -> fprintf ppf "Never_inline"
   | Unroll n -> fprintf ppf "@[(Unroll %d)@]" n
   | Default_inline -> fprintf ppf "Default_inline"

--- a/middle_end/flambda/basic/inline_attribute.mli
+++ b/middle_end/flambda/basic/inline_attribute.mli
@@ -18,6 +18,7 @@
 
 type t =
   | Always_inline
+  | Hint_inline
   | Never_inline
   | Unroll of int
   | Default_inline

--- a/middle_end/flambda/from_lambda/lambda_conversions.ml
+++ b/middle_end/flambda/from_lambda/lambda_conversions.ml
@@ -40,7 +40,7 @@ let inline_attribute (attr : L.inline_attribute) : Inline_attribute.t =
   match attr with
   | Always_inline -> Always_inline
   | Never_inline -> Never_inline
-  | Hint_inline -> Always_inline
+  | Hint_inline -> Hint_inline
   | Unroll i -> Unroll i
   | Default_inline -> Default_inline
 

--- a/middle_end/flambda/inlining/inlining_decision.ml
+++ b/middle_end/flambda/inlining/inlining_decision.ml
@@ -90,7 +90,7 @@ let make_decision_for_function_declaration denv ?params_and_body function_decl
   let code = DE.find_code denv code_id in
   match Code.inline code with
   | Never_inline -> Never_inline_attribute
-  | Always_inline -> Inline None
+  | Hint_inline | Always_inline -> Inline None
   | Default_inline | Unroll _ ->
     if Code.stub code then Stub
     else
@@ -226,7 +226,7 @@ let make_decision_for_call_site denv ~function_decl_rec_info
   else
     match inline with
     | Never_inline -> Never_inline_attribute
-    | Default_inline | Unroll _ | Always_inline ->
+    | Default_inline | Unroll _ | Always_inline | Hint_inline ->
       match Rec_info.unroll_to function_decl_rec_info with
       | Some unroll_to ->
         if Rec_info.depth function_decl_rec_info >= unroll_to then
@@ -250,5 +250,5 @@ let make_decision_for_call_site denv ~function_decl_rec_info
               Rec_info.depth function_decl_rec_info + unroll_to
             in
             Inline { attribute = Some Unroll; unroll_to = Some unroll_to; }
-          | Always_inline ->
+          | Always_inline | Hint_inline ->
             Inline { attribute = Some Always; unroll_to = None; }

--- a/middle_end/flambda/naming/name_permutation.ml
+++ b/middle_end/flambda/naming/name_permutation.ml
@@ -19,8 +19,8 @@
 (* CR mshinwell: Disabling warning 55 is required to satisfy Closure, work
    out something better... *)
 
-module Continuations = (Permutation.Make [@inlined always]) (Continuation)
-module Variables = (Permutation.Make [@inlined always]) (Variable)
+module Continuations = (Permutation.Make [@inlined hint]) (Continuation)
+module Variables = (Permutation.Make [@inlined hint]) (Variable)
 
 type t = {
   continuations : Continuations.t;

--- a/middle_end/flambda/parser/fexpr.ml
+++ b/middle_end/flambda/parser/fexpr.ml
@@ -198,6 +198,7 @@ type function_arities = {
 
 type inline_attribute = Inline_attribute.t =
   | Always_inline
+  | Hint_inline
   | Never_inline
   | Unroll of int
   | Default_inline

--- a/middle_end/flambda/parser/flambda_lex.mll
+++ b/middle_end/flambda/parser/flambda_lex.mll
@@ -49,6 +49,7 @@ let keyword_table =
     "fabricated", FABRICATED;
     "float", FLOAT_KIND;
     "halt_and_catch_fire", HCF;
+    "hint", HINT;
     "imm", IMM;
     "immutable_unique", IMMUTABLE_UNIQUE;
     "in", IN;

--- a/middle_end/flambda/parser/flambda_parser.mly
+++ b/middle_end/flambda/parser/flambda_parser.mly
@@ -75,6 +75,7 @@ let make_const_int (i, m) : const =
 %token GREATERDOT [@symbol ">."]
 %token GREATEREQUALDOT [@symbol ">"]
 %token HCF   [@symbol "HCF"]
+%token HINT  [@symbol "hint"]
 %token <string> IDENT
 %token IMM   [@symbol "imm" ]
 %token IMMUTABLE_UNIQUE [@symbol "immutable_unique"]
@@ -489,6 +490,7 @@ call_kind:
 
 inline:
   | INLINE LPAREN ALWAYS RPAREN { Always_inline }
+  | INLINE LPAREN HINT RPAREN { Hint_inline }
   | INLINE LPAREN NEVER RPAREN { Never_inline }
   | UNROLL LPAREN; i = plain_int; RPAREN { Unroll i }
   | INLINE LPAREN DEFAULT RPAREN { Default_inline }

--- a/middle_end/flambda/parser/print_fexpr.ml
+++ b/middle_end/flambda/parser/print_fexpr.ml
@@ -375,6 +375,7 @@ let inline_attribute ?prefix ?suffix () ppf (i : Inline_attribute.t) =
   let str =
     match i with
     | Always_inline -> Some "inline(always)"
+    | Hint_inline -> Some "inline(hint)"
     | Never_inline -> Some "inline(never)"
     | Unroll i -> Some (Format.sprintf "unroll(%d)" i)
     | Default_inline -> None

--- a/middle_end/flambda/terms/code.rec.ml
+++ b/middle_end/flambda/terms/code.rec.ml
@@ -67,8 +67,8 @@ let create
       ~is_a_functor
       ~recursive =
   begin match stub, inline with
-  | true, (Never_inline | Default_inline)
-  | false, (Never_inline | Default_inline | Always_inline | Unroll _) -> ()
+  | true, (Hint_inline | Never_inline | Default_inline)
+  | false, (Never_inline | Default_inline | Always_inline | Hint_inline | Unroll _) -> ()
   | true, (Always_inline | Unroll _) ->
     Misc.fatal_error "Stubs may not be annotated as [Always_inline] or [Unroll]"
   end;

--- a/testsuite/tests/basic-float/tfloat_record.ml
+++ b/testsuite/tests/basic-float/tfloat_record.ml
@@ -35,7 +35,7 @@ print_newline ();;
 
 
 let b = Float_array.small_float_array 12
-let c = (Float_array.longer_float_array [@inlined]) 34
+let c = Float_array.longer_float_array 34
 
 let print_array a =
   Array.iter (fun f ->

--- a/testsuite/tests/warnings/w55.flambda.reference
+++ b/testsuite/tests/warnings/w55.flambda.reference
@@ -1,12 +1,16 @@
-File "w55.ml", line 33, characters 10-26:
-33 | let h x = (j [@inlined]) x
+File "w55.ml", line 25, characters 10-26:
+25 | let g x = (f [@inlined]) x
                ^^^^^^^^^^^^^^^^
-Warning 55: Cannot inline: [@inlined] attributes may not be used on partial applications
+Warning 55: Cannot inline: [@inlined] attribute was not used on this function application (the optimizer decided not to inline the function given its definition)
 File "w55.ml", line 29, characters 10-27:
 29 | let i x = (!r [@inlined]) x
                ^^^^^^^^^^^^^^^^^
 Warning 55: Cannot inline: [@inlined] attribute was not used on this function application (the optimizer did not know what function was being applied)
-File "w55.ml", line 39, characters 12-30:
-39 | let b x y = (a [@inlined]) x y
-                 ^^^^^^^^^^^^^^^^^^
-Warning 55: Cannot inline: [@inlined] attribute was not used on this function application (the optimizer did not know what function was being applied)
+File "w55.ml", line 33, characters 10-26:
+33 | let h x = (j [@inlined]) x
+               ^^^^^^^^^^^^^^^^
+Warning 55: Cannot inline: [@inlined] attributes may not be used on partial applications
+File "w55.ml", line 42, characters 10-26:
+42 | let d x = (c [@inlined]) x
+               ^^^^^^^^^^^^^^^^
+Warning 55: Cannot inline: [@inlined] attribute was not used on this function application (the optimizer decided not to inline the function given its definition)

--- a/utils/identifiable.ml
+++ b/utils/identifiable.ml
@@ -111,7 +111,7 @@ module Pair (A : Thing) (B : Thing) : Thing with type t = A.t * B.t = struct
 end
 
 module Make_map (T : Thing) (Set : Set with module T := T) = struct
-  include (Map.Make [@inlined always]) (T)
+  include (Map.Make [@inlined hint]) (T)
 
   module Set = Set
 
@@ -222,7 +222,7 @@ end [@@@inline always]
 
 module Make_set (T : Thing) = struct
   module T0 = struct
-    include (Set.Make [@inlined always]) (T)
+    include (Set.Make [@inlined hint]) (T)
 
     let output oc s =
       Printf.fprintf oc " ( ";
@@ -263,7 +263,7 @@ module Make_set (T : Thing) = struct
 end [@@@inline always]
 
 module Make_tbl (T : Thing) (Map : Map with module T := T) = struct
-  include (Hashtbl.Make [@inlined always]) (T)
+  include (Hashtbl.Make [@inlined hint]) (T)
 
   module Map = Map
 


### PR DESCRIPTION
As commit messages say, three changes in this PR:
- change the occurrences in the code of `[@inlined always]` attribute into `[@inlined hint]` in order for the compiler to be able to build using a non-flambda compiler with dune. The only changes needed were on `Set/Map` functors that closure cannot inline because the functors are not defined in the same file as the one where they are used.
- implement hint_inline in flmbda2: that means actually raising warning 55 when adequate, and propagating the hint_inline attribute to silence these warnings where the hint is present
- adapt the testsuite file for warning 55.

An example of the warnings emitted can be found in the reference files for testsuite test `warnings/w55.ml`. Flambda2 currently behaves in the same way as closure modulo a few things:
- cross-module inlining should work with flambda2 (and not closure), though this is not tested in the testsuite
- over-applications can be inlined by flambda2 since if enough information is available, flambda2 will split the over-application into a full application, and an application for the rest of the arguments, and the full application can be inlined (as well as the left-over application potentially), see the `a`, `b` example from the testsuite.

For reference, here is the testsuite file:
```
let f = (fun x -> x + 1) [@inline never]

let g x = (f [@inlined]) x

let r = ref f

let i x = (!r [@inlined]) x

let j x y = x + y

let h x = (j [@inlined]) x

let a x =
  let b = x + 1 in
  fun y -> y + b

let b x y = (a [@inlined]) x y

let c x = x + 1 [@@inline never]
let d x = (c [@inlined]) x

let g' x = (f [@inlined hint]) x

let i' x = (!r [@inlined hint]) x

let h' x = (j [@inlined hint]) x

let b' x y = (a [@inlined hint]) x y

let d' x = (c [@inlined hint]) x
```

The results with closure:
```
File "w55.ml", line 25, characters 10-26:
25 | let g x = (f [@inlined]) x
               ^^^^^^^^^^^^^^^^
Warning 55: Cannot inline: Function information unavailable
File "w55.ml", line 29, characters 10-27:
29 | let i x = (!r [@inlined]) x
               ^^^^^^^^^^^^^^^^^
Warning 55: Cannot inline: Unknown function
File "w55.ml", line 33, characters 10-26:
33 | let h x = (j [@inlined]) x
               ^^^^^^^^^^^^^^^^
Warning 55: Cannot inline: Partial application
File "w55.ml", line 39, characters 12-30:
39 | let b x y = (a [@inlined]) x y
                 ^^^^^^^^^^^^^^^^^^
Warning 55: Cannot inline: Over-application
File "w55.ml", line 39, characters 12-30:
39 | let b x y = (a [@inlined]) x y
                 ^^^^^^^^^^^^^^^^^^
Warning 55: Cannot inline: Function information unavailable
File "w55.ml", line 42, characters 10-26:
42 | let d x = (c [@inlined]) x
               ^^^^^^^^^^^^^^^^
Warning 55: Cannot inline: Function information unavailable
```

The results with flambda2 can be seen in the `testsuite/warnings/w55.flambda.reference` file in the changes of this PR (with the old contents of the file being what fambda1 emits, and the new contents what flambda2 emits).