### PR TITLE
Record use of continuation with traps

### DIFF
--- a/middle_end/flambda/naming/bindable_continuation.ml
+++ b/middle_end/flambda/naming/bindable_continuation.ml
@@ -36,4 +36,9 @@ let name_permutation t ~guaranteed_fresh =
 
 let singleton_occurrence_in_terms t = Name_occurrences.singleton_continuation t
 
-let add_occurrence_in_terms t occs = Name_occurrences.add_continuation occs t
+let add_occurrence_in_terms t occs =
+  (* This is used to diff the bound names from the free names of the term in
+     Name_abstraction. Setting has_traps to true ensures that the
+     continuations are properly removed from both the regular continuation
+     count and the continuations_with_traps count. *)
+  Name_occurrences.add_continuation occs t ~has_traps:true

--- a/middle_end/flambda/naming/bindable_exn_continuation.ml
+++ b/middle_end/flambda/naming/bindable_exn_continuation.ml
@@ -29,7 +29,8 @@ let singleton_occurrence_in_terms t =
   Name_occurrences.singleton_continuation (exn_handler t)
 
 let add_occurrence_in_terms t occs =
-  Name_occurrences.add_continuation occs (exn_handler t)
+  (* See the comment in Bindable_continuation.add_occurrence_in_terms *)
+  Name_occurrences.add_continuation occs (exn_handler t) ~has_traps:true
 
 let rename t =
   let exn_handler = Continuation.rename (exn_handler t) in

--- a/middle_end/flambda/naming/name_occurrences.ml
+++ b/middle_end/flambda/naming/name_occurrences.ml
@@ -701,6 +701,9 @@ let add_continuation_in_trap_action t cont =
 let count_continuation t cont =
   For_continuations.count t.continuations cont
 
+let continuation_is_applied_with_traps t cont =
+  For_continuations.mem t.continuations_with_traps cont
+
 let count_variable t var =
   For_names.count t.names (Name.var var)
 

--- a/middle_end/flambda/naming/name_occurrences.mli
+++ b/middle_end/flambda/naming/name_occurrences.mli
@@ -41,7 +41,7 @@ val singleton_continuation : Continuation.t -> t
 
 val singleton_continuation_in_trap_action : Continuation.t -> t
 
-val add_continuation : t -> Continuation.t -> t
+val add_continuation : t -> Continuation.t -> has_traps:bool -> t
 
 val add_continuation_in_trap_action : t -> Continuation.t -> t
 
@@ -106,6 +106,8 @@ val no_variables : t -> bool
 val no_continuations : t -> bool
 
 val continuations : t -> Continuation.Set.t
+
+val continuations_with_traps : t -> Continuation.Set.t
 
 val continuations_including_in_trap_actions : t -> Continuation.Set.t
 

--- a/middle_end/flambda/naming/name_occurrences.mli
+++ b/middle_end/flambda/naming/name_occurrences.mli
@@ -47,6 +47,8 @@ val add_continuation_in_trap_action : t -> Continuation.t -> t
 
 val count_continuation : t -> Continuation.t -> Num_occurrences.t
 
+val continuation_is_applied_with_traps : t -> Continuation.t -> bool
+
 val count_variable : t -> Variable.t -> Num_occurrences.t
 
 val count_variable_normal_mode : t -> Variable.t -> Num_occurrences.t

--- a/middle_end/flambda/simplify/simplify_let_cont_expr.rec.ml
+++ b/middle_end/flambda/simplify/simplify_let_cont_expr.rec.ml
@@ -366,6 +366,11 @@ let simplify_non_recursive_let_cont dacc non_rec ~down_to_up =
                         name_occurrences_body
                         cont
                     in
+                    let is_applied_with_traps =
+                      Name_occurrences.continuation_is_applied_with_traps
+                        name_occurrences_body
+                        cont
+                    in
                     let remove_let_cont_leaving_body =
                       match num_free_occurrences_of_cont_in_body with
                       | Zero -> true
@@ -441,6 +446,7 @@ let simplify_non_recursive_let_cont dacc non_rec ~down_to_up =
                             Let_cont.create_non_recursive' ~cont handler ~body
                               ~num_free_occurrences_of_cont_in_body:
                                 (Known num_free_occurrences_of_cont_in_body)
+                              ~is_applied_with_traps
                           in
                           expr, uacc
                     in

