### PR TITLE
Add fast path for simplification of Project_var

### DIFF
--- a/middle_end/flambda/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda/simplify/simplify_unary_primitive.ml
@@ -92,13 +92,16 @@ let simplify_project_var closure_id closure_element ~min_name_mode dacc
     in
     reachable, env_extension, dacc
   | Unknown ->
-    Simplify_common.simplify_projection
-      dacc ~original_term ~deconstructing:closure_ty
-      ~shape:(T.closure_with_at_least_this_closure_var
-                ~this_closure:closure_id
-                closure_element
-                ~closure_element_var:(Var_in_binding_pos.var result_var))
-      ~result_var ~result_kind:K.value
+    let reachable, env_extension, dacc =
+      Simplify_common.simplify_projection
+        dacc ~original_term ~deconstructing:closure_ty
+        ~shape:(T.closure_with_at_least_this_closure_var
+                  ~this_closure:closure_id
+                  closure_element
+                  ~closure_element_var:(Var_in_binding_pos.var result_var))
+        ~result_var ~result_kind:K.value
+    in
+    reachable, env_extension, DA.add_use_of_closure_var dacc closure_element
 
 let simplify_unbox_number (boxable_number_kind : K.Boxable_number.t)
       dacc ~original_term ~arg ~arg_ty:boxed_number_ty ~result_var =

--- a/middle_end/flambda/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda/simplify/simplify_unary_primitive.ml
@@ -74,7 +74,24 @@ let simplify_select_closure ~move_from ~move_to
 
 let simplify_project_var closure_id closure_element ~min_name_mode dacc
       ~original_term ~arg:_closure ~arg_ty:closure_ty ~result_var =
