### PR TITLE
Add symbols and code_ids to name permutations

### DIFF
--- a/.depend
+++ b/.depend
@@ -5591,20 +5591,26 @@ middle_end/flambda/naming/name_occurrences.cmi : \
     middle_end/flambda/basic/code_id.cmi
 middle_end/flambda/naming/name_permutation.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
+    middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/naming/permutation.cmi \
     middle_end/flambda/basic/name.cmi \
     middle_end/flambda/basic/continuation.cmi \
+    middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/naming/name_permutation.cmi
 middle_end/flambda/naming/name_permutation.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
+    middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/naming/permutation.cmx \
     middle_end/flambda/basic/name.cmx \
     middle_end/flambda/basic/continuation.cmx \
+    middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/naming/name_permutation.cmi
 middle_end/flambda/naming/name_permutation.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
+    middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/basic/name.cmi \
-    middle_end/flambda/basic/continuation.cmi
+    middle_end/flambda/basic/continuation.cmi \
+    middle_end/flambda/basic/code_id.cmi
 middle_end/flambda/naming/num_occurrences.cmo : \
     middle_end/flambda/naming/num_occurrences.cmi
 middle_end/flambda/naming/num_occurrences.cmx : \
@@ -7404,6 +7410,7 @@ middle_end/flambda/terms/apply_expr.cmi : \
     middle_end/flambda/terms/call_kind.cmi
 middle_end/flambda/terms/bound_symbols.cmo : \
     middle_end/flambda/compilenv_deps/symbol.cmi \
+    middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     utils/misc.cmi \
@@ -7414,6 +7421,7 @@ middle_end/flambda/terms/bound_symbols.cmo : \
     middle_end/flambda/terms/bound_symbols.cmi
 middle_end/flambda/terms/bound_symbols.cmx : \
     middle_end/flambda/compilenv_deps/symbol.cmx \
+    middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     utils/misc.cmx \
@@ -7431,6 +7439,7 @@ middle_end/flambda/terms/bound_symbols.cmi : \
     middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/terms/call_kind.cmo : \
     middle_end/flambda/basic/simple.cmi \
+    middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     utils/misc.cmi \
@@ -7443,6 +7452,7 @@ middle_end/flambda/terms/call_kind.cmo : \
     middle_end/flambda/terms/call_kind.cmi
 middle_end/flambda/terms/call_kind.cmx : \
     middle_end/flambda/basic/simple.cmx \
+    middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     utils/misc.cmx \
@@ -7465,6 +7475,7 @@ middle_end/flambda/terms/code.rec.cmo : \
     middle_end/flambda/basic/recursive.cmi \
     utils/printing_cache.cmi \
     middle_end/flambda/basic/or_deleted.cmi \
+    middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/basic/name.cmi \
@@ -7481,6 +7492,7 @@ middle_end/flambda/terms/code.rec.cmx : \
     middle_end/flambda/basic/recursive.cmx \
     utils/printing_cache.cmx \
     middle_end/flambda/basic/or_deleted.cmx \
+    middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/basic/name.cmx \
@@ -7823,21 +7835,29 @@ middle_end/flambda/terms/flambda_primitive.cmi : \
     middle_end/flambda/basic/coeffects.cmi \
     middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/terms/flambda_unit.cmo : \
+    middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
+    middle_end/flambda/naming/name_permutation.cmi \
     utils/misc.cmi \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/basic/continuation.cmi \
+    middle_end/flambda/compilenv_deps/compilation_unit.cmi \
+    middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/naming/bindable_let_bound.cmi \
     middle_end/flambda/terms/flambda_unit.cmi
 middle_end/flambda/terms/flambda_unit.cmx : \
+    middle_end/flambda/compilenv_deps/variable.cmx \
     middle_end/flambda/basic/var_within_closure.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/types/basic/or_unknown.cmx \
+    middle_end/flambda/naming/name_permutation.cmx \
     utils/misc.cmx \
     middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/basic/continuation.cmx \
+    middle_end/flambda/compilenv_deps/compilation_unit.cmx \
+    middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/naming/bindable_let_bound.cmx \
     middle_end/flambda/terms/flambda_unit.cmi
 middle_end/flambda/terms/flambda_unit.cmi : \
@@ -7850,6 +7870,7 @@ middle_end/flambda/terms/flambda_unit.cmi : \
     middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/terms/function_declaration.cmo : \
     utils/printing_cache.cmi \