--- a/middle_end/flambda/terms/apply_cont_expr.ml
+++ b/middle_end/flambda/terms/apply_cont_expr.ml
@@ -220,22 +220,16 @@ let debuginfo t = t.dbg
 
 let free_names { k; args; trap_action; dbg=_; } =
   let default =
-    Name_occurrences.add_continuation (Simple.List.free_names args) k
+    Simple.List.free_names args
   in
   match trap_action with
-  | None -> default
+  | None ->
+    Name_occurrences.add_continuation default k ~has_traps:false
   | Some trap_action ->
-    (* A second occurrence of [k] is added to ensure that the continuation [k]
-       is never inlined out (which cannot be done, or the trap action
-       would be lost). *)
-    (* CR mshinwell: We don't need this for Simplify now -- but Un_cps is
-       still relying on this.  We should fix that. *)
     Name_occurrences.add_continuation
       (Name_occurrences.union default (Trap_action.free_names trap_action))
       k
-    (*
-    Name_occurrences.union default (Trap_action.free_names trap_action)
-    *)
+      ~has_traps:true
 
 let apply_name_permutation ({ k; args; trap_action; dbg; } as t) perm =
   let k' = Name_permutation.apply_continuation perm k in

--- a/middle_end/flambda/terms/flambda.mli
+++ b/middle_end/flambda/terms/flambda.mli
@@ -263,6 +263,9 @@ end and Let_cont_expr : sig
         (** [num_free_occurrences] can be used, for example, to decide whether
             to inline out a linearly-used continuation.  It will always be
             strictly greater than zero. *)
+        is_applied_with_traps : bool;
+        (** [is_applied_with_traps] is used to prevent inlining of continuations
+            that are applied with a trap action *)
       }
     | Recursive of Recursive_let_cont_handlers.t
 
@@ -284,6 +287,7 @@ end and Let_cont_expr : sig
     -> Continuation_handler.t
     -> body:Expr.t
     -> num_free_occurrences_of_cont_in_body:Num_occurrences.t Or_unknown.t
+    -> is_applied_with_traps:bool
     -> Expr.t
 
   (** Create a definition of a set of possibly-recursive continuations. *)

--- a/middle_end/flambda/terms/let_cont_expr.rec.mli
+++ b/middle_end/flambda/terms/let_cont_expr.rec.mli
@@ -43,6 +43,9 @@ type t = private
       num_free_occurrences : Num_occurrences.t Or_unknown.t;
       (** [num_free_occurrences] can be used, for example, to decide whether
           to inline out a linearly-used continuation. *)
+      is_applied_with_traps : bool;
+      (** [is_applied_with_traps] is used to prevent inlining of continuations
+          that are applied with a trap action *)
     }
   | Recursive of Recursive_let_cont_handlers.t
 
@@ -66,6 +69,7 @@ val create_non_recursive'
   -> Continuation_handler.t
   -> body:Expr.t
   -> num_free_occurrences_of_cont_in_body:Num_occurrences.t Or_unknown.t
+  -> is_applied_with_traps:bool
   -> Expr.t
 
 (** Create a definition of a set of possibly-recursive continuations. *)

--- a/middle_end/flambda/to_cmm/un_cps.ml
+++ b/middle_end/flambda/to_cmm/un_cps.ml
@@ -791,17 +791,20 @@ and let_expr_prim body env res v ~num_normal_occurrences_of_bound_vars p dbg =
   in
   expr env res body
 
-and decide_inline_cont h k ~num_free_occurrences =
+and decide_inline_cont h k ~num_free_occurrences ~is_applied_with_traps =
   (not (Continuation_handler.is_exn_handler h))
+  && (not is_applied_with_traps)
   && cont_is_known_to_have_exactly_one_occurrence k num_free_occurrences
 
 and let_cont env res = function
-  | Let_cont.Non_recursive { handler; num_free_occurrences; } ->
+  | Let_cont.Non_recursive { handler; num_free_occurrences;
+                             is_applied_with_traps; } ->
     Non_recursive_let_cont_handler.pattern_match handler ~f:(fun k ~body ->
       let h = Non_recursive_let_cont_handler.handler handler in
-      if decide_inline_cont h k ~num_free_occurrences then begin
+      if decide_inline_cont h k ~num_free_occurrences ~is_applied_with_traps
+      then
         let_cont_inline env res k h body
-      end else
+      else
         let_cont_jump env res k h body
     )
   | Let_cont.Recursive handlers ->


### PR DESCRIPTION
This allows removing the hack that counts continuations twice, while still preserving the ability to decide whether to inline a continuation handler in `Un_cps` or not just by looking at the binding point.