### PR TITLE
Add machine readable inlining reports

### DIFF
--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -170,9 +170,10 @@ let mk_inlining_report f =
       round) showing the inliner's decisions, in a human readable format"
 ;;
 
-let mk_inlining_report_mr f =
-  "-inlining-report-mr", Arg.Unit f, " Emit `.<round>.inlining' file(s) (one per \
-      round) showing the inliner's decisions in a machine readable format"
+let mk_inlining_report_serialized f =
+  "-inlining-report-serialized", Arg.Unit f, " Emit `.<round>.inlining' \
+      file(s) (one per round) showing the inliner's decisions in a serialized \
+      format"
 ;;
 
 
@@ -1170,7 +1171,7 @@ module type Optcommon_options = sig
   val _inline : string -> unit
   val _inline_toplevel : string -> unit
   val _inlining_report : unit -> unit
-  val _inlining_report_mr : unit -> unit
+  val _inlining_report_serialized : unit -> unit
   val _dump_pass : string -> unit
   val _inline_max_depth : string -> unit
   val _rounds : int -> unit
@@ -1502,7 +1503,7 @@ struct
     mk_inline_indirect_cost F._inline_indirect_cost;
     mk_inline_lifting_benefit F._inline_lifting_benefit;
     mk_inlining_report F._inlining_report;
-    mk_inlining_report_mr F._inlining_report_mr;
+    mk_inlining_report_serialized F._inlining_report_serialized;
     mk_insn_sched F._insn_sched;
     mk_intf F._intf;
     mk_intf_suffix F._intf_suffix;
@@ -1675,7 +1676,7 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_inline F._inline;
     mk_inline_toplevel F._inline_toplevel;
     mk_inlining_report F._inlining_report;
-    mk_inlining_report_mr F._inlining_report_mr;
+    mk_inlining_report_serialized F._inlining_report_serialized;
     mk_rounds F._rounds;
     mk_inline_max_unroll F._inline_max_unroll;
     mk_inline_call_cost F._inline_call_cost;
@@ -2032,7 +2033,7 @@ module Default = struct
         "Syntax: -inline-toplevel <n> | <round>=<n>[,...]"
         inline_toplevel_threshold
     let _inlining_report () = inlining_report := true
-    let _inlining_report_mr () = inlining_report_mr := true
+    let _inlining_report_serialized () = inlining_report_serialized := true
     let _insn_sched = set insn_sched
     let _no_insn_sched = clear insn_sched
     let _linscan = set use_linscan

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -171,7 +171,7 @@ let mk_inlining_report f =
 ;;
 
 let mk_inlining_report_bin f =
-  "-inlining-report-serialized", Arg.Unit f, " Emit `.<round>.inlining' \
+  "-inlining-report-bin", Arg.Unit f, " Emit `.<round>.inlining' \
       file(s) (one per round) recording the inliner's decisions in a bianry \
       format"
 ;;

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -166,13 +166,13 @@ let mk_inline_toplevel f =
 ;;
 
 let mk_inlining_report f =
-  "-inlining-report", Arg.Unit f, " Emit `.<round>.inlining' file(s) (one per \
+  "-inlining-report", Arg.Unit f, " Emit `.<round>.inlining.org' file(s) (one per \
       round) showing the inliner's decisions, in a human readable format"
 ;;
 
-let mk_inlining_report_serialized f =
+let mk_inlining_report_bin f =
   "-inlining-report-serialized", Arg.Unit f, " Emit `.<round>.inlining' \
-      file(s) (one per round) showing the inliner's decisions in a serialized \
+      file(s) (one per round) recording the inliner's decisions in a bianry \
       format"
 ;;
 
@@ -1171,7 +1171,7 @@ module type Optcommon_options = sig
   val _inline : string -> unit
   val _inline_toplevel : string -> unit
   val _inlining_report : unit -> unit
-  val _inlining_report_serialized : unit -> unit
+  val _inlining_report_bin : unit -> unit
   val _dump_pass : string -> unit
   val _inline_max_depth : string -> unit
   val _rounds : int -> unit
@@ -1503,7 +1503,7 @@ struct
     mk_inline_indirect_cost F._inline_indirect_cost;
     mk_inline_lifting_benefit F._inline_lifting_benefit;
     mk_inlining_report F._inlining_report;
-    mk_inlining_report_serialized F._inlining_report_serialized;
+    mk_inlining_report_bin F._inlining_report_bin;
     mk_insn_sched F._insn_sched;
     mk_intf F._intf;
     mk_intf_suffix F._intf_suffix;