+    middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
@@ -7859,6 +7880,7 @@ middle_end/flambda/terms/function_declaration.cmo : \
     middle_end/flambda/terms/function_declaration.cmi
 middle_end/flambda/terms/function_declaration.cmx : \
     utils/printing_cache.cmx \
+    middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
@@ -8215,6 +8237,7 @@ middle_end/flambda/terms/symbol_projection.cmo : \
     middle_end/flambda/basic/var_within_closure.cmi \
     utils/targetint.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
+    middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
@@ -8224,6 +8247,7 @@ middle_end/flambda/terms/symbol_projection.cmx : \
     middle_end/flambda/basic/var_within_closure.cmx \
     utils/targetint.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
+    middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
@@ -9381,6 +9405,7 @@ middle_end/flambda/types/structures/function_declaration_type.rec.cmo : \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
     middle_end/flambda/types/basic/or_unknown_or_bottom.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
+    middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/types/structures/lattice_ops_intf.cmo \
@@ -9393,6 +9418,7 @@ middle_end/flambda/types/structures/function_declaration_type.rec.cmx : \
     middle_end/flambda/compilenv_deps/rec_info.cmx \
     middle_end/flambda/types/basic/or_unknown_or_bottom.cmx \
     middle_end/flambda/types/basic/or_bottom.cmx \
+    middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/types/structures/lattice_ops_intf.cmx \

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -987,6 +987,16 @@ let mk_flambda_expert_max_block_size_for_projections f =
     this value"
 ;;
 
+let mk_flambda_debug_permute_every_name f =
+  "-flambda-debug-permute-every-name", Arg.Unit f,
+    " Permute every name to check permutation works"
+;;
+
+let mk_no_flambda_debug_permute_every_name f =
+  "-no-flambda-debug-permute-every-name", Arg.Unit f,
+    " Do not permute every name to check permutation works"
+;;
+
 let mk_flambda_debug_concrete_types_only_on_canonicals f =
   "-flambda-debug-concrete-types-only-on-canonicals", Arg.Unit f,
     " Check that concrete types are only assigned to canonical names"
@@ -1235,6 +1245,8 @@ module type Optcommon_options = sig
   val _no_flambda_expert_phantom_lets : unit -> unit
   val _flambda_expert_max_inlining_depth : int -> unit
   val _flambda_expert_max_block_size_for_projections : int -> unit
+  val _flambda_debug_permute_every_name : unit -> unit
+  val _no_flambda_debug_permute_every_name : unit -> unit
   val _flambda_debug_concrete_types_only_on_canonicals : unit -> unit
   val _no_flambda_debug_concrete_types_only_on_canonicals : unit -> unit
 
@@ -1599,6 +1611,10 @@ struct
       F._flambda_expert_max_inlining_depth;
     mk_flambda_expert_max_block_size_for_projections
       F._flambda_expert_max_block_size_for_projections;
+    mk_flambda_debug_permute_every_name
+      F._flambda_debug_permute_every_name;
+    mk_no_flambda_debug_permute_every_name
+      F._no_flambda_debug_permute_every_name;
     mk_flambda_debug_concrete_types_only_on_canonicals
       F._flambda_debug_concrete_types_only_on_canonicals;
     mk_no_flambda_debug_concrete_types_only_on_canonicals
@@ -1758,6 +1774,10 @@ module Make_opttop_options (F : Opttop_options) = struct
       F._flambda_expert_max_inlining_depth;
     mk_flambda_expert_max_block_size_for_projections
       F._flambda_expert_max_block_size_for_projections;
+    mk_flambda_debug_permute_every_name
+      F._flambda_debug_permute_every_name;
+    mk_no_flambda_debug_permute_every_name
+      F._no_flambda_debug_permute_every_name;
     mk_flambda_debug_concrete_types_only_on_canonicals
       F._flambda_debug_concrete_types_only_on_canonicals;
     mk_no_flambda_debug_concrete_types_only_on_canonicals
@@ -2067,6 +2087,10 @@ module Default = struct
       Flambda.Expert.max_inlining_depth := depth
     let _flambda_expert_max_block_size_for_projections size =
       Flambda.Expert.max_block_size_for_projections := Some size
