### PR TITLE
Move CSE code into the simplifier

### DIFF
--- a/.depend
+++ b/.depend
@@ -5904,6 +5904,47 @@ middle_end/flambda/parser/print_fexpr.cmx : \
     middle_end/flambda/parser/print_fexpr.cmi
 middle_end/flambda/parser/print_fexpr.cmi : \
     middle_end/flambda/parser/fexpr.cmo
+middle_end/flambda/simplify/common_subexpression_elimination.cmo : \
+    middle_end/flambda/compilenv_deps/variable.cmi \
+    middle_end/flambda/basic/simple.cmi \
+    middle_end/flambda/naming/name_occurrences.cmi \
+    middle_end/flambda/naming/name_mode.cmi \
+    middle_end/flambda/basic/name.cmi \
+    utils/misc.cmi \
+    middle_end/flambda/basic/kinded_parameter.cmi \
+    utils/identifiable.cmi \
+    middle_end/flambda/types/flambda_type.cmi \
+    middle_end/flambda/terms/flambda_primitive.cmi \
+    middle_end/flambda/types/kinds/flambda_kind.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
+    middle_end/flambda/basic/continuation_extra_params_and_args.cmi \
+    middle_end/flambda/basic/apply_cont_rewrite_id.cmi \
+    middle_end/flambda/simplify/common_subexpression_elimination.cmi
+middle_end/flambda/simplify/common_subexpression_elimination.cmx : \
+    middle_end/flambda/compilenv_deps/variable.cmx \
+    middle_end/flambda/basic/simple.cmx \
+    middle_end/flambda/naming/name_occurrences.cmx \
+    middle_end/flambda/naming/name_mode.cmx \
+    middle_end/flambda/basic/name.cmx \
+    utils/misc.cmx \
+    middle_end/flambda/basic/kinded_parameter.cmx \
+    utils/identifiable.cmx \
+    middle_end/flambda/types/flambda_type.cmx \
+    middle_end/flambda/terms/flambda_primitive.cmx \
+    middle_end/flambda/types/kinds/flambda_kind.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
+    middle_end/flambda/basic/continuation_extra_params_and_args.cmx \
+    middle_end/flambda/basic/apply_cont_rewrite_id.cmx \
+    middle_end/flambda/simplify/common_subexpression_elimination.cmi
+middle_end/flambda/simplify/common_subexpression_elimination.cmi : \
+    middle_end/flambda/basic/simple.cmi \
+    middle_end/flambda/naming/name_occurrences.cmi \
+    middle_end/flambda/basic/name.cmi \
+    middle_end/flambda/basic/kinded_parameter.cmi \
+    middle_end/flambda/types/flambda_type.cmi \
+    middle_end/flambda/terms/flambda_primitive.cmi \
+    middle_end/flambda/basic/continuation_extra_params_and_args.cmi \
+    middle_end/flambda/basic/apply_cont_rewrite_id.cmi
 middle_end/flambda/simplify/expr_builder.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/var_within_closure.cmi \
@@ -6349,6 +6390,7 @@ middle_end/flambda/simplify/simplify_import.cmo : \
     middle_end/flambda/simplify/env/continuation_uses_env.cmi \
     middle_end/flambda/basic/continuation_extra_params_and_args.cmi \
     middle_end/flambda/basic/code_id_or_symbol.cmi \
+    middle_end/flambda/basic/apply_cont_rewrite_id.cmi \
     middle_end/flambda/simplify/simplify_import.cmi
 middle_end/flambda/simplify/simplify_import.cmx : \
     middle_end/flambda/naming/var_in_binding_pos.cmx \
@@ -6367,6 +6409,7 @@ middle_end/flambda/simplify/simplify_import.cmx : \
     middle_end/flambda/simplify/env/continuation_uses_env.cmx \
     middle_end/flambda/basic/continuation_extra_params_and_args.cmx \
     middle_end/flambda/basic/code_id_or_symbol.cmx \
+    middle_end/flambda/basic/apply_cont_rewrite_id.cmx \
     middle_end/flambda/simplify/simplify_import.cmi
 middle_end/flambda/simplify/simplify_import.cmi : \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
@@ -6384,7 +6427,8 @@ middle_end/flambda/simplify/simplify_import.cmi : \
     middle_end/flambda/simplify/env/downwards_acc.cmi \
     middle_end/flambda/simplify/env/continuation_uses_env.cmi \
     middle_end/flambda/basic/continuation_extra_params_and_args.cmi \
-    middle_end/flambda/basic/code_id_or_symbol.cmi
+    middle_end/flambda/basic/code_id_or_symbol.cmi \
+    middle_end/flambda/basic/apply_cont_rewrite_id.cmi
 middle_end/flambda/simplify/simplify_let_cont_expr.rec.cmo : \
     middle_end/flambda/unboxing/unbox_continuation_params.cmi \
     middle_end/flambda/simplify/simplify_import.cmi \
@@ -7034,6 +7078,7 @@ middle_end/flambda/simplify/env/simplify_envs.cmo : \
     middle_end/flambda/simplify/basic/continuation_in_env.cmi \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
+    middle_end/flambda/simplify/common_subexpression_elimination.cmi \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/basic/closure_id.cmi \
     middle_end/flambda/terms/bound_symbols.cmi \
@@ -7072,6 +7117,7 @@ middle_end/flambda/simplify/env/simplify_envs.cmx : \
     middle_end/flambda/simplify/basic/continuation_in_env.cmx \
     middle_end/flambda/basic/continuation.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
+    middle_end/flambda/simplify/common_subexpression_elimination.cmx \
     middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/basic/closure_id.cmx \
     middle_end/flambda/terms/bound_symbols.cmx \
@@ -7092,6 +7138,7 @@ middle_end/flambda/simplify/env/simplify_envs_intf.cmo : \
     middle_end/flambda/basic/name.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/types/flambda_type.cmi \
+    middle_end/flambda/terms/flambda_primitive.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/flambda_backend_intf.cmi \
     middle_end/flambda/types/kinds/flambda_arity.cmi \
@@ -7102,6 +7149,7 @@ middle_end/flambda/simplify/env/simplify_envs_intf.cmo : \
     middle_end/flambda/simplify/basic/continuation_in_env.cmi \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
+    middle_end/flambda/simplify/common_subexpression_elimination.cmi \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/basic/closure_id.cmi \
     middle_end/flambda/terms/bound_symbols.cmi \
@@ -7119,6 +7167,7 @@ middle_end/flambda/simplify/env/simplify_envs_intf.cmx : \
     middle_end/flambda/basic/name.cmx \
     middle_end/flambda/basic/kinded_parameter.cmx \
     middle_end/flambda/types/flambda_type.cmx \
+    middle_end/flambda/terms/flambda_primitive.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
     middle_end/flambda/flambda_backend_intf.cmi \
     middle_end/flambda/types/kinds/flambda_arity.cmx \
@@ -7129,6 +7178,7 @@ middle_end/flambda/simplify/env/simplify_envs_intf.cmx : \
     middle_end/flambda/simplify/basic/continuation_in_env.cmx \
     middle_end/flambda/basic/continuation.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
+    middle_end/flambda/simplify/common_subexpression_elimination.cmx \
     middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/basic/closure_id.cmx \
     middle_end/flambda/terms/bound_symbols.cmx \
@@ -7180,6 +7230,7 @@ middle_end/flambda/simplify/typing_helpers/continuation_uses.cmo : \
     middle_end/flambda/simplify/env/simplify_envs.cmi \
     middle_end/flambda/basic/scope.cmi \
     middle_end/flambda/simplify/typing_helpers/one_continuation_use.cmi \
+    middle_end/flambda/basic/name.cmi \
     utils/misc.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/types/flambda_type.cmi \
@@ -7190,6 +7241,7 @@ middle_end/flambda/simplify/typing_helpers/continuation_uses.cmo : \
     middle_end/flambda/basic/continuation_extra_params_and_args.cmi \
     middle_end/flambda/simplify/env/continuation_env_and_param_types.cmi \
     middle_end/flambda/basic/continuation.cmi \
+    middle_end/flambda/simplify/common_subexpression_elimination.cmi \
     utils/clflags.cmi \
     middle_end/flambda/basic/apply_cont_rewrite_id.cmi \
     middle_end/flambda/simplify/typing_helpers/continuation_uses.cmi
@@ -7197,6 +7249,7 @@ middle_end/flambda/simplify/typing_helpers/continuation_uses.cmx : \
     middle_end/flambda/simplify/env/simplify_envs.cmx \
     middle_end/flambda/basic/scope.cmx \
     middle_end/flambda/simplify/typing_helpers/one_continuation_use.cmx \
