### PR TITLE
Fix `Inline_attribute.equal`

### DIFF
--- a/middle_end/flambda/basic/inline_attribute.ml
+++ b/middle_end/flambda/basic/inline_attribute.ml
@@ -33,7 +33,9 @@ let print ppf t =
   | Default_inline -> fprintf ppf "Default_inline"
 
 let equal t1 t2 =
-  t1 == t2
+  match t1, t2 with
+  | Unroll n1, Unroll n2 -> n1 = n2
+  | _, _ -> t1 == t2
 
 let is_default t =
   match t with

--- a/middle_end/flambda/basic/inline_attribute.ml
+++ b/middle_end/flambda/basic/inline_attribute.ml
@@ -34,8 +34,12 @@ let print ppf t =
 
 let equal t1 t2 =
   match t1, t2 with
+  | Always_inline, Always_inline
+  | Hint_inline, Hint_inline
+  | Never_inline, Never_inline
+  | Default_inline, Default_inline -> true
   | Unroll n1, Unroll n2 -> n1 = n2
-  | _, _ -> t1 == t2
+  | _, _ -> false
 
 let is_default t =
   match t with


### PR DESCRIPTION
The current implementation defers to `==`, which is a problem because
`Unroll 1 == Unroll 1` is false.