+    let _flambda_debug_permute_every_name =
+      set Flambda.Debug.permute_every_name
+    let _no_flambda_debug_permute_every_name =
+      clear Flambda.Debug.permute_every_name
     let _flambda_debug_concrete_types_only_on_canonicals =
       set Flambda.Debug.concrete_types_only_on_canonicals
     let _no_flambda_debug_concrete_types_only_on_canonicals =

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -243,6 +243,8 @@ module type Optcommon_options = sig
   val _no_flambda_expert_phantom_lets : unit -> unit
   val _flambda_expert_max_inlining_depth : int -> unit
   val _flambda_expert_max_block_size_for_projections : int -> unit
+  val _flambda_debug_permute_every_name : unit -> unit
+  val _no_flambda_debug_permute_every_name : unit -> unit
   val _flambda_debug_concrete_types_only_on_canonicals : unit -> unit
   val _no_flambda_debug_concrete_types_only_on_canonicals : unit -> unit
 

--- a/middle_end/flambda/flambda_middle_end.ml
+++ b/middle_end/flambda/flambda_middle_end.ml
@@ -143,6 +143,11 @@ let middle_end0 ppf ~prefixname ~backend ~filename ~module_ident
     in
     print_rawflambda ppf flambda;
     check_invariants flambda;
+    let flambda =
+      if !Clflags.Flambda.Debug.permute_every_name
+      then Flambda_unit.permute_everything flambda
+      else flambda
+    in
     let round = 0 in
     let new_flambda =
       Profile.record_call ~accumulate:true "simplify"

--- a/middle_end/flambda/naming/bindable_let_bound.ml
+++ b/middle_end/flambda/naming/bindable_let_bound.ml
@@ -93,7 +93,12 @@ let apply_name_permutation t perm =
     in
     if closure_vars == closure_vars' then t
     else Set_of_closures { name_mode; closure_vars = closure_vars'; }
-  | Symbols _ -> t
+  | Symbols ({ bound_symbols; scoping_rule = _; } as symbols) ->
+    let bound_symbols' =
+      Bound_symbols.apply_name_permutation bound_symbols perm
+    in
+    if bound_symbols == bound_symbols' then t
+    else Symbols { symbols with bound_symbols = bound_symbols'; }
 
 let all_ids_for_export t =
   match t with

--- a/middle_end/flambda/naming/bindable_let_bound.ml
+++ b/middle_end/flambda/naming/bindable_let_bound.ml
@@ -93,12 +93,12 @@ let apply_name_permutation t perm =
     in
     if closure_vars == closure_vars' then t
     else Set_of_closures { name_mode; closure_vars = closure_vars'; }
-  | Symbols ({ bound_symbols; scoping_rule = _; } as symbols) ->
+  | Symbols { bound_symbols; scoping_rule; } ->
     let bound_symbols' =
       Bound_symbols.apply_name_permutation bound_symbols perm
     in
     if bound_symbols == bound_symbols' then t
-    else Symbols { symbols with bound_symbols = bound_symbols'; }
+    else Symbols { scoping_rule; bound_symbols = bound_symbols'; }
 
 let all_ids_for_export t =
   match t with

--- a/middle_end/flambda/naming/name_occurrences.ml
+++ b/middle_end/flambda/naming/name_occurrences.ml
@@ -620,6 +620,9 @@ end)
 module For_code_ids = For_one_variety_of_names (struct
   include Code_id
   (* We never bind [Code_id]s using [Name_abstraction]. *)
+  (* CR gbury: should we nevertheless call Name_permutation.apply_code_id,
+     at least for theoretical correctness ? (and if not, these should
+     probably be fatal_errors) *)
   let apply_name_permutation t _perm = t
 end)
 

--- a/middle_end/flambda/naming/name_occurrences.ml
+++ b/middle_end/flambda/naming/name_occurrences.ml
@@ -620,10 +620,7 @@ end)
 module For_code_ids = For_one_variety_of_names (struct
   include Code_id
   (* We never bind [Code_id]s using [Name_abstraction]. *)
-  (* CR gbury: should we nevertheless call Name_permutation.apply_code_id,
-     at least for theoretical correctness ? (and if not, these should
-     probably be fatal_errors) *)
-  let apply_name_permutation t _perm = t
+  let apply_name_permutation t perm = Name_permutation.apply_code_id perm t
 end)
 
 type t = {

--- a/middle_end/flambda/naming/name_permutation.ml
+++ b/middle_end/flambda/naming/name_permutation.ml
@@ -81,6 +81,7 @@ let compose ~second ~first =
   else if is_empty first then second
   else compose0 ~second ~first
 
+
 (* variables *)
 
 let add_variable t var1 var2 =
@@ -127,12 +128,14 @@ let apply_symbol_set t symbols =
     symbols
     Symbol.Set.empty
 
+
 (* application of permutations *)
 
 let apply_name t name =
   Name.pattern_match name
     ~var:(fun var -> Name.var (apply_variable t var))
     ~symbol:(fun symbol -> Name.symbol (apply_symbol t symbol))
+
 
 (* continuations *)
 
@@ -149,6 +152,7 @@ let add_fresh_continuation t k1 ~guaranteed_fresh:k2 =
 
 let apply_continuation t k =
   Continuations.apply t.continuations k
+
 
 (* Code ids *)
 

--- a/middle_end/flambda/naming/name_permutation.ml
+++ b/middle_end/flambda/naming/name_permutation.ml
@@ -2,7 +2,7 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*                       Pierre Chambart, OCamlPro                        *)
+(*    Pierre Chambart and Guillaume Bury, OCamlPro                        *)
 (*           Mark Shinwell and Leo White, Jane Street Europe              *)
 (*                                                                        *)
 (*   Copyright 2018--2019 OCamlPro SAS                                    *)
@@ -21,47 +21,67 @@
 
 module Continuations = (Permutation.Make [@inlined hint]) (Continuation)
 module Variables = (Permutation.Make [@inlined hint]) (Variable)
+module Code_ids = (Permutation.Make [@inlined hint]) (Code_id)
+module Symbols = (Permutation.Make [@inlined hint]) (Symbol)
 
 type t = {
   continuations : Continuations.t;
   variables : Variables.t;
+  code_ids : Code_ids.t;
+  symbols : Symbols.t;
 }
 
 let empty =
   { continuations = Continuations.empty;
     variables = Variables.empty;
+    code_ids = Code_ids.empty;
+    symbols = Symbols.empty;
   }
 
-let print ppf { continuations; variables; } =
+let print ppf { continuations; variables; code_ids; symbols; } =
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(continuations@ %a)@]@ \
       @[<hov 1>(variables@ %a)@])\
+      @[<hov 1>(code_ids@ %a)@])\
+      @[<hov 1>(symbols@ %a)@])\
       @]"
     Continuations.print continuations
     Variables.print variables