+    middle_end/flambda/basic/name.cmx \
     utils/misc.cmx \
     middle_end/flambda/basic/kinded_parameter.cmx \
     middle_end/flambda/types/flambda_type.cmx \
@@ -7207,6 +7260,7 @@ middle_end/flambda/simplify/typing_helpers/continuation_uses.cmx : \
     middle_end/flambda/basic/continuation_extra_params_and_args.cmx \
     middle_end/flambda/simplify/env/continuation_env_and_param_types.cmx \
     middle_end/flambda/basic/continuation.cmx \
+    middle_end/flambda/simplify/common_subexpression_elimination.cmx \
     utils/clflags.cmx \
     middle_end/flambda/basic/apply_cont_rewrite_id.cmx \
     middle_end/flambda/simplify/typing_helpers/continuation_uses.cmi
@@ -7352,6 +7406,7 @@ middle_end/flambda/terms/bound_symbols.cmo : \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
+    utils/misc.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/basic/code_id_or_symbol.cmi \
     middle_end/flambda/basic/code_id.cmi \
@@ -7361,6 +7416,7 @@ middle_end/flambda/terms/bound_symbols.cmx : \
     middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
+    utils/misc.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/basic/code_id_or_symbol.cmx \
     middle_end/flambda/basic/code_id.cmx \
@@ -8591,7 +8647,6 @@ middle_end/flambda/types/flambda_type.cmo : \
     middle_end/flambda/types/structures/set_of_closures_contents.cmi \
     middle_end/flambda/basic/scope.cmi \
     middle_end/flambda/types/structures/row_like_maps_to_intf.cmo \
-    middle_end/flambda/compilenv_deps/reg_width_things.cmi \
     middle_end/flambda/basic/reg_width_const.cmi \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
     middle_end/flambda/types/structures/product_intf.cmo \
@@ -8613,14 +8668,11 @@ middle_end/flambda/types/flambda_type.cmo : \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     utils/identifiable.cmi \
-    middle_end/flambda/terms/flambda_primitive.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
-    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/types/kinds/flambda_arity.cmi \
     lambda/debuginfo.cmi \
     middle_end/flambda/simplify/env/continuation_use_kind.cmi \
-    middle_end/flambda/basic/continuation_extra_params_and_args.cmi \
     middle_end/flambda/naming/contains_names.cmo \
     middle_end/flambda/cmx/contains_ids.cmo \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
@@ -8653,7 +8705,6 @@ middle_end/flambda/types/flambda_type.cmx : \
     middle_end/flambda/types/structures/set_of_closures_contents.cmx \
     middle_end/flambda/basic/scope.cmx \
     middle_end/flambda/types/structures/row_like_maps_to_intf.cmx \
-    middle_end/flambda/compilenv_deps/reg_width_things.cmx \
     middle_end/flambda/basic/reg_width_const.cmx \
     middle_end/flambda/compilenv_deps/rec_info.cmx \
     middle_end/flambda/types/structures/product_intf.cmx \
@@ -8675,14 +8726,11 @@ middle_end/flambda/types/flambda_type.cmx : \
     middle_end/flambda/basic/kinded_parameter.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     utils/identifiable.cmx \
-    middle_end/flambda/terms/flambda_primitive.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
-    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/types/kinds/flambda_arity.cmx \
     lambda/debuginfo.cmx \
     middle_end/flambda/simplify/env/continuation_use_kind.cmx \
-    middle_end/flambda/basic/continuation_extra_params_and_args.cmx \
     middle_end/flambda/naming/contains_names.cmx \
     middle_end/flambda/cmx/contains_ids.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
@@ -8721,12 +8769,10 @@ middle_end/flambda/types/flambda_type.cmi : \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/basic/invariant_env.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
-    middle_end/flambda/terms/flambda_primitive.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/types/kinds/flambda_arity.cmi \
     lambda/debuginfo.cmi \
     middle_end/flambda/simplify/env/continuation_use_kind.cmi \
-    middle_end/flambda/basic/continuation_extra_params_and_args.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/types/structures/code_age_relation.cmi \
@@ -9118,7 +9164,6 @@ middle_end/flambda/types/env/typing_env.rec.cmo : \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/basic/scope.cmi \
-    middle_end/flambda/compilenv_deps/reg_width_things.cmi \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
     utils/printing_cache.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
@@ -9128,7 +9173,6 @@ middle_end/flambda/types/env/typing_env.rec.cmo : \
     utils/misc.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
-    middle_end/flambda/terms/flambda_primitive.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
@@ -9143,7 +9187,6 @@ middle_end/flambda/types/env/typing_env.rec.cmx : \
     middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/basic/scope.cmx \
-    middle_end/flambda/compilenv_deps/reg_width_things.cmx \
     middle_end/flambda/compilenv_deps/rec_info.cmx \
     utils/printing_cache.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
@@ -9153,7 +9196,6 @@ middle_end/flambda/types/env/typing_env.rec.cmx : \
     utils/misc.cmx \
     middle_end/flambda/basic/kinded_parameter.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
-    middle_end/flambda/terms/flambda_primitive.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
@@ -9174,10 +9216,8 @@ middle_end/flambda/types/env/typing_env.rec.cmi : \
     middle_end/flambda/basic/name.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
-    middle_end/flambda/terms/flambda_primitive.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/simplify/env/continuation_use_kind.cmi \
-    middle_end/flambda/basic/continuation_extra_params_and_args.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/types/structures/code_age_relation.cmi \
@@ -9185,6 +9225,7 @@ middle_end/flambda/types/env/typing_env.rec.cmi : \
 middle_end/flambda/types/env/typing_env_extension.rec.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
+    middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_abstraction.cmi \
     middle_end/flambda/naming/bindable_variable_in_types.cmi \
     middle_end/flambda/basic/apply_cont_rewrite_id.cmi \
@@ -9192,15 +9233,14 @@ middle_end/flambda/types/env/typing_env_extension.rec.cmo : \
 middle_end/flambda/types/env/typing_env_extension.rec.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
+    middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_abstraction.cmx \
     middle_end/flambda/naming/bindable_variable_in_types.cmx \
     middle_end/flambda/basic/apply_cont_rewrite_id.cmx \
     middle_end/flambda/types/env/typing_env_extension.rec.cmi
 middle_end/flambda/types/env/typing_env_extension.rec.cmi : \
-    middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/basic/name.cmi \
-    middle_end/flambda/basic/kinded_parameter.cmi \
-    middle_end/flambda/terms/flambda_primitive.cmi
+    middle_end/flambda/basic/kinded_parameter.cmi
 middle_end/flambda/types/env/typing_env_level.rec.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
@@ -9216,17 +9256,12 @@ middle_end/flambda/types/env/typing_env_level.rec.cmo : \
     utils/misc.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
-    utils/identifiable.cmi \
-    middle_end/flambda/terms/flambda_primitive.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
-    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
-    middle_end/flambda/basic/continuation_extra_params_and_args.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/types/structures/code_age_relation.cmi \
     utils/clflags.cmi \
     middle_end/flambda/types/env/binding_time.cmi \
-    middle_end/flambda/basic/apply_cont_rewrite_id.cmi \
     middle_end/flambda/types/env/typing_env_level.rec.cmi
 middle_end/flambda/types/env/typing_env_level.rec.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
@@ -9243,30 +9278,23 @@ middle_end/flambda/types/env/typing_env_level.rec.cmx : \
     utils/misc.cmx \
     middle_end/flambda/basic/kinded_parameter.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
-    utils/identifiable.cmx \
-    middle_end/flambda/terms/flambda_primitive.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
-    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
-    middle_end/flambda/basic/continuation_extra_params_and_args.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
     middle_end/flambda/types/structures/code_age_relation.cmx \
     utils/clflags.cmx \
     middle_end/flambda/types/env/binding_time.cmx \
-    middle_end/flambda/basic/apply_cont_rewrite_id.cmx \
     middle_end/flambda/types/env/typing_env_level.rec.cmi
 middle_end/flambda/types/env/typing_env_level.rec.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/terms/symbol_projection.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/basic/simple.cmi \
     utils/printing_cache.cmi \
+    middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/basic/name.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
-    middle_end/flambda/terms/flambda_primitive.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/simplify/env/continuation_use_kind.cmi \
-    middle_end/flambda/basic/continuation_extra_params_and_args.cmi \
     middle_end/flambda/naming/contains_names.cmo \
     middle_end/flambda/cmx/contains_ids.cmo \
     middle_end/flambda/types/env/binding_time.cmi \