-  let reachable, env_extension, dacc =
+  let result_var' = Var_in_binding_pos.var result_var in
+  let typing_env = DA.typing_env dacc in
+  match
+    T.prove_project_var_simple typing_env ~min_name_mode
+      closure_ty closure_element
+  with
+  | Invalid ->
+    let ty = T.bottom K.value in
+    let env_extension = TEE.one_equation (Name.var result_var') ty in
+    Simplified_named.invalid (), env_extension, dacc
+  | Proved simple ->
+    let reachable = Simplified_named.reachable (Named.create_simple simple) in
+    let env_extension =
+      TEE.one_equation (Name.var result_var')
+        (T.alias_type_of K.value simple)
+    in
+    reachable, env_extension, dacc
+  | Unknown ->
     Simplify_common.simplify_projection
       dacc ~original_term ~deconstructing:closure_ty
       ~shape:(T.closure_with_at_least_this_closure_var
@@ -82,39 +99,6 @@ let simplify_project_var closure_id closure_element ~min_name_mode dacc
                 closure_element
                 ~closure_element_var:(Var_in_binding_pos.var result_var))
       ~result_var ~result_kind:K.value
-  in
-  let reachable, removed_var =
-    (* CR-someday mshinwell: Perhaps a more elegant way than this could be
-       found.  One possibility is that [simplify_projection] should try to
-       return a [Simple] rather than the original term, but that might be
-       unnecessary work, since the [Simple] will appear in subsequent places
-       by virtue of the typing anyway. *)
-    match reachable with
-    | Reachable _ ->
-      let typing_env =
-        TE.add_definition (DA.typing_env dacc)
-          (Name_in_binding_pos.var result_var)
-          K.value
-      in
-      let typing_env = TE.add_env_extension typing_env env_extension in
-      let name = Name.var (Var_in_binding_pos.var result_var) in
-      let ty = TE.find typing_env name (Some (K.value)) in
-      begin match T.get_alias_exn ty with
-      | exception Not_found -> reachable, false
-      | alias ->
-        match TE.get_canonical_simple_exn ~min_name_mode typing_env alias with
-        | exception Not_found -> reachable, false
-        | canonical ->
-          let reachable = Simplified_named.reachable (Named.create_simple canonical) in
-          reachable, true
-      end
-    | Invalid _ -> reachable, false
-  in
-  let dacc =
-    if removed_var then dacc
-    else DA.add_use_of_closure_var dacc closure_element
-  in
-  reachable, env_extension, dacc
 
 let simplify_unbox_number (boxable_number_kind : K.Boxable_number.t)
       dacc ~original_term ~arg ~arg_ty:boxed_number_ty ~result_var =

--- a/middle_end/flambda/types/env/aliases.mli
+++ b/middle_end/flambda/types/env/aliases.mli
@@ -59,3 +59,5 @@ val get_aliases : t -> Simple.t -> Simple.Set.t
 val get_canonical_ignoring_name_mode : t -> Name.t -> Simple.t
 
 val merge : t -> t -> t
+
+val clean_for_export : t -> t

--- a/middle_end/flambda/types/env/typing_env.rec.ml
+++ b/middle_end/flambda/types/env/typing_env.rec.ml
@@ -175,8 +175,10 @@ end = struct
                current_compilation_unit)
         names_to_types
     in
+    let aliases = Aliases.clean_for_export t.aliases in
     { t with
       names_to_types;
+      aliases;
     }
 
   let import import_map { names_to_types; aliases; symbol_projections; } =

--- a/middle_end/flambda/types/flambda_type.mli
+++ b/middle_end/flambda/types/flambda_type.mli
@@ -567,8 +567,16 @@ val prove_strings : Typing_env.t -> t -> String_info.Set.t proof
 
 val prove_block_field_simple
    : Typing_env.t
+  -> min_name_mode:Name_mode.t
   -> t
   -> Target_imm.t
+  -> Simple.t proof
+
+val prove_project_var_simple
+   : Typing_env.t
+  -> min_name_mode:Name_mode.t
+  -> t
+  -> Var_within_closure.t
   -> Simple.t proof
 
 type var_or_symbol_or_tagged_immediate = private

--- a/middle_end/flambda/types/structures/row_like.rec.ml
+++ b/middle_end/flambda/types/structures/row_like.rec.ml
@@ -613,6 +613,19 @@ struct
         if not (Var_within_closure.Set.mem env_var
                   (Set_of_closures_contents.closure_vars index))
         then Unknown
-        else Known (Var_within_closure.Map.find env_var
-                      (Closures_entry.closure_var_types maps_to))
+        else
+          let env_var_ty =
+            try Var_within_closure.Map.find env_var
+                  (Closures_entry.closure_var_types maps_to)
+            with Not_found ->
+              Misc.fatal_errorf
+                "Environment variable %a is bound in index \
+                 but not in maps_to@.\
+                 Index:@ %a@.\
+                 Maps_to:@ %a"
+                Var_within_closure.print env_var
+                Set_of_closures_contents.print index
+                Closures_entry.print maps_to
+          in
+          Known env_var_ty
   end

--- a/middle_end/flambda/types/structures/row_like.rec.ml
+++ b/middle_end/flambda/types/structures/row_like.rec.ml
@@ -606,4 +606,13 @@ struct
         other_tags = Bottom;
       }
 
+    let get_env_var t env_var : _ Or_unknown.t =
+      match get_singleton t with
+      | None -> Unknown
+      | Some ((_tag, index), maps_to) ->
+        if not (Var_within_closure.Set.mem env_var
+                  (Set_of_closures_contents.closure_vars index))
+        then Unknown
+        else Known (Var_within_closure.Map.find env_var
+                      (Closures_entry.closure_var_types maps_to))
   end

--- a/middle_end/flambda/types/structures/row_like.rec.mli
+++ b/middle_end/flambda/types/structures/row_like.rec.mli
@@ -104,6 +104,10 @@ module For_closures_entry_by_set_of_closures_contents : sig
      : t
     -> ((Closure_id.t * Set_of_closures_contents.t) * Closures_entry.t) option
 
+  (** Same as For_blocks.get_field: attempt to find the type associated to
+      the given environment variable without an expensive meet. *)
+  val get_env_var : t -> Var_within_closure.t -> Type_grammar.t Or_unknown.t
+
   val map_function_decl_types
      : t
     -> f:(Function_declaration_type.t -> Function_declaration_type.t Or_bottom.t)


### PR DESCRIPTION
This also fixes a small oversight in the fast path for block loads, as the required minimal name mode was not taken into account.