+    Code_ids.print code_ids
+    Symbols.print symbols
 
-let is_empty { continuations; variables }  =
+let is_empty { continuations; variables; code_ids; symbols; }  =
   Continuations.is_empty continuations
-    && Variables.is_empty variables
+  && Variables.is_empty variables
+  && Code_ids.is_empty code_ids
+  && Symbols.is_empty symbols
 
 let compose0
       ~second:
         { continuations = continuations2;
           variables = variables2;
+          code_ids = code_ids2;
+          symbols = symbols2;
         }
       ~first:
         { continuations = continuations1;
           variables = variables1;
+          code_ids = code_ids1;
+          symbols = symbols1;
         } =
   { continuations =
       Continuations.compose ~second:continuations2 ~first:continuations1;
     variables = Variables.compose ~second:variables2 ~first:variables1;
+    code_ids = Code_ids.compose ~second:code_ids2 ~first:code_ids1;
+    symbols = Symbols.compose ~second:symbols2 ~first:symbols1;
   }
 
 let compose ~second ~first =
   if is_empty second then first
   else if is_empty first then second
   else compose0 ~second ~first
+
+(* variables *)
 
 let add_variable t var1 var2 =
   { t with
@@ -84,10 +104,37 @@ let apply_variable_set t vars =
     vars
     Variable.Set.empty
 
+
+(* symbols *)
+
+let add_symbol t symbol1 symbol2 =
+  { t with
+    symbols = Symbols.compose_one ~first:t.symbols symbol1 symbol2;
+  }
+
+let add_fresh_symbol t symbol1 ~guaranteed_fresh:symbol2 =
+  { t with
+    symbols = Symbols.compose_one_fresh t.symbols symbol1 ~fresh:symbol2;
+  }
+
+let apply_symbol t symbol =
+  Symbols.apply t.symbols symbol
+
+let apply_symbol_set t symbols =
+  Symbol.Set.fold (fun symbol result ->
+    let symbol = apply_symbol t symbol in
+    Symbol.Set.add symbol result)
+    symbols
+    Symbol.Set.empty
+
+(* application of permutations *)
+
 let apply_name t name =
   Name.pattern_match name
     ~var:(fun var -> Name.var (apply_variable t var))
-    ~symbol:(fun _ -> name)
+    ~symbol:(fun symbol -> Name.symbol (apply_symbol t symbol))
+
+(* continuations *)
 
 let add_continuation t k1 k2 =
   { t with
@@ -102,3 +149,20 @@ let add_fresh_continuation t k1 ~guaranteed_fresh:k2 =
 
 let apply_continuation t k =
   Continuations.apply t.continuations k
+
+(* Code ids *)
+
+let add_code_id t code_id1 code_id2 =
+  { t with
+    code_ids = Code_ids.compose_one ~first:t.code_ids code_id1 code_id2;
+  }
+
+let add_fresh_code_id t code_id1 ~guaranteed_fresh:code_id2 =
+  { t with
+    code_ids = Code_ids.compose_one_fresh t.code_ids code_id1 ~fresh:code_id2;
+  }
+
+let apply_code_id t code_id =
+  Code_ids.apply t.code_ids code_id
+
+

--- a/middle_end/flambda/naming/name_permutation.mli
+++ b/middle_end/flambda/naming/name_permutation.mli
@@ -34,6 +34,8 @@ val is_empty : t -> bool
     [first] then subsequently like [second]. *)
 val compose : second:t -> first:t -> t
 
+
+(** Variable bindings *)
 val add_variable : t -> Variable.t -> Variable.t -> t
 
 val add_fresh_variable : t -> Variable.t -> guaranteed_fresh:Variable.t -> t
@@ -42,8 +44,22 @@ val apply_variable : t -> Variable.t -> Variable.t
 
 val apply_variable_set : t -> Variable.Set.t -> Variable.Set.t
 
+
+(** Symbol bindings *)
+val add_symbol : t -> Symbol.t -> Symbol.t -> t
+
+val add_fresh_symbol : t -> Symbol.t -> guaranteed_fresh:Symbol.t -> t
+
+val apply_symbol : t -> Symbol.t -> Symbol.t
+
+val apply_symbol_set : t -> Symbol.Set.t -> Symbol.Set.t
+
+
+(** Application to {Name.t} *)
 val apply_name : t -> Name.t -> Name.t
 
+
+(** Continuation bindings *)
 val add_continuation : t -> Continuation.t -> Continuation.t -> t
 
 val add_fresh_continuation
@@ -53,3 +69,16 @@ val add_fresh_continuation
   -> t
 
 val apply_continuation : t -> Continuation.t -> Continuation.t
+
+
+(** Code_id bindings *)
+val add_code_id : t -> Code_id.t -> Code_id.t -> t
+
+val add_fresh_code_id
+   : t
+  -> Code_id.t
+  -> guaranteed_fresh:Code_id.t
+  -> t
+
+val apply_code_id : t -> Code_id.t -> Code_id.t
+

--- a/middle_end/flambda/terms/bound_symbols.ml
+++ b/middle_end/flambda/terms/bound_symbols.ml
@@ -36,6 +36,15 @@ module Pattern = struct
     | Block_like symbol ->
       Format.fprintf ppf "@[<hov 1>(Block_like@ %a)@]" Symbol.print symbol
 
+  let apply_name_permutation t perm =
+    match t with
+    | Code code_id ->
+      Code (Name_permutation.apply_code_id perm code_id)
+    | Set_of_closures map ->
+      Set_of_closures (Closure_id.Lmap.map (Name_permutation.apply_symbol perm) map)
+    | Block_like symbol ->
+      Block_like (Name_permutation.apply_symbol perm symbol)
+
   let free_names t =
     match t with
     | Code code_id ->
@@ -170,7 +179,8 @@ let for_all_everything_being_defined t ~f =
     t
     f
 
-let apply_name_permutation t _perm = t
+let apply_name_permutation t perm =
+  List.map (fun pattern -> Pattern.apply_name_permutation pattern perm) t
 
 let free_names t =
   List.map Pattern.free_names t

--- a/middle_end/flambda/terms/call_kind.ml
+++ b/middle_end/flambda/terms/call_kind.ml
@@ -167,7 +167,10 @@ let free_names t =
 
 let apply_name_permutation t perm =
   match t with
-  | Function (Direct { code_id = _; closure_id = _; return_arity = _; })
+  | Function (Direct { code_id; closure_id; return_arity; }) ->
+    let code_id' = Name_permutation.apply_code_id perm code_id in
+    if code_id == code_id' then t
+    else Function (Direct { code_id = code_id'; closure_id; return_arity; })
   | Function Indirect_unknown_arity
   | Function (Indirect_known_arity { param_arity = _; return_arity = _; })
   | C_call { alloc = _; param_arity = _; return_arity = _; } -> t

--- a/middle_end/flambda/terms/code.rec.ml
+++ b/middle_end/flambda/terms/code.rec.ml
@@ -213,10 +213,21 @@ let free_names t =
   Name_occurrences.union from_newer_version_of t.free_names_of_params_and_body
 
 let apply_name_permutation
-      ({ code_id = _; params_and_body; newer_version_of = _; params_arity = _;
+      ({ code_id; params_and_body; newer_version_of; params_arity = _;
          result_arity = _; stub = _; inline = _; is_a_functor = _;
-         recursive = _; free_names_of_params_and_body = _; } as t)
+         recursive = _; free_names_of_params_and_body } as t)
       perm =
+  (* inlined and modified version of Option.map to preserve sharing *)
+  let newer_version_of' =
+    match newer_version_of with
+    | None -> newer_version_of
+    | Some code_id ->
+      let code_id' = Name_permutation.apply_code_id perm code_id in
+      if code_id == code_id'
+      then newer_version_of
+      else Some code_id'
+  in
+  let code_id' = Name_permutation.apply_code_id perm code_id in
   let params_and_body' : Function_params_and_body.t Or_deleted.t =
     match params_and_body with
     | Deleted -> Deleted
@@ -230,12 +241,19 @@ let apply_name_permutation
       else
         Present params_and_body_inner'
   in
-  (* N.B. At present we don't need to apply the permutation to
-     [free_names_of_params_and_body] since we never permute symbols or
-     code IDs. *)
-  if params_and_body == params_and_body' then t
-  else
-    { t with params_and_body = params_and_body'; }
+  if params_and_body == params_and_body' &&
+     code_id == code_id' &&
+     newer_version_of == newer_version_of' then t
+  else begin
+    let free_names_of_params_and_body' =
+      Name_occurrences.apply_name_permutation free_name_sof_params_and_body
+    in
+    { t with code_id = code_id';
+             params_and_body = params_and_body';
+             newer_version_of = newer_version_of';
+             free_names_of_params_and_body = free_names_of_params_and_body;
+    }
+  end
 
 let all_ids_for_export { code_id; params_and_body; newer_version_of;
                          params_arity = _; result_arity = _; stub = _;

--- a/middle_end/flambda/terms/code.rec.ml
+++ b/middle_end/flambda/terms/code.rec.ml
@@ -246,12 +246,12 @@ let apply_name_permutation
      newer_version_of == newer_version_of' then t
   else begin
     let free_names_of_params_and_body' =
-      Name_occurrences.apply_name_permutation free_name_sof_params_and_body
+      Name_occurrences.apply_name_permutation free_names_of_params_and_body perm
     in
     { t with code_id = code_id';
              params_and_body = params_and_body';
              newer_version_of = newer_version_of';
-             free_names_of_params_and_body = free_names_of_params_and_body;
+             free_names_of_params_and_body = free_names_of_params_and_body';
     }
   end
 

--- a/middle_end/flambda/terms/flambda.mli
+++ b/middle_end/flambda/terms/flambda.mli
@@ -42,6 +42,8 @@ module rec Expr : sig
   (** Printing, invariant checks, name manipulation, etc. *)
   include Expr_std.S with type t := t
 
+  val all_ids_for_export : t -> Ids_for_export.t
+
   type descr = private
     | Let of Let_expr.t
     (** Bind variable(s) or symbol(s).  There can be no effect on control flow

--- a/middle_end/flambda/terms/flambda_unit.ml
+++ b/middle_end/flambda/terms/flambda_unit.ml
@@ -39,6 +39,7 @@ let return_continuation t = t.return_continuation
 let exn_continuation t = t.exn_continuation
 let body t = t.body
 let module_symbol t = t.module_symbol
+let used_closure_vars t = t.used_closure_vars
 
 let print ppf
       { return_continuation; exn_continuation; body; module_symbol;
@@ -59,7 +60,56 @@ let print ppf
 
 let invariant _t = ()
 
-let used_closure_vars t = t.used_closure_vars
+let apply_name_permutation { return_continuation; exn_continuation;
+                             body; module_symbol; used_closure_vars; } perm =
+  let body = Expr.apply_name_permutation body perm in
+  let module_symbol = Name_permutation.apply_symbol perm module_symbol in
+  let return_continuation = Name_permutation.apply_continuation perm return_continuation in
+  let exn_continuation = Name_permutation.apply_continuation perm exn_continuation in
+  let used_closure_vars = Or_unknown.map used_closure_vars ~f:(fun set ->
+    Var_within_closure.Set.map (fun var ->
+      let comp_unit = Var_within_closure.get_compilation_unit var in
+      let v = Var_within_closure.unwrap var in
+      let v' = Name_permutation.apply_variable perm v in
+      Var_within_closure.wrap comp_unit v'
+    ) set)
+  in
+  create ~return_continuation ~exn_continuation ~body ~module_symbol ~used_closure_vars
+
+let permute_everything t =
+  (* Only symbols (and code_ids) from the current compilation unit, and
+     that are not the module symbol can be safely permuted *)
+  let current_comp_unit = Compilation_unit.get_current_exn () in
+  let ids = Expr.all_ids_for_export t.body in
+  let perm = Name_permutation.empty in
+  let perm = Symbol.Set.fold (fun symbol perm ->
+    if Symbol.in_compilation_unit symbol current_comp_unit
+       && not (Symbol.equal t.module_symbol symbol) then begin
+      let guaranteed_fresh = Symbol.rename symbol in
+      Name_permutation.add_fresh_symbol perm symbol ~guaranteed_fresh
+    end else
+      perm
+  ) ids.symbols perm
+  in
+  let perm = Code_id.Set.fold (fun code_id perm ->
+    if Code_id.in_compilation_unit code_id current_comp_unit then begin
+      let guaranteed_fresh = Code_id.rename code_id in
+      Name_permutation.add_fresh_code_id perm code_id ~guaranteed_fresh
+    end else
+      perm
+  ) ids.code_ids perm
+  in
+  let perm = Variable.Set.fold (fun variable perm ->
+    let guaranteed_fresh = Variable.rename variable in
+    Name_permutation.add_fresh_variable perm variable ~guaranteed_fresh
+  ) ids.variables perm
+  in
+  let perm = Continuation.Set.fold (fun k perm ->
+    let guaranteed_fresh = Continuation.rename k in
+    Name_permutation.add_fresh_continuation perm k ~guaranteed_fresh
+  ) ids.continuations perm
+  in
+  apply_name_permutation t perm
 
 (* Iter on all sets of closures of a given program. *)
 (* CR mshinwell: These functions should be pushed directly into [Flambda] *)

--- a/middle_end/flambda/terms/flambda_unit.ml
+++ b/middle_end/flambda/terms/flambda_unit.ml
@@ -66,14 +66,6 @@ let apply_name_permutation { return_continuation; exn_continuation;
   let module_symbol = Name_permutation.apply_symbol perm module_symbol in
   let return_continuation = Name_permutation.apply_continuation perm return_continuation in
   let exn_continuation = Name_permutation.apply_continuation perm exn_continuation in
-  let used_closure_vars = Or_unknown.map used_closure_vars ~f:(fun set ->
-    Var_within_closure.Set.map (fun var ->
-      let comp_unit = Var_within_closure.get_compilation_unit var in
-      let v = Var_within_closure.unwrap var in
-      let v' = Name_permutation.apply_variable perm v in
-      Var_within_closure.wrap comp_unit v'
-    ) set)
-  in
   create ~return_continuation ~exn_continuation ~body ~module_symbol ~used_closure_vars
 
 let permute_everything t =

--- a/middle_end/flambda/terms/flambda_unit.mli
+++ b/middle_end/flambda/terms/flambda_unit.mli
@@ -46,6 +46,8 @@ val used_closure_vars : t -> Var_within_closure.Set.t Or_unknown.t
 
 val body : t -> Flambda.Expr.t
 
+val permute_everything : t -> t
+
 val iter
    : ?code:(id:Code_id.t
      -> Flambda.Code.t

--- a/middle_end/flambda/terms/function_declaration.ml
+++ b/middle_end/flambda/terms/function_declaration.ml
@@ -62,7 +62,10 @@ let free_names
       } =
   Name_occurrences.add_code_id Name_occurrences.empty code_id Name_mode.normal
 
-let apply_name_permutation t _perm = t
+let apply_name_permutation ({ code_id; dbg = _; is_tupled = _; } as t) perm =
+  let code_id' = Name_permutation.apply_code_id perm code_id in
+  if code_id == code_id' then t
+  else { t with code_id = code_id'; }
 
 let all_ids_for_export
       { code_id;

--- a/middle_end/flambda/terms/function_declarations.ml
+++ b/middle_end/flambda/terms/function_declarations.ml
@@ -57,6 +57,10 @@ let free_names { funs; _ } =
     funs
     (Name_occurrences.empty)
 
+(* Note: the call to {create} at the end already takes into account the
+   permutation applied to the function_declarations in {in_order}, so
+   there is no need to apply_name_permutation the func_decls in the {funs}
+   field. *)
 let apply_name_permutation ({ in_order; _ } as t) perm =
   let in_order' =
     Closure_id.Lmap.map_sharing (fun func_decl ->

--- a/middle_end/flambda/terms/static_const.rec.ml
+++ b/middle_end/flambda/terms/static_const.rec.ml
@@ -65,7 +65,11 @@ module Field_of_block = struct
 
   let apply_name_permutation t perm =
     match t with
-    | Symbol _ | Tagged_immediate _ -> t
+    | Tagged_immediate _ -> t
+    | Symbol symbol ->
+      let symbol' = Name_permutation.apply_symbol perm symbol in
+      if symbol == symbol' then t
+      else Symbol symbol'
     | Dynamically_computed var ->
       let var' = Name_permutation.apply_variable perm var in
       if var == var' then t

--- a/middle_end/flambda/terms/symbol_projection.ml
+++ b/middle_end/flambda/terms/symbol_projection.ml
@@ -92,7 +92,10 @@ let equal t1 t2 =
 let hash { symbol; projection; } =
   Hashtbl.hash (Symbol.hash symbol, Projection.hash projection)
 
-let apply_name_permutation ({ symbol = _; projection = _; } as t) _perm = t
+let apply_name_permutation ({ symbol; projection = _; } as t) perm =
+  let symbol' = Name_permutation.apply_symbol perm symbol in
+  if symbol == symbol' then t
+  else { t with symbol = symbol'; }
 
 let free_names { symbol; projection = _; } =
   Name_occurrences.singleton_symbol symbol Name_mode.normal

--- a/middle_end/flambda/types/env/typing_env_level.rec.ml
+++ b/middle_end/flambda/types/env/typing_env_level.rec.ml
@@ -130,20 +130,6 @@ let apply_name_permutation
       equations
       Name.Map.empty
   in
-  let cse_changed = ref false in
-  let cse' =
-    Flambda_primitive.Eligible_for_cse.Map.fold (fun prim simple cse' ->
-        let simple' = Simple.apply_name_permutation simple perm in
-        let prim' =
-          Flambda_primitive.Eligible_for_cse.apply_name_permutation prim perm
-        in
-        if (not (simple == simple')) || (not (prim == prim')) then begin
-          cse_changed := true
-        end;
-        Flambda_primitive.Eligible_for_cse.Map.add prim' simple' cse')
-      cse
-      Flambda_primitive.Eligible_for_cse.Map.empty
-  in
   let symbol_projections_changed = ref false in
   let symbol_projections' =
     Variable.Map.fold (fun var projection symbol_projections ->
@@ -161,14 +147,12 @@ let apply_name_permutation
   in
   if (not !defined_vars_changed)
     && (not !equations_changed)
-    && (not !cse_changed)
     && (not !symbol_projections_changed)
   then t
   else
     { defined_vars = defined_vars';
       binding_times = binding_times';
       equations = equations';
-      cse = cse';
       symbol_projections = symbol_projections';
     }
 

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -441,6 +441,7 @@ module Flambda = struct
   end
 
   module Debug = struct
+    let permute_every_name = ref false
     let concrete_types_only_on_canonicals = ref false
   end
 

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -261,6 +261,7 @@ module Flambda : sig
   end
 
   module Debug : sig
+    val permute_every_name : bool ref
     val concrete_types_only_on_canonicals : bool ref
   end
 


### PR DESCRIPTION
This PR's main goal is to add symbols and code_ids to name permutations.
- The first commit simply add the possibility for name_permutations to also map symbols and code_ids
- The second commit updates all the implementations of `apply_name_premutation` to correctly substitute symbols and code_ids, and propagate to structures that can contain these (whereas before it wasn't necessary so it was not propagated in some places)
- The third commit adds code to test permutations, by permuting every symbol, code_id, variable, and continuation that appears in an flambda unit (with a CLI option to enable/disable the permutation

The compiler seems to compile and work fine with the permute-ever-name option `true` by default, which seems to indicate the extension of `apply_name_permutation` to symbols and code_ids is correct and complete (else I'd expect missing symbol errors 
 occur during linking). I'm checking to see whether the permuted ocamlopt also passes the testsuite.