@@ -9327,6 +9355,7 @@ middle_end/flambda/types/structures/closures_entry.rec.cmi : \
 middle_end/flambda/types/structures/code_age_relation.cmo : \
     middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
+    middle_end/flambda/naming/name_occurrences.cmi \
     utils/misc.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
@@ -9335,6 +9364,7 @@ middle_end/flambda/types/structures/code_age_relation.cmo : \
 middle_end/flambda/types/structures/code_age_relation.cmx : \
     middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/types/basic/or_bottom.cmx \
+    middle_end/flambda/naming/name_occurrences.cmx \
     utils/misc.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
@@ -9343,6 +9373,7 @@ middle_end/flambda/types/structures/code_age_relation.cmx : \
 middle_end/flambda/types/structures/code_age_relation.cmi : \
     middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
+    middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/basic/code_id.cmi
@@ -9769,6 +9800,7 @@ middle_end/flambda/unboxing/unbox_continuation_params.cmo : \
     utils/misc.cmi \
     utils/identifiable.cmi \
     middle_end/flambda/compilenv_deps/flambda_features.cmi \
+    middle_end/flambda/simplify/common_subexpression_elimination.cmi \
     middle_end/flambda/basic/closure_id.cmi \
     middle_end/flambda/basic/apply_cont_rewrite_id.cmi \
     middle_end/flambda/unboxing/unbox_continuation_params.cmi
@@ -9788,6 +9820,7 @@ middle_end/flambda/unboxing/unbox_continuation_params.cmx : \
     utils/misc.cmx \
     utils/identifiable.cmx \
     middle_end/flambda/compilenv_deps/flambda_features.cmx \
+    middle_end/flambda/simplify/common_subexpression_elimination.cmx \
     middle_end/flambda/basic/closure_id.cmx \
     middle_end/flambda/basic/apply_cont_rewrite_id.cmx \
     middle_end/flambda/unboxing/unbox_continuation_params.cmi

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -303,6 +303,7 @@ MIDDLE_END_FLAMBDA_SIMPLIFY=\
   middle_end/flambda/simplify/basic/continuation_in_env.cmo \
   middle_end/flambda/simplify/basic/simplified_named.cmo \
   middle_end/flambda/simplify/static_const_with_free_names.cmo \
+  middle_end/flambda/simplify/common_subexpression_elimination.cmo \
   middle_end/flambda/simplify/env/simplify_envs_intf.cmo \
   middle_end/flambda/simplify/env/simplify_envs.cmo \
   middle_end/flambda/simplify/typing_helpers/one_continuation_use.cmo \