@@ -1676,7 +1676,7 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_inline F._inline;
     mk_inline_toplevel F._inline_toplevel;
     mk_inlining_report F._inlining_report;
-    mk_inlining_report_serialized F._inlining_report_serialized;
+    mk_inlining_report_bin F._inlining_report_bin;
     mk_rounds F._rounds;
     mk_inline_max_unroll F._inline_max_unroll;
     mk_inline_call_cost F._inline_call_cost;
@@ -2033,7 +2033,7 @@ module Default = struct
         "Syntax: -inline-toplevel <n> | <round>=<n>[,...]"
         inline_toplevel_threshold
     let _inlining_report () = inlining_report := true
-    let _inlining_report_serialized () = inlining_report_serialized := true
+    let _inlining_report_bin () = inlining_report_bin := true
     let _insn_sched = set insn_sched
     let _no_insn_sched = clear insn_sched
     let _linscan = set use_linscan

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -167,8 +167,14 @@ let mk_inline_toplevel f =
 
 let mk_inlining_report f =
   "-inlining-report", Arg.Unit f, " Emit `.<round>.inlining' file(s) (one per \
-      round) showing the inliner's decisions"
+      round) showing the inliner's decisions, in a human readable format"
 ;;
+
+let mk_inlining_report_mr f =
+  "-inlining-report-mr", Arg.Unit f, " Emit `.<round>.inlining' file(s) (one per \
+      round) showing the inliner's decisions in a machine readable format"
+;;
+
 
 let mk_dump_pass f =
   "-dump-pass", Arg.String f,
@@ -1164,6 +1170,7 @@ module type Optcommon_options = sig
   val _inline : string -> unit
   val _inline_toplevel : string -> unit
   val _inlining_report : unit -> unit
+  val _inlining_report_mr : unit -> unit
   val _dump_pass : string -> unit
   val _inline_max_depth : string -> unit
   val _rounds : int -> unit
@@ -1495,6 +1502,7 @@ struct
     mk_inline_indirect_cost F._inline_indirect_cost;
     mk_inline_lifting_benefit F._inline_lifting_benefit;
     mk_inlining_report F._inlining_report;
+    mk_inlining_report_mr F._inlining_report_mr;
     mk_insn_sched F._insn_sched;
     mk_intf F._intf;
     mk_intf_suffix F._intf_suffix;
@@ -1667,6 +1675,7 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_inline F._inline;
     mk_inline_toplevel F._inline_toplevel;
     mk_inlining_report F._inlining_report;
+    mk_inlining_report_mr F._inlining_report_mr;
     mk_rounds F._rounds;
     mk_inline_max_unroll F._inline_max_unroll;
     mk_inline_call_cost F._inline_call_cost;
@@ -2023,6 +2032,7 @@ module Default = struct
         "Syntax: -inline-toplevel <n> | <round>=<n>[,...]"
         inline_toplevel_threshold
     let _inlining_report () = inlining_report := true
+    let _inlining_report_mr () = inlining_report_mr := true
     let _insn_sched = set insn_sched
     let _no_insn_sched = clear insn_sched
     let _linscan = set use_linscan

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -170,6 +170,7 @@ module type Optcommon_options = sig
   val _inline : string -> unit
   val _inline_toplevel : string -> unit
   val _inlining_report : unit -> unit
+  val _inlining_report_mr : unit -> unit
   val _dump_pass : string -> unit
   val _inline_max_depth : string -> unit
   val _rounds : int -> unit

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -170,7 +170,7 @@ module type Optcommon_options = sig
   val _inline : string -> unit
   val _inline_toplevel : string -> unit
   val _inlining_report : unit -> unit
-  val _inlining_report_mr : unit -> unit
+  val _inlining_report_serialized : unit -> unit
   val _dump_pass : string -> unit
   val _inline_max_depth : string -> unit
   val _rounds : int -> unit

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -170,7 +170,7 @@ module type Optcommon_options = sig
   val _inline : string -> unit
   val _inline_toplevel : string -> unit
   val _inlining_report : unit -> unit
-  val _inlining_report_serialized : unit -> unit
+  val _inlining_report_bin : unit -> unit
   val _dump_pass : string -> unit
   val _inline_max_depth : string -> unit
   val _rounds : int -> unit

--- a/middle_end/flambda/inlining/inlining_report.ml
+++ b/middle_end/flambda/inlining/inlining_report.ml
@@ -142,22 +142,29 @@ let record_decision ~dbg decision =
   end
 
 let output_then_forget_decisions ~output_prefix =