--- a/middle_end/flambda/simplify/common_subexpression_elimination.ml
+++ b/middle_end/flambda/simplify/common_subexpression_elimination.ml
@@ -1,0 +1,363 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Pierre Chambart, OCamlPro                        *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2013--2021 OCamlPro SAS                                    *)
+(*   Copyright 2014--2021 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+(* [Simplify_import] cannot be used owing to a circular dependency. *)
+module EA = Continuation_extra_params_and_args.Extra_arg
+module EP = Flambda_primitive.Eligible_for_cse
+module EPA = Continuation_extra_params_and_args
+module K = Flambda_kind
+module KP = Kinded_parameter
+module NM = Name_mode
+module P = Flambda_primitive
+module RI = Apply_cont_rewrite_id
+module T = Flambda_type
+module TE = Flambda_type.Typing_env
+
+module List = ListLabels
+
+(* For the moment we don't index by scope level, unlike for [Typing_env],
+   and use a diff operation to cut the CSE environment.  This is probably
+   fine as there should be many fewer CSE equations than type equations. *)
+type t = {
+  cse : Simple.t EP.Map.t;
+}
+
+let print ppf { cse; } =
+  Format.fprintf ppf "@[%a@]" (EP.Map.print Simple.print) cse
+
+let empty =
+  { cse = EP.Map.empty;
+  }
+
+let add t prim ~bound_to =
+  match EP.Map.find prim t.cse with
+  | exception Not_found ->
+    let cse = EP.Map.add prim bound_to t.cse in
+    { cse; }
+  | _bound_to -> t
+
+let find t prim =
+  match EP.Map.find prim t.cse with
+  | exception Not_found -> None
+  | bound_to -> Some bound_to
+
+let concat { cse = cse1; } { cse = cse2; } =
+  let cse =
+    (* CR mshinwell: I think elsewhere we are preferring the earlier binding *)
+    EP.Map.union (fun _prim _t1 t2 -> Some t2) cse1 cse2
+  in
+  { cse; }
+
+let meet { cse = cse1; } { cse = cse2; } =
+  let cse =
+    EP.Map.merge (fun _ simple1 simple2 ->
+        match simple1, simple2 with
+        | None, None | None, Some _ | Some _, None -> None
+        | Some simple1, Some simple2 ->
+          if Simple.equal simple1 simple2 then Some simple1
+          else None)
+      cse1 cse2
+  in
+  { cse; }
+
+module Rhs_kind : sig
+  type t =
+    | Needs_extra_binding of { bound_to : Simple.t; }
+    | Rhs_in_scope of { bound_to : Simple.t; }
+
+  val bound_to : t -> Simple.t
+
+  include Identifiable.S with type t := t
+end = struct
+  type t =
+    | Needs_extra_binding of { bound_to : Simple.t; }
+    | Rhs_in_scope of { bound_to : Simple.t; }
+
+  let bound_to t =
+    match t with
+    | Needs_extra_binding { bound_to; }
+    | Rhs_in_scope { bound_to; } -> bound_to
+
+  include Identifiable.Make (struct
+    type nonrec t = t
+
+    let print ppf t =
+      match t with
+      | Needs_extra_binding { bound_to; } ->
+        Format.fprintf ppf "@[<hov 1>(Needs_extra_binding@ %a)@]"
+          Simple.print bound_to
+      | Rhs_in_scope { bound_to; } ->
+        Format.fprintf ppf "@[<hov 1>(Rhs_in_scope@ %a)@]"
+          Simple.print bound_to
+
+    let output _ _ = Misc.fatal_error "Rhs_kind.output not yet implemented"
+    let hash _ = Misc.fatal_error "Rhs_kind.hash not yet implemented"
+    let equal _ = Misc.fatal_error "Rhs_kind.equal not yet implemented"
+
+    let compare t1 t2 =
+      match t1, t2 with
+      | Needs_extra_binding { bound_to = bound_to1; },
+          Needs_extra_binding { bound_to = bound_to2; } ->
+        Simple.compare bound_to1 bound_to2
+      | Rhs_in_scope { bound_to = bound_to1; },
+          Rhs_in_scope { bound_to = bound_to2; } ->
+        Simple.compare bound_to1 bound_to2
+      | Needs_extra_binding _, _ -> -1
+      | Rhs_in_scope _, _ -> 1
+  end)
+end
+
+let cse_with_eligible_lhs ~typing_env_at_fork ~cse_at_each_use ~params prev_cse
+      (extra_bindings: EPA.t) extra_equations =
+  let params = KP.List.simple_set params in
+  List.fold_left cse_at_each_use ~init:EP.Map.empty
+    ~f:(fun eligible (env_at_use, id, t) ->
+      let find_new_name =
+        if EPA.is_empty extra_bindings
+        then (fun _arg -> None)
+        else begin
+          let extra_args = RI.Map.find id extra_bindings.extra_args in
+          let rec find_name simple params args =
+            match args, params with
+            | [], [] -> None
+            | [], _ | _, [] ->
+              Misc.fatal_error "Mismatching params and args arity"
+            | arg :: args, param :: params ->
+              begin
+              match (arg : EA.t) with
+              | Already_in_scope arg when Simple.equal arg simple ->
+                (* If [param] has an extra equation associated to it,
+                   we shouldn't propagate equations on it as it will mess
+                   with the application of constraints later *)
+                if Name.Map.mem (KP.name param) extra_equations
+                then None
+                else Some (KP.simple param)
+              | Already_in_scope _ | New_let_binding _ ->
+                find_name simple params args
+              end
+          in
+          (fun arg -> find_name arg extra_bindings.extra_params extra_args)
+        end
+      in
+      EP.Map.fold (fun prim bound_to eligible ->
+        let prim =
+          EP.filter_map_args prim ~f:(fun arg ->
+            match
+              TE.get_canonical_simple_exn env_at_use arg
+                ~min_name_mode:NM.normal
+            with
+            | exception Not_found -> None
+            | arg ->
+              begin match find_new_name arg with
+              | None ->
+                if TE.mem_simple typing_env_at_fork arg
+                then Some arg
+                else None
+              | Some _ as arg_opt -> arg_opt
+              end)
+        in
+        match prim with
+        | None -> eligible
+        | Some prim when EP.Map.mem prim prev_cse ->
+          (* We've already got it from a previous round *)
+          eligible
+        | Some prim ->
+          match
+            TE.get_canonical_simple_exn env_at_use bound_to
+              ~min_name_mode:NM.normal
+          with
+          | exception Not_found -> eligible
+          | bound_to ->
+            let bound_to =
+              (* CR mshinwell: Think about whether this is the best fix.
+                 The canonical simple might end up being one of the [params]
+                 since they are defined in [env_at_fork].  However these
+                 aren't bound at the use sites, so we must choose another
+                 alias that is. *)
+              if not (Simple.Set.mem bound_to params) then Some bound_to
+              else
+                let aliases =
+                  TE.aliases_of_simple env_at_use
+                    ~min_name_mode:NM.normal bound_to
+                  |> Simple.Set.filter (fun simple ->
+                    not (Simple.Set.mem simple params))
+                in
+                Simple.Set.get_singleton aliases
+            in
+            match bound_to with
+            | None -> eligible
+            | Some bound_to ->
+              let bound_to : Rhs_kind.t =
+                if TE.mem_simple typing_env_at_fork bound_to then
+                  Rhs_in_scope { bound_to; }
+                else
+                  Needs_extra_binding { bound_to; }
+              in
+              (* CR mshinwell: Add [Map.add_or_replace]. *)
+              match EP.Map.find prim eligible with
+              | exception Not_found ->
+                EP.Map.add prim (RI.Map.singleton id bound_to) eligible
+              | from_prev_levels ->
+                let map = RI.Map.add id bound_to from_prev_levels in
+                EP.Map.add prim map eligible)
+      t.cse
+      eligible)
+
+let join_one_cse_equation ~cse_at_each_use prim bound_to_map
+      (cse, extra_bindings, extra_equations, allowed) =
+  let has_value_on_all_paths =
+    List.for_all cse_at_each_use ~f:(fun (_, id, _) ->
+      RI.Map.mem id bound_to_map)
+  in
+  if not has_value_on_all_paths then
+    cse, extra_bindings, extra_equations, allowed
+  else
+    let bound_to_set =
+      RI.Map.data bound_to_map
+      |> Rhs_kind.Set.of_list
+    in
+    match Rhs_kind.Set.get_singleton bound_to_set with
+    | Some (Rhs_kind.Rhs_in_scope { bound_to; }) ->
+      EP.Map.add prim bound_to cse, extra_bindings, extra_equations, allowed
+    | None | Some (Rhs_kind.Needs_extra_binding { bound_to = _; }) ->
+      let prim_result_kind = P.result_kind' (EP.to_primitive prim) in
+      let var = Variable.create "cse_param" in
+      let extra_param =
+        KP.create var (K.With_subkind.create prim_result_kind Anything)
+      in
+      let bound_to = RI.Map.map Rhs_kind.bound_to bound_to_map in
+      let cse = EP.Map.add prim (Simple.var var) cse in
+      let extra_args =
+        RI.Map.map (fun simple : EA.t -> Already_in_scope simple) bound_to
+      in
+      let extra_bindings = EPA.add extra_bindings ~extra_param ~extra_args in
+      let extra_equations =
+        (* For the primitives Is_int and Get_tag, they're strongly linked
+           to their argument: additional information on the cse parameter
+           should translate into additional information on the argument.
+           This can be done by giving them the appropriate type. *)
+        match EP.to_primitive prim with
+        | Unary (Is_int, scrutinee) ->
+          Name.Map.add (Name.var var) (T.is_int_for_scrutinee ~scrutinee)
+            extra_equations
+        | Unary (Get_tag, block) ->
+          Name.Map.add (Name.var var) (T.get_tag_for_block ~block)
+            extra_equations
+        | _ -> extra_equations
+      in
+      let allowed =
+        Name_occurrences.add_name allowed (Name.var var) NM.normal
+      in
+      cse, extra_bindings, extra_equations, allowed
+
+let cut_cse_environment { cse; } ~cse_at_fork =
+  let { cse = cse_at_fork; } = cse_at_fork in
+  let cse =
+    (* Remove all equations present at the fork from the use environment.
+       (See comment earlier in this file about speed.) *)
+    if cse == cse_at_fork then EP.Map.empty
+    else
+      EP.Map.fold (fun prim _simple t -> EP.Map.remove prim t) cse_at_fork cse
+  in
+  { cse; }
+
+module Join_result = struct
+  type nonrec t =
+    { cse_at_join_point : t;
+      extra_params : EPA.t;
+      (* CR mshinwell: [extra_equations] should be something like [TEE.t] but
+         that is kind of slow at present. *)
+      extra_equations : T.t Name.Map.t;
+      extra_allowed_names : Name_occurrences.t;
+    }
+end
+
+let join ~typing_env_at_fork ~cse_at_fork ~cse_at_each_use ~params =
+  let cse_at_each_use =
+    List.map cse_at_each_use ~f:(fun (env_at_use, id, t) ->
+      let t = cut_cse_environment t ~cse_at_fork in
+      env_at_use, id, t)
+  in
+  let compute_cse_one_round prev_cse extra_params extra_equations ~allowed =
+  (* CSE equations have a left-hand side specifying a primitive and a
+     right-hand side specifying a [Simple].  The left-hand side is matched
+     against portions of terms.  As such, the [Simple]s therein must have
+     name mode [Normal], since we do not do CSE for phantom bindings (see
+     [Simplify_common]).  It follows that any CSE equation whose left-hand side
+     involves a name not defined at the fork point, having canonicalised such
+     name, cannot be propagated.  This step also canonicalises the right-hand
+     sides of the CSE equations. *)
+    let new_t =
+      cse_with_eligible_lhs ~typing_env_at_fork ~cse_at_each_use ~params
+        prev_cse extra_params extra_equations
+    in
+  (* To make use of a CSE equation at or after the join point, its right-hand
+     side must have the same value, no matter which path is taken from the
+     fork point to the join point.  We filter out equations that do not
+     satisfy this.  Sometimes we can force an equation to satisfy the
+     property by explicitly passing the value of the right-hand side as an
+     extra parameter to the continuation at the join point. *)
+    let cse', extra_params', extra_equations', allowed =
+      EP.Map.fold (join_one_cse_equation ~cse_at_each_use)
+        new_t (EP.Map.empty, EPA.empty, Name.Map.empty, allowed)
+    in
+    let need_other_round =
+      (* If we introduce new parameters, then CSE equations involving the
+         corresponding arguments can be considered again, so we need
+         another round. *)
+      not (EPA.is_empty extra_params')
+    in
+    let cse = EP.Map.disjoint_union prev_cse cse' in
+    let extra_params = EPA.concat extra_params' extra_params in
+    let extra_equations =
+      Name.Map.disjoint_union extra_equations extra_equations'
+    in
+    cse, extra_params, extra_equations, allowed, need_other_round
+  in
+  let cse, extra_params, extra_equations, allowed =
+    let rec do_rounds current_round cse extra_params extra_equations allowed =
+      let cse, extra_params, extra_equations, allowed, need_other_round =
+        compute_cse_one_round cse extra_params extra_equations ~allowed
+      in
+      if need_other_round && current_round < Flambda_features.cse_depth ()
+      then begin
+        do_rounds (succ current_round) cse extra_params extra_equations allowed
+      end else begin
+        (* Either a fixpoint has been reached or we've already explored far
+           enough *)
+        cse, extra_params, extra_equations, allowed
+      end
+    in
+    do_rounds 1 EP.Map.empty EPA.empty Name.Map.empty Name_occurrences.empty
+  in
+  let cse =
+    (* Any CSE equation whose right-hand side identifies a name in the [allowed]
+       set is propagated.  We don't need to check the left-hand sides because
+       we know all of those names are in [typing_env_at_fork]. *)
+    EP.Map.filter (fun _prim bound_to ->
+        Simple.pattern_match bound_to
+          ~const:(fun _ -> true)
+          ~name:(fun name -> Name_occurrences.mem_name allowed name))
+      cse
+  in
+  { Join_result.
+    cse_at_join_point = concat cse_at_fork { cse; };
+    extra_params;
+    extra_equations;
+    extra_allowed_names = allowed;
+  }

--- a/middle_end/flambda/simplify/common_subexpression_elimination.mli
+++ b/middle_end/flambda/simplify/common_subexpression_elimination.mli
@@ -32,13 +32,13 @@ val print : Format.formatter -> t -> unit
 
 val empty : t
 
-val add : t -> P.Eligible_for_cse.t -> bound_to:Simple.t -> t
+(** If the [t] already has an equation for the given primitive, then [add]
+    does nothing.  (Expected usage is that this will correspond to outermost
+    bindings taking precedence, but for simplicity, this function does not
+    enforce that.) *)
+val add : t -> P.Eligible_for_cse.t -> bound_to:Simple.t -> Scope.t -> t
 
 val find : t -> P.Eligible_for_cse.t -> Simple.t option
-
-val concat : t -> t -> t
-
-val meet : t -> t -> t
 
 module Join_result : sig
   type nonrec t = private
@@ -49,6 +49,8 @@ module Join_result : sig
     }
 end
 
+(** [join] adds CSE equations into [cse_at_fork] at the next scope level after
+    that given by the [typing_env_at_fork]. *)
 val join
    : typing_env_at_fork:TE.t
   -> cse_at_fork:t

--- a/middle_end/flambda/simplify/common_subexpression_elimination.mli
+++ b/middle_end/flambda/simplify/common_subexpression_elimination.mli
@@ -54,6 +54,9 @@ end
 val join
    : typing_env_at_fork:TE.t
   -> cse_at_fork:t
-  -> cse_at_each_use:(TE.t * RI.t * t) list
+  -> use_info:'a list
+  -> get_typing_env:('a -> TE.t)
+  -> get_rewrite_id:('a -> RI.t)
+  -> get_cse:('a -> t)
   -> params:KP.t list
-  -> Join_result.t
+  -> Join_result.t option

--- a/middle_end/flambda/simplify/env/simplify_envs_intf.ml
+++ b/middle_end/flambda/simplify/env/simplify_envs_intf.ml
@@ -203,6 +203,20 @@ module type Downwards_env = sig
   val set_inlining_depth_increment : t -> int -> t
 
   val get_inlining_depth_increment : t -> int
+
+  val add_cse
+     : t
+    -> Flambda_primitive.Eligible_for_cse.t
+    -> bound_to:Simple.t
+    -> t
+
+  val find_cse : t -> Flambda_primitive.Eligible_for_cse.t -> Simple.t option
+
+  val cse : t -> Common_subexpression_elimination.t
+
+  val with_cse : t -> Common_subexpression_elimination.t -> t
+
+  val concat_cse : t -> Common_subexpression_elimination.t -> t
 end
 
 module type Upwards_env = sig

--- a/middle_end/flambda/simplify/env/simplify_envs_intf.ml
+++ b/middle_end/flambda/simplify/env/simplify_envs_intf.ml
@@ -215,8 +215,6 @@ module type Downwards_env = sig
   val cse : t -> Common_subexpression_elimination.t
 
   val with_cse : t -> Common_subexpression_elimination.t -> t
-
-  val concat_cse : t -> Common_subexpression_elimination.t -> t
 end
 
 module type Upwards_env = sig

--- a/middle_end/flambda/simplify/simplify_common.ml
+++ b/middle_end/flambda/simplify/simplify_common.ml
@@ -60,11 +60,10 @@ let apply_cse dacc ~original_prim =
   match P.Eligible_for_cse.create original_prim with
   | None -> None
   | Some with_fixed_value ->
-    let typing_env = DA.typing_env dacc in
-    match TE.find_cse typing_env with_fixed_value with
+    match DE.find_cse (DA.denv dacc) with_fixed_value with
     | None -> None
     | Some simple ->
-      match TE.get_canonical_simple_exn typing_env simple with
+      match TE.get_canonical_simple_exn (DA.typing_env dacc) simple with
       | exception Not_found -> None
       | simple -> Some simple
 
@@ -86,8 +85,7 @@ let try_cse dacc ~original_prim ~result_kind ~min_name_mode ~args
         | Some eligible_prim ->
           let bound_to = Simple.var result_var in
           DA.map_denv dacc ~f:(fun denv ->
-            DE.with_typing_env denv
-            (TE.add_cse (DE.typing_env denv) eligible_prim ~bound_to))
+            DE.add_cse denv eligible_prim ~bound_to)
       in
       Not_applied dacc
 

--- a/middle_end/flambda/simplify/simplify_import.ml
+++ b/middle_end/flambda/simplify/simplify_import.ml
@@ -53,6 +53,7 @@ module LC = Simplify_envs.Lifted_constant
 module LCS = Simplify_envs.Lifted_constant_state
 module NM = Name_mode
 module P = Flambda_primitive
+module RI = Apply_cont_rewrite_id
 module S = Simplify_simple
 module SC = Static_const
 module T = Flambda_type

--- a/middle_end/flambda/simplify/simplify_import.mli
+++ b/middle_end/flambda/simplify/simplify_import.mli
@@ -53,6 +53,7 @@ module LC = Simplify_envs.Lifted_constant
 module LCS = Simplify_envs.Lifted_constant_state
 module NM = Name_mode
 module P = Flambda_primitive
+module RI = Apply_cont_rewrite_id
 module S = Simplify_simple
 module SC = Static_const
 module T = Flambda_type

--- a/middle_end/flambda/simplify/simplify_let_cont_expr.rec.ml
+++ b/middle_end/flambda/simplify/simplify_let_cont_expr.rec.ml
@@ -202,28 +202,28 @@ let simplify_non_recursive_let_cont_handler ~denv_before_body ~dacc_after_body
           EPA.empty cont_handler uacc ~after_rebuild)
   | Uses { handler_env; arg_types_by_use_id; extra_params_and_args;
            is_single_inlinable_use; is_single_use; } ->
-    let handler_typing_env, extra_params_and_args =
-      let handler_typing_env = DE.typing_env handler_env in
+    let handler_env, extra_params_and_args =
       (* Unbox the parameters of the continuation if possible.
          Any such unboxing will induce a rewrite (or wrapper) on
          the application sites of the continuation. *)
       match Continuation.sort cont with
       | Normal when is_single_inlinable_use ->
         assert (not is_exn_handler);
-        handler_typing_env, extra_params_and_args
+        handler_env, extra_params_and_args
       | Normal | Define_root_symbol ->
         assert (not is_exn_handler);
-        let param_types = TE.find_params handler_typing_env params in
-        Unbox_continuation_params.make_unboxing_decisions handler_typing_env
+        let param_types =
+          TE.find_params (DE.typing_env handler_env) params
+        in
+        Unbox_continuation_params.make_unboxing_decisions handler_env
           ~arg_types_by_use_id ~params ~param_types extra_params_and_args
       | Return | Toplevel_return ->
         assert (not is_exn_handler);
-        handler_typing_env, extra_params_and_args
+        handler_env, extra_params_and_args
       | Exn ->
         assert is_exn_handler;
-        handler_typing_env, extra_params_and_args
+        handler_env, extra_params_and_args
     in
-    let handler_env = DE.with_typing_env handler_env handler_typing_env in
     let at_unit_toplevel =
       (* We try to show that [handler] postdominates [body] (which is done by
          showing that [body] can only return through [cont]) and that if [body]

--- a/middle_end/flambda/simplify/simplify_named.rec.ml
+++ b/middle_end/flambda/simplify/simplify_named.rec.ml
@@ -181,6 +181,9 @@ let simplify_named0 dacc (bindable_let_bound : Bindable_let_bound.t)
     in
     let kind = P.result_kind' prim in
     let dacc =
+      (* CR mshinwell: It's a bit weird that the env_extension is added to
+         the typing env here; couldn't it just have been returned already
+         added to [dacc]? *)
       let dacc = DA.add_variable dacc bound_var (T.unknown kind) in
       DA.extend_typing_environment dacc env_extension
     in

--- a/middle_end/flambda/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda/simplify/simplify_unary_primitive.ml
@@ -142,9 +142,10 @@ let simplify_unbox_number (boxable_number_kind : K.Boxable_number.t)
     Unary (Box_number boxable_number_kind,
       Simple.var (Var_in_binding_pos.var result_var))
   in
-  let env_extension =
-    TEE.add_cse env_extension ~prim:(P.Eligible_for_cse.create_exn box_prim)
-      ~bound_to:arg
+  let dacc =
+    DA.map_denv dacc ~f:(fun denv ->
+      DE.add_cse denv (P.Eligible_for_cse.create_exn box_prim)
+        ~bound_to:arg)
   in
   reachable, env_extension, dacc
 

--- a/middle_end/flambda/simplify/typing_helpers/continuation_uses.ml
+++ b/middle_end/flambda/simplify/typing_helpers/continuation_uses.ml
@@ -191,7 +191,7 @@ Format.eprintf "Unknown at or later than %a\n%!"
         let extra_lifted_consts_in_use_envs =
           LCS.all_defined_symbols consts_lifted_during_body
         in
-        let use_envs_with_ids =
+        let use_envs_with_ids' =
           List.map (fun (use_env, id, use_kind) ->
               DE.typing_env use_env, id, use_kind)
             use_envs_with_ids
@@ -200,15 +200,29 @@ Format.eprintf "Unknown at or later than %a\n%!"
         let handler_env, extra_params_and_args =
           if not (Flambda_features.join_points ()) then
             let handler_env = simple_join typing_env uses ~params in
-            handler_env, Continuation_extra_params_and_args.empty
+            let denv = DE.with_typing_env denv handler_env in
+            denv, Continuation_extra_params_and_args.empty
           else
-            let env_extension, extra_params_and_args =
+            let cse_at_each_use =
+              ListLabels.map use_envs_with_ids ~f:(fun (use_env, id, _) ->
+                DE.typing_env use_env, id, DE.cse use_env)
+            in
+            let module CSE = Common_subexpression_elimination in
+            let cse_join_result =
+              CSE.join ~typing_env_at_fork:typing_env
+                ~cse_at_fork:(DE.cse denv)
+                ~cse_at_each_use
+                ~params
+            in
+            let extra_params_and_args = cse_join_result.extra_params in
+            let env_extension =
               TE.cut_and_n_way_join typing_env
-                use_envs_with_ids
+                use_envs_with_ids'
                 ~params
                 ~unknown_if_defined_at_or_later_than:
                   (Scope.next definition_scope_level)
                 ~extra_lifted_consts_in_use_envs
+                ~extra_allowed_names:cse_join_result.extra_allowed_names
             in
 (*
 Format.eprintf "handler env extension for %a is:@ %a\n%!"
@@ -223,15 +237,25 @@ Format.eprintf "The extra params and args are:@ %a\n%!"
                 ~params:extra_params_and_args.extra_params
             in
             let handler_env =
+              Name.Map.fold (fun name ty handler_env ->
+                  TE.add_equation handler_env name ty)
+                cse_join_result.extra_equations
+                handler_env
+            in
+            let handler_env =
               TE.add_env_extension handler_env env_extension
             in
-            handler_env, extra_params_and_args
+            let denv =
+              DE.with_cse (DE.with_typing_env denv handler_env)
+                cse_join_result.cse_at_join_point
+            in
+            denv, extra_params_and_args
         in
-        let handler_env =
-          TE.with_code_age_relation handler_env
-            code_age_relation_after_body
+        let denv =
+          DE.map_typing_env handler_env ~f:(fun handler_env ->
+            TE.with_code_age_relation handler_env
+              code_age_relation_after_body)
         in
-        let handler_env = DE.with_typing_env denv handler_env in
         let is_single_use =
           match uses with
           | [_] -> true
@@ -241,7 +265,7 @@ Format.eprintf "The extra params and args are:@ %a\n%!"
         | [_, _, Inlinable] -> assert false  (* handled above *)
         | [] | [_, _, Non_inlinable]
         | (_, _, (Inlinable | Non_inlinable)) :: _ ->
-          handler_env, extra_params_and_args, false, is_single_use
+          denv, extra_params_and_args, false, is_single_use
     in
     let arg_types_by_use_id =
       List.fold_left (fun args use ->

--- a/middle_end/flambda/simplify/typing_helpers/continuation_uses.ml
+++ b/middle_end/flambda/simplify/typing_helpers/continuation_uses.ml
@@ -209,6 +209,8 @@ Format.eprintf "Unknown at or later than %a\n%!"
             in
             let module CSE = Common_subexpression_elimination in
             let cse_join_result =
+              assert (Scope.equal definition_scope_level
+                (TE.current_scope typing_env));
               CSE.join ~typing_env_at_fork:typing_env
                 ~cse_at_fork:(DE.cse denv)
                 ~cse_at_each_use
@@ -219,6 +221,10 @@ Format.eprintf "Unknown at or later than %a\n%!"
               TE.cut_and_n_way_join typing_env
                 use_envs_with_ids'
                 ~params
+                (* CR mshinwell: If this didn't do Scope.next then TE could
+                   probably be slightly more efficient, as it wouldn't need
+                   to look at the middle of the three return values from
+                   Scope.Map.Split. *)
                 ~unknown_if_defined_at_or_later_than:
                   (Scope.next definition_scope_level)
                 ~extra_lifted_consts_in_use_envs

--- a/middle_end/flambda/simplify/typing_helpers/continuation_uses.mli
+++ b/middle_end/flambda/simplify/typing_helpers/continuation_uses.mli
@@ -19,6 +19,9 @@
     corresponding argument types across the recorded uses; and the environment
     to be used for simplifying the continuation itself. *)
 
+(* CR mshinwell: The join code should go into a new compilation unit called
+   Join_points or similar. *)
+
 [@@@ocaml.warning "+a-30-40-41-42"]
 
 type t

--- a/middle_end/flambda/types/env/typing_env.rec.mli
+++ b/middle_end/flambda/types/env/typing_env.rec.mli
@@ -83,17 +83,6 @@ val mem : ?min_name_mode:Name_mode.t -> t -> Name.t -> bool
 
 val mem_simple : ?min_name_mode:Name_mode.t -> t -> Simple.t -> bool
 
-val add_cse
-   : t
-  -> Flambda_primitive.Eligible_for_cse.t
-  -> bound_to:Simple.t
-  -> t
-
-val find_cse
-   : t
-  -> Flambda_primitive.Eligible_for_cse.t
-  -> Simple.t option
-
 val add_env_extension_from_level
    : t
   -> Typing_env_level.t
@@ -148,7 +137,8 @@ val cut_and_n_way_join
   -> params:Kinded_parameter.t list
   -> unknown_if_defined_at_or_later_than:Scope.t
   -> extra_lifted_consts_in_use_envs:Symbol.Set.t
-  -> Typing_env_extension.t * Continuation_extra_params_and_args.t
+  -> extra_allowed_names:Name_occurrences.t
+  -> Typing_env_extension.t
 
 val free_names_transitive : t -> Type_grammar.t -> Name_occurrences.t
 

--- a/middle_end/flambda/types/env/typing_env_level.rec.mli
+++ b/middle_end/flambda/types/env/typing_env_level.rec.mli
@@ -54,12 +54,6 @@ val add_definition : t -> Variable.t -> Flambda_kind.t -> Binding_time.t -> t
 
 val add_or_replace_equation : t -> Name.t -> Type_grammar.t -> t
 
-val add_cse
-   : t
-  -> Flambda_primitive.Eligible_for_cse.t
-  -> bound_to:Simple.t
-  -> t
-
 val add_symbol_projection : t -> Variable.t -> Symbol_projection.t -> t
 
 val symbol_projections : t -> Symbol_projection.t Variable.Map.t
@@ -78,9 +72,8 @@ val n_way_join
        * t) list
   -> params:Kinded_parameter.t list
   -> extra_lifted_consts_in_use_envs:Symbol.Set.t
-  -> t * Continuation_extra_params_and_args.t
-
-val cse : t -> Simple.t Flambda_primitive.Eligible_for_cse.Map.t
+  -> extra_allowed_names:Name_occurrences.t
+  -> t
 
 include Contains_names.S with type t := t
 

--- a/middle_end/flambda/types/flambda_type.mli
+++ b/middle_end/flambda/types/flambda_type.mli
@@ -52,12 +52,6 @@ module Typing_env_extension : sig
   val one_equation : Name.t -> flambda_type -> t
 
   val add_or_replace_equation : t -> Name.t -> flambda_type -> t
-
-  val add_cse
-     : t
-    -> prim:Flambda_primitive.Eligible_for_cse.t
-    -> bound_to:Simple.t
-    -> t
 end
 
 module Typing_env : sig
@@ -112,12 +106,6 @@ module Typing_env : sig
     -> param_types:flambda_type list
     -> t
 
-  val add_cse
-     : t
-    -> Flambda_primitive.Eligible_for_cse.t
-    -> bound_to:Simple.t
-    -> t
-
   val mem : ?min_name_mode:Name_mode.t -> t -> Name.t -> bool
 
   val mem_simple : ?min_name_mode:Name_mode.t -> t -> Simple.t -> bool
@@ -127,8 +115,6 @@ module Typing_env : sig
   val find_or_missing : t -> Name.t -> flambda_type option
 
   val find_params : t -> Kinded_parameter.t list -> flambda_type list
-
-  val find_cse : t -> Flambda_primitive.Eligible_for_cse.t -> Simple.t option
 
   val add_env_extension : t -> Typing_env_extension.t -> t
 
@@ -158,12 +144,19 @@ module Typing_env : sig
     -> params:Kinded_parameter.t list
     -> unknown_if_defined_at_or_later_than:Scope.t
     -> extra_lifted_consts_in_use_envs:Symbol.Set.t
-    -> Typing_env_extension.t * Continuation_extra_params_and_args.t
+    -> extra_allowed_names:Name_occurrences.t
+    -> Typing_env_extension.t
 
   val free_names_transitive
      : t
     -> flambda_type
     -> Name_occurrences.t
+
+  val aliases_of_simple
+     : t
+    -> min_name_mode:Name_mode.t
+    -> Simple.t
+    -> Simple.Set.t
 
   val clean_for_export : t -> reachable_names:Name_occurrences.t -> t
 

--- a/middle_end/flambda/unboxing/unbox_continuation_params.ml
+++ b/middle_end/flambda/unboxing/unbox_continuation_params.ml
@@ -18,6 +18,8 @@
 
 open! Simplify_import
 
+module CSE = Common_subexpression_elimination
+
 (* CR mshinwell: Add a command-line flag. *)
 let max_unboxing_depth = 1
 
@@ -60,7 +62,7 @@ module type Unboxing_spec = sig
     -> param_being_unboxed:KP.t
     -> new_params:KP.t Index.Map.t
     -> fields:T.t Index.Map.t
-    -> T.t * TEE.t
+    -> T.t * CSE.t * TEE.t
 
   val extend_with_projection
      : Info.t
@@ -296,7 +298,7 @@ module Make (U : Unboxing_spec) = struct
       Continue (param_types, List.rev all_field_types_by_id_rev,
         extra_params_and_args)
 
-  let unbox_one_parameter typing_env ~depth ~arg_types_by_use_id
+  let unbox_one_parameter denv ~depth ~arg_types_by_use_id
         ~param_being_unboxed ~param_type extra_params_and_args ~unbox_value
         info indexes =
     let orig_arg_types_by_use_id = arg_types_by_use_id in
@@ -317,7 +319,7 @@ module Make (U : Unboxing_spec) = struct
         <> Apply_cont_rewrite_id.Map.cardinal arg_types_by_use_id
     in
     if do_not_unbox then
-      typing_env, param_type, extra_params_and_args
+      denv, param_type, extra_params_and_args
     else
       let new_params =
         Index.Set.fold (fun index new_params ->
@@ -339,48 +341,53 @@ module Make (U : Unboxing_spec) = struct
           ~arg_types_by_use_id extra_params_and_args
       in
       match result with
-      | Aborted -> typing_env, param_type, extra_params_and_args
+      | Aborted -> denv, param_type, extra_params_and_args
       | Continue (fields, all_field_types_by_id, extra_params_and_args) ->
-        let block_type, env_extension =
+        let block_type, cse, env_extension =
           U.make_boxed_value info ~param_being_unboxed ~new_params ~fields
         in
-        let typing_env =
-          TE.add_definitions_of_params typing_env
-            ~params:(Index.Map.data new_params)
+        let denv = DE.concat_cse denv cse in
+        let denv =
+          DE.map_typing_env denv ~f:(fun typing_env ->
+            let typing_env =
+              TE.add_definitions_of_params typing_env
+                ~params:(Index.Map.data new_params)
+            in
+            TE.add_env_extension typing_env env_extension)
         in
-        let typing_env = TE.add_env_extension typing_env env_extension in
-        (* Format.eprintf "@[<v 2>Meet:@ @[block_type:@ %a@]@ @[param_type:@ %a@]@]@."
-         *   T.print block_type T.print param_type; *)
-        match T.meet typing_env block_type param_type with
+        match T.meet (DE.typing_env denv) block_type param_type with
         | Bottom ->
           Misc.fatal_errorf "[meet] between %a and %a should not have \
             failed.  Typing env:@ %a"
             T.print block_type
             T.print param_type
-            TE.print typing_env
+            DE.print denv
         | Ok (param_type, env_extension) ->
-          let typing_env = TE.add_env_extension typing_env env_extension in
+          let denv =
+            DE.map_typing_env denv ~f:(fun typing_env ->
+              TE.add_env_extension typing_env env_extension)
+          in
           assert (Index.Map.cardinal fields =
             List.length all_field_types_by_id);
-          let typing_env, extra_params_and_args =
+          let denv, extra_params_and_args =
             List.fold_left2
-              (fun (typing_env, extra_params_and_args)
+              (fun (denv, extra_params_and_args)
                   field_type field_types_by_id ->
                 if not (U.unbox_recursively ~field_type) then
-                  typing_env, extra_params_and_args
+                  denv, extra_params_and_args
                 else begin
-                  let typing_env, _, extra_params_and_args =
-                    unbox_value typing_env ~depth:(depth + 1)
+                  let denv, _, extra_params_and_args =
+                    unbox_value denv ~depth:(depth + 1)
                       ~arg_types_by_use_id:field_types_by_id
                       ~param_being_unboxed
                       ~param_type:field_type extra_params_and_args
                   in
-                  typing_env, extra_params_and_args
+                  denv, extra_params_and_args
                 end)
-              (typing_env, extra_params_and_args)
+              (denv, extra_params_and_args)
               (Index.Map.data fields) all_field_types_by_id
           in
-          typing_env, param_type, extra_params_and_args
+          denv, param_type, extra_params_and_args
 end
 
 module Block_of_values_spec : Unboxing_spec
@@ -393,7 +400,7 @@ struct
   module Use_info = struct
     type t = unit
 
-    let create _typing_env ~type_at_use:_ : _ create_use_info_result = Ok ()
+    let create _denv ~type_at_use:_ : _ create_use_info_result = Ok ()
   end
 
   let var_name = "unboxed"
@@ -409,7 +416,8 @@ struct
   let make_boxed_value tag ~param_being_unboxed:_ ~new_params:_ ~fields =
     let fields = Index.Map.data fields in
     T.immutable_block ~is_unique:false tag ~field_kind:K.value ~fields,
-    TEE.empty ()
+      CSE.empty,
+      TEE.empty ()
 
   let make_boxed_value_accommodating tag index ~index_var
         ~untagged_index_var:_ =
@@ -649,27 +657,22 @@ struct
     let is_int = Simple.name is_int_name in
     let get_tag = Simple.name get_tag_name in
     let is_int_prim =
-      P.Unary (Is_int, param_being_unboxed)
-      |> P.Eligible_for_cse.create_exn
+      P.Eligible_for_cse.create_exn (Unary (Is_int, param_being_unboxed))
     in
     let get_tag_prim =
-      P.Unary (Get_tag, param_being_unboxed)
-      |> P.Eligible_for_cse.create_exn
+      P.Eligible_for_cse.create_exn (Unary (Get_tag, param_being_unboxed))
     in
+    let cse = CSE.add CSE.empty is_int_prim ~bound_to:is_int in
+    let cse = CSE.add cse get_tag_prim ~bound_to:get_tag in
     let env_extension =
-      TEE.empty ()
-      |> TEE.add_cse ~prim:is_int_prim ~bound_to:is_int
-      |> TEE.add_cse ~prim:get_tag_prim ~bound_to:get_tag
-    in
-    let env_extension =
-      TEE.add_or_replace_equation env_extension is_int_name
+      TEE.one_equation is_int_name
         (T.is_int_for_scrutinee ~scrutinee:param_being_unboxed)
     in
     let env_extension =
       TEE.add_or_replace_equation env_extension get_tag_name
         (T.get_tag_for_block ~block:param_being_unboxed)
     in
-    ty, env_extension
+    ty, cse, env_extension
 
   let make_boxed_value_accommodating _variant (index : Index.t) ~index_var
         ~untagged_index_var =
@@ -766,7 +769,8 @@ struct
   let make_boxed_value tag ~param_being_unboxed:_ ~new_params:_ ~fields =
     let fields = Index.Map.data fields in
     T.immutable_block ~is_unique:false tag ~field_kind:K.naked_float ~fields,
-    TEE.empty ()
+      CSE.empty,
+      TEE.empty ()
 
   let make_boxed_value_accommodating tag index ~index_var
         ~untagged_index_var:_ =
@@ -841,7 +845,7 @@ struct
         ~all_closures_in_set
         ~all_closure_vars_in_set:closure_vars
     in
-    ty, TEE.empty ()
+    ty, CSE.empty, TEE.empty ()
 
   let make_boxed_value_accommodating (info : Info.t) closure_var ~index_var
         ~untagged_index_var:_ =
@@ -905,7 +909,7 @@ end) = struct
     assert (Tag.equal tag N.tag);
     let fields = Index.Map.data fields in
     match fields with
-    | [field] -> N.box field, TEE.empty ()
+    | [field] -> N.box field, CSE.empty, TEE.empty ()
     | _ -> Misc.fatal_errorf "Boxed %ss only have one field" N.name
 
   let make_boxed_value_accommodating _tag index ~index_var
@@ -1012,12 +1016,12 @@ let unboxed_number_decisions = [
   T.prove_is_a_boxed_nativeint, Nativeints.unbox_one_parameter, Tag.custom_tag;
 ]
 
-let rec make_unboxing_decision typing_env ~depth ~arg_types_by_use_id
+let rec make_unboxing_decision denv ~depth ~arg_types_by_use_id
       ~param_being_unboxed ~param_type extra_params_and_args =
   if depth > max_unboxing_depth then
-    typing_env, param_type, extra_params_and_args
+    denv, param_type, extra_params_and_args
   else
-    match T.prove_unique_tag_and_size typing_env param_type with
+    match T.prove_unique_tag_and_size (DE.typing_env denv) param_type with
     | Proved (tag, size) ->
       let indexes =
         let size = Targetint.OCaml.to_int size in
@@ -1027,14 +1031,14 @@ let rec make_unboxing_decision typing_env ~depth ~arg_types_by_use_id
       (* If the fields have kind [Naked_float] then the [tag] will always
          be [Tag.double_array_tag].  See [Row_like.For_blocks]. *)
       if Tag.equal tag Tag.double_array_tag then
-        Blocks_of_naked_floats.unbox_one_parameter typing_env ~depth
+        Blocks_of_naked_floats.unbox_one_parameter denv ~depth
           ~arg_types_by_use_id ~param_being_unboxed ~param_type
           extra_params_and_args ~unbox_value:make_unboxing_decision
           tag indexes
       else
         begin match Tag.Scannable.of_tag tag with
         | Some _ ->
-          Blocks_of_values.unbox_one_parameter typing_env ~depth
+          Blocks_of_values.unbox_one_parameter denv ~depth
             ~arg_types_by_use_id ~param_being_unboxed ~param_type
             extra_params_and_args ~unbox_value:make_unboxing_decision
             tag indexes
@@ -1042,10 +1046,10 @@ let rec make_unboxing_decision typing_env ~depth ~arg_types_by_use_id
           Misc.fatal_errorf "Block that is not of tag [Double_array_tag] \
               and yet also not scannable:@ %a@ in env:@ %a"
             T.print param_type
-            TE.print typing_env
+            DE.print denv
         end
     | Wrong_kind | Invalid | Unknown ->
-      match T.prove_variant typing_env param_type with
+      match T.prove_variant (DE.typing_env denv) param_type with
       | Proved variant ->
         (*
         Format.eprintf "Starting variant unboxing\n%!";
@@ -1064,12 +1068,12 @@ let rec make_unboxing_decision typing_env ~depth ~arg_types_by_use_id
           |> Variant_index.Set.add Tag
           |> Variant_index.Set.union fields
         in
-        Variants.unbox_one_parameter typing_env ~depth
+        Variants.unbox_one_parameter denv ~depth
           ~arg_types_by_use_id ~param_being_unboxed ~param_type
           extra_params_and_args ~unbox_value:make_unboxing_decision
           variant indexes
       | Invalid | Unknown | Wrong_kind ->
-        match T.prove_single_closures_entry' typing_env param_type with
+        match T.prove_single_closures_entry' (DE.typing_env denv) param_type with
         | Proved (closure_id, closures_entry, Ok _func_decl_type) ->
           let closure_var_types =
             T.Closures_entry.closure_var_types closures_entry
@@ -1080,58 +1084,55 @@ let rec make_unboxing_decision typing_env ~depth ~arg_types_by_use_id
             }
           in
           let closure_vars = Var_within_closure.Map.keys closure_var_types in
-          Closures.unbox_one_parameter typing_env ~depth
+          Closures.unbox_one_parameter denv ~depth
             ~arg_types_by_use_id ~param_being_unboxed ~param_type
             extra_params_and_args ~unbox_value:make_unboxing_decision
             info closure_vars
         | Proved (_, _, (Unknown | Bottom)) | Wrong_kind | Invalid | Unknown ->
           let rec try_unboxing = function
-            | [] -> typing_env, param_type, extra_params_and_args
+            | [] -> denv, param_type, extra_params_and_args
             | (prover, unboxer, tag) :: decisions ->
               let proof : _ T.proof_allowing_kind_mismatch =
-                prover typing_env param_type
+                prover (DE.typing_env denv) param_type
               in
               match proof with
               | Proved () ->
                 let indexes =
                   Targetint.OCaml.Set.singleton Targetint.OCaml.zero
                 in
-                unboxer typing_env ~depth ~arg_types_by_use_id
+                unboxer denv ~depth ~arg_types_by_use_id
                   ~param_being_unboxed ~param_type extra_params_and_args
                   ~unbox_value:make_unboxing_decision tag indexes
               | Wrong_kind | Invalid | Unknown -> try_unboxing decisions
           in
           try_unboxing unboxed_number_decisions
 
-let make_unboxing_decisions0 typing_env ~arg_types_by_use_id ~params
+let make_unboxing_decisions0 denv ~arg_types_by_use_id ~params
       ~param_types extra_params_and_args =
   assert (List.compare_lengths params param_types = 0);
-  let typing_env, param_types_rev, extra_params_and_args =
-    List.fold_left (fun (typing_env, param_types_rev, extra_params_and_args)
+  let denv, param_types_rev, extra_params_and_args =
+    List.fold_left (fun (denv, param_types_rev, extra_params_and_args)
               (arg_types_by_use_id, (param, param_type)) ->
-        let typing_env, param_type, extra_params_and_args =
-          make_unboxing_decision typing_env ~depth:1 ~arg_types_by_use_id
+        let denv, param_type, extra_params_and_args =
+          make_unboxing_decision denv ~depth:1 ~arg_types_by_use_id
             ~param_being_unboxed:param ~param_type extra_params_and_args
         in
-        typing_env, param_type :: param_types_rev, extra_params_and_args)
-      (typing_env, [], extra_params_and_args)
+        denv, param_type :: param_types_rev, extra_params_and_args)
+      (denv, [], extra_params_and_args)
       (List.combine arg_types_by_use_id
         (List.combine params param_types))
   in
-  let typing_env =
-    TE.add_equations_on_params typing_env
-      ~params ~param_types:(List.rev param_types_rev)
+  let denv =
+    DE.map_typing_env denv ~f:(fun typing_env ->
+      TE.add_equations_on_params typing_env
+        ~params ~param_types:(List.rev param_types_rev))
   in
-  (*
-  Format.eprintf "Final typing env:@ %a\n%!" TE.print typing_env;
-  Format.eprintf "EPA:@ %a\n%!" EPA.print extra_params_and_args;
-  *)
-  typing_env, extra_params_and_args
+  denv, extra_params_and_args
 
-let make_unboxing_decisions typing_env ~arg_types_by_use_id ~params
+let make_unboxing_decisions denv ~arg_types_by_use_id ~params
       ~param_types extra_params_and_args =
   if Flambda_features.unbox_along_intra_function_control_flow () then
-    make_unboxing_decisions0 typing_env ~arg_types_by_use_id ~params
+    make_unboxing_decisions0 denv ~arg_types_by_use_id ~params
       ~param_types extra_params_and_args
   else
-    typing_env, extra_params_and_args
+    denv, extra_params_and_args

--- a/middle_end/flambda/unboxing/unbox_continuation_params.mli
+++ b/middle_end/flambda/unboxing/unbox_continuation_params.mli
@@ -19,9 +19,9 @@
 open! Simplify_import
 
 val make_unboxing_decisions
-   : TE.t
-  -> arg_types_by_use_id: (TE.t * T.t) Apply_cont_rewrite_id.Map.t list
+   : DE.t
+  -> arg_types_by_use_id:(TE.t * T.t) Apply_cont_rewrite_id.Map.t list
   -> params:KP.t list
   -> param_types:T.t list
   -> Continuation_extra_params_and_args.t
-  -> TE.t * Continuation_extra_params_and_args.t
+  -> DE.t * Continuation_extra_params_and_args.t


### PR DESCRIPTION
Whilst starting to sketch out what needs doing to implement partial dead code elimination, which should enable us to sink boxing operations (as part of the general aim of matching and improving upon the unboxing strategy of `Cmmgen`), I realised that it was probably a design mistake to have the existing CSE code tied up with the type system side of things.  This PR separates it out; it now lives in the simplifier.  This seems better and is in fact a net reduction in lines of code.