-  let l = lazy (List.rev !log) in
-  if !Clflags.inlining_report then begin
-    let out_channel = open_out (output_prefix ^ ".inlining.org") in
-    let fmt = Format.formatter_of_out_channel out_channel in
-    Format.fprintf fmt "%a@." (print ~depth:0) (Lazy.force l);
-    close_out out_channel;
-  end;
-  if !Clflags.inlining_report_serialized then begin
-    let ch = open_out_bin (output_prefix ^ ".inlining.obj.magic") in
-    let metadata = {
-      compilation_unit = Compilation_unit.get_current_exn ();
-    } in
-    let report : report = `Flambda2_1_0_0 (metadata, Lazy.force l) in
-    Marshal.to_channel ch report [];
-    close_out ch
-  end;
-  log := [];
+  Misc.try_finally
+    ~always:(fun () -> log := [])
+    ~exceptionally:(fun () ->
+      (* CR gbury: Is there a more appropritate function to report a warning
+                   (that is not one of the numbered warnings *)
+      Format.eprintf "WARNING: inlining report output failed@.")
+    (fun () ->
+       let l = lazy (List.rev !log) in
+       if !Clflags.inlining_report then begin
+         let out_channel = open_out (output_prefix ^ ".inlining.org") in
+         let fmt = Format.formatter_of_out_channel out_channel in
+         Format.fprintf fmt "%a@." (print ~depth:0) (Lazy.force l);
+         close_out out_channel;
+       end;
+       if !Clflags.inlining_report_bin then begin
+         let ch = open_out_bin (output_prefix ^ ".inlining") in
+         let metadata = {
+           compilation_unit = Compilation_unit.get_current_exn ();
+         } in
+         let report : report = `Flambda2_1_0_0 (metadata, Lazy.force l) in
+         Marshal.to_channel ch report [];
+         close_out ch
+       end
+    )
 
 

--- a/middle_end/flambda/inlining/inlining_report.ml
+++ b/middle_end/flambda/inlining/inlining_report.ml
@@ -21,10 +21,10 @@
 type at_call_site =
   | Unknown_function
   | Non_inlinable_function of {
-      code_id : Code_id.t;
+      code_id : Code_id.exported;
     }
   | Inlinable_function of {
-      code_id : Code_id.t;
+      code_id : Code_id.exported;
       decision : Inlining_decision.Call_site_decision.t;
     }
 
@@ -34,7 +34,7 @@ type fundecl_pass =
 
 type at_function_declaration = {
   pass : fundecl_pass;
-  code_id : Code_id.t;
+  code_id : Code_id.exported;
   decision : Inlining_decision.Function_declaration_decision.t;
 }
 
@@ -66,6 +66,12 @@ type t = {
   decision : decision;
 }
 
+type metadata = {
+  compilation_unit : Compilation_unit.t;
+}
+
+type report = [ `Flambda2_1_0_0 of metadata * t list ]
+
 (* Actual log storage. During simplification, in order to be more efficient,
    decisions are stored from the most recent one (in the head of the list),
    to the oldest one (at the end of the list).
@@ -85,7 +91,7 @@ let rec print ~depth fmt = function
   | { dbg; decision = At_function_declaration {
       pass = Before_simplify; code_id; decision; } } :: r ->
     Format.fprintf fmt "%a Definition of %s{%a}@\n"
-      stars depth (Code_id.name code_id) Debuginfo.print dbg;
+      stars depth Code_id.(name (import code_id)) Debuginfo.print dbg;
     Format.fprintf fmt "%a @[<v>Before simplification:@ @ %a@]@\n@\n"
       stars (depth + 1)
       Inlining_decision.Function_declaration_decision.report decision;
@@ -95,7 +101,7 @@ let rec print ~depth fmt = function
   | { dbg ; decision = At_function_declaration {
       pass = After_simplify; code_id; decision; } } :: r ->
     Format.fprintf fmt "%a @[<v>After simplification of %s{%a}:@ @ %a@]@\n@\n@\n"
-      stars depth (Code_id.name code_id) Debuginfo.print dbg
+      stars depth Code_id.(name (import code_id)) Debuginfo.print dbg
       Inlining_decision.Function_declaration_decision.report decision;
     print ~depth:(depth - 1) fmt r
 
@@ -113,7 +119,7 @@ let rec print ~depth fmt = function
     Format.fprintf fmt "%a @[<v>%s of %s{%a}@ @ %s@ %s@]@\n@\n"
       stars depth
       (if depth = 0 then "Toplevel application" else "Application")
-      (Code_id.name code_id) Debuginfo.print dbg
+      Code_id.(name (import code_id)) Debuginfo.print dbg
       "The function call has not been inlined"
       "because its definition was deemed not inlinable";
     print ~depth fmt r
@@ -122,7 +128,7 @@ let rec print ~depth fmt = function
     Format.fprintf fmt "%a @[<v>%s of %s{%a}@ @ %a@]@\n@\n"
       stars depth
       (if depth = 0 then "Toplevel application" else "Application")
-      (Code_id.name code_id) Debuginfo.print dbg
+      Code_id.(name (import code_id)) Debuginfo.print dbg
       Inlining_decision.Call_site_decision.report decision;
     print ~depth fmt r
 
@@ -136,12 +142,22 @@ let record_decision ~dbg decision =
   end
 
 let output_then_forget_decisions ~output_prefix =
+  let l = lazy (List.rev !log) in
   if !Clflags.inlining_report then begin
     let out_channel = open_out (output_prefix ^ ".inlining.org") in
     let fmt = Format.formatter_of_out_channel out_channel in
-    Format.fprintf fmt "%a@." (print ~depth:0) (List.rev !log);
+    Format.fprintf fmt "%a@." (print ~depth:0) (Lazy.force l);
     close_out out_channel;
-    log := [];
-  end
+  end;
+  if !Clflags.inlining_report_mr then begin
+    let ch = open_out_bin (output_prefix ^ ".inlining.obj.magic") in
+    let metadata = {
+      compilation_unit = Compilation_unit.get_current_exn ();
+    } in
+    let report : report = `Flambda2_1_0_0 (metadata, Lazy.force l) in
+    Marshal.to_channel ch report [];
+    close_out ch
+  end;
+  log := [];
 
 

--- a/middle_end/flambda/inlining/inlining_report.ml
+++ b/middle_end/flambda/inlining/inlining_report.ml
@@ -149,7 +149,7 @@ let output_then_forget_decisions ~output_prefix =
     Format.fprintf fmt "%a@." (print ~depth:0) (Lazy.force l);
     close_out out_channel;
   end;
-  if !Clflags.inlining_report_mr then begin
+  if !Clflags.inlining_report_serialized then begin
     let ch = open_out_bin (output_prefix ^ ".inlining.obj.magic") in
     let metadata = {
       compilation_unit = Compilation_unit.get_current_exn ();

--- a/middle_end/flambda/inlining/inlining_report.ml
+++ b/middle_end/flambda/inlining/inlining_report.ml
@@ -137,7 +137,7 @@ let rec print ~depth fmt = function
 (* Exposed interface *)
 
 let record_decision ~dbg decision =
-  if !Clflags.inlining_report then begin
+  if !Clflags.inlining_report || !Clflags.inlining_report_bin then begin
     log := { dbg; decision; } :: !log
   end
 

--- a/middle_end/flambda/inlining/inlining_report.mli
+++ b/middle_end/flambda/inlining/inlining_report.mli
@@ -18,12 +18,12 @@ type at_call_site =
   | Unknown_function
   (** Function call where the function's type is unknown. *)
   | Non_inlinable_function of {
-      code_id : Code_id.t; (** code id of the callee *)
+      code_id : Code_id.exported; (** code id of the callee *)
     }
   (** Function call where the function's type is known,
       but was marked as non-inlinable. *)
   | Inlinable_function of {
-      code_id : Code_id.t; (** code id of the callee *)
+      code_id : Code_id.exported; (** code id of the callee *)
       decision : Inlining_decision.Call_site_decision.t;
     }
   (** Function call where the function's type is known,
@@ -38,7 +38,7 @@ type fundecl_pass =
 
 type at_function_declaration = {
   pass : fundecl_pass;
-  code_id : Code_id.t; (** code id of the function being declared *)
+  code_id : Code_id.exported; (** code id of the function being declared *)
   decision : Inlining_decision.Function_declaration_decision.t;
 }
 

--- a/middle_end/flambda/simplify/simplify_apply_expr.rec.ml
+++ b/middle_end/flambda/simplify/simplify_apply_expr.rec.ml
@@ -92,7 +92,8 @@ let simplify_direct_full_application dacc apply function_decl_opt
     match function_decl_opt with
     | None ->
       Inlining_report.record_decision
-        (At_call_site (Non_inlinable_function { code_id = callee's_code_id; }))
+        (At_call_site (Non_inlinable_function
+                         { code_id = Code_id.export callee's_code_id; }))
         ~dbg:(DE.add_inlined_debuginfo' (DA.denv dacc) (Apply.dbg apply));
       warn_not_inlined_if_needed apply
         "[@inlined] attribute was not used on this function application \
@@ -108,7 +109,7 @@ let simplify_direct_full_application dacc apply function_decl_opt
       in
       let code_id = T.Function_declaration_type.Inlinable.code_id function_decl in
       Inlining_report.record_decision
-        (At_call_site (Inlinable_function { code_id; decision; }))
+        (At_call_site (Inlinable_function { code_id = Code_id.export code_id; decision; }))
         ~dbg:(DE.add_inlined_debuginfo' (DA.denv dacc) (Apply.dbg apply));
       match Inlining_decision.Call_site_decision.can_inline decision with
       | Do_not_inline ->

--- a/middle_end/flambda/simplify/simplify_set_of_closures.rec.ml
+++ b/middle_end/flambda/simplify/simplify_set_of_closures.rec.ml
@@ -32,7 +32,8 @@ let function_decl_type ~pass denv function_decl ?code_id ?params_and_body rec_in
       denv ?params_and_body function_decl
   in
   let code_id = Option.value code_id ~default:(FD.code_id function_decl) in
-  Inlining_report.record_decision (At_function_declaration { code_id; pass; decision; })
+  Inlining_report.record_decision (
+    At_function_declaration { code_id = Code_id.export code_id; pass; decision; })
     ~dbg:(DE.add_inlined_debuginfo' denv (FD.dbg function_decl));
   if Inlining_decision.Function_declaration_decision.can_inline decision then
     T.create_inlinable_function_declaration

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -180,8 +180,8 @@ let unsafe_string =
   else ref (not Config.default_safe_string)
                                    (* -safe-string / -unsafe-string *)
 
-let inlining_report = ref false            (* -inlining-report *)
-let inlining_report_serialized = ref false (* -inlining-report-serialized *)
+let inlining_report = ref false     (* -inlining-report *)
+let inlining_report_bin = ref false (* -inlining-report-bin *)
 
 let afl_instrument = ref Config.afl_instrument (* -afl-instrument *)
 let afl_inst_ratio = ref 100           (* -afl-inst-ratio *)

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -181,6 +181,7 @@ let unsafe_string =
                                    (* -safe-string / -unsafe-string *)
 
 let inlining_report = ref false    (* -inlining-report *)
+let inlining_report_mr = ref false (* -inlining-report-mr *)
 
 let afl_instrument = ref Config.afl_instrument (* -afl-instrument *)
 let afl_inst_ratio = ref 100           (* -afl-inst-ratio *)

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -180,8 +180,8 @@ let unsafe_string =
   else ref (not Config.default_safe_string)
                                    (* -safe-string / -unsafe-string *)
 
-let inlining_report = ref false    (* -inlining-report *)
-let inlining_report_mr = ref false (* -inlining-report-mr *)
+let inlining_report = ref false            (* -inlining-report *)
+let inlining_report_serialized = ref false (* -inlining-report-serialized *)
 
 let afl_instrument = ref Config.afl_instrument (* -afl-instrument *)
 let afl_inst_ratio = ref 100           (* -afl-inst-ratio *)

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -164,7 +164,7 @@ val native_code : bool ref
 val default_inline_threshold : float
 val inline_threshold : Float_arg_helper.parsed ref
 val inlining_report : bool ref
-val inlining_report_serialized : bool ref
+val inlining_report_bin : bool ref
 val simplify_rounds : int option ref
 val default_simplify_rounds : int ref
 val rounds : unit -> int

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -164,7 +164,7 @@ val native_code : bool ref
 val default_inline_threshold : float
 val inline_threshold : Float_arg_helper.parsed ref
 val inlining_report : bool ref
-val inlining_report_mr : bool ref
+val inlining_report_serialized : bool ref
 val simplify_rounds : int option ref
 val default_simplify_rounds : int ref
 val rounds : unit -> int

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -164,6 +164,7 @@ val native_code : bool ref
 val default_inline_threshold : float
 val inline_threshold : Float_arg_helper.parsed ref
 val inlining_report : bool ref
+val inlining_report_mr : bool ref
 val simplify_rounds : int option ref
 val default_simplify_rounds : int ref
 val rounds : unit -> int


### PR DESCRIPTION
This PR adds the ability for ocamlopt to output marshalled inlining reports, using the `-inlining-report-mr` option. Such marshalled reports can then be read using the small library in https://github.com/Gbury/ocir . Additionally, the linked repo contains an executable that reads a marshalled inlining report and then print it in a human readable format. In the long term, `ocir` will also contain facilities to compare inlining reports.

This patch should be mergeable, but the name of the option could be changed for something a little bit more understandable/intuitive if there's any good proposition; the extension of marshalled files (currently `.obj.magic`) could also be changed if something more standard exists.