### PR TITLE
Refactor Expr.create_switch 

### DIFF
--- a/middle_end/flambda/compare/compare.ml
+++ b/middle_end/flambda/compare/compare.ml
@@ -470,7 +470,7 @@ and subst_switch env switch =
   let arms =
     Target_imm.Map.map (subst_apply_cont env) (Switch_expr.arms switch)
   in
-  Expr.create_switch ~scrutinee ~arms
+  Expr.create_switch (Switch_expr.create ~scrutinee ~arms)
 ;;
 
 module Comparator = struct
@@ -1062,7 +1062,7 @@ let switch_exprs env switch1 switch2 : Expr.t Comparison.t =
     (Switch.arms switch1, Switch.scrutinee switch1)
     (Switch.arms switch2, Switch.scrutinee switch2)
   |> Comparison.map ~f:(fun (arms, scrutinee) ->
-      Expr.create_switch ~scrutinee ~arms
+      Expr.create_switch (Switch.create ~scrutinee ~arms)
   )
 ;;
 

--- a/middle_end/flambda/from_lambda/lambda_to_flambda_primitives_helpers.ml
+++ b/middle_end/flambda/from_lambda/lambda_to_flambda_primitives_helpers.ml
@@ -258,13 +258,14 @@ let rec bind_rec ~backend exn_cont
               (Prim expr_primitive) dbg
               (fun prim_result ->
                 (Expr.create_switch
-                  ~scrutinee:prim_result
-                  ~arms:(Target_imm.Map.of_list [
-                    Target_imm.bool_true,
-                      Apply_cont.goto condition_passed_cont;
-                    Target_imm.bool_false,
-                      Apply_cont.goto failure_cont;
-                  ])))
+                   (Switch.create
+                    ~scrutinee:prim_result
+                    ~arms:(Target_imm.Map.of_list [
+                      Target_imm.bool_true,
+                        Apply_cont.goto condition_passed_cont;
+                      Target_imm.bool_false,
+                        Apply_cont.goto failure_cont;
+                  ]))))
           in
           Let_cont.create_non_recursive condition_passed_cont
             condition_passed_cont_handler ~body

--- a/middle_end/flambda/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda/parser/fexpr_to_flambda.ml
@@ -514,8 +514,9 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
       |> Target_imm.Map.of_list
     in
     Flambda.Expr.create_switch
-      ~scrutinee:(simple env scrutinee)
-      ~arms
+      (Flambda.Switch.create
+        ~scrutinee:(simple env scrutinee)
+        ~arms)
 
   | Let_symbol { bindings; closure_elements; body } ->
     (* Desugar the abbreviated form for a single set of closures *)

--- a/middle_end/flambda/simplify/expr_builder.mli
+++ b/middle_end/flambda/simplify/expr_builder.mli
@@ -67,3 +67,11 @@ val place_lifted_constants
   -> body:Expr.t
   -> critical_deps_of_bindings:Name_occurrences.t
   -> Expr.t * Upwards_acc.t
+
+(** Create a [Switch] expression, save that zero-arm switches are converted
+    to [Invalid], and one-arm switches to [Apply_cont]. *)
+val create_switch
+  : Upwards_acc.t
+      -> scrutinee:Simple.t
+      -> arms:Apply_cont_expr.t Target_imm.Map.t
+      -> Expr.t * Upwards_acc.t

--- a/middle_end/flambda/simplify/simplify_switch_expr.rec.ml
+++ b/middle_end/flambda/simplify/simplify_switch_expr.rec.ml
@@ -208,7 +208,7 @@ let rebuild_switch dacc ~arms ~scrutinee ~scrutinee_ty uacc
               ~free_names_of_body:(Known (Expr.free_names body))
             |> Expr.create_let)
         | None ->
-          let expr = Expr.create_switch ~scrutinee ~arms in
+          let expr, uacc = EB.create_switch uacc ~scrutinee ~arms in
           if !Clflags.flambda_invariant_checks
             && Simple.is_const scrutinee
             && Target_imm.Map.cardinal arms > 1

--- a/middle_end/flambda/terms/expr.rec.mli
+++ b/middle_end/flambda/terms/expr.rec.mli
@@ -55,25 +55,7 @@ val create_apply : Apply.t -> t
 (** Create a continuation application (in the zero-arity case, "goto"). *)
 val create_apply_cont : Apply_cont.t -> t
 
-(* CR mshinwell: Move this stuff to [Simplify_switch]. *)
-type switch_creation_result = private
-  | Have_deleted_comparison_but_not_branch
-  | Have_deleted_comparison_and_branch
-  | Nothing_deleted
-
-(** Create a [Switch] expression, save that zero-arm switches are converted
-    to [Invalid], and one-arm switches to [Apply_cont]. *)
-val create_switch0
-   : scrutinee:Simple.t
-  -> arms:Apply_cont_expr.t Target_imm.Map.t
-  -> Expr.t * switch_creation_result
-
-(** Like [create_switch0], but for use when the caller isn't interested in
-    whether something got deleted. *)
-val create_switch
-   : scrutinee:Simple.t
-  -> arms:Apply_cont_expr.t Target_imm.Map.t
-  -> Expr.t
+val create_switch : Switch_expr.t -> t
 
 (** Build a [Switch] corresponding to a traditional if-then-else. *)
 val create_if_then_else

--- a/middle_end/flambda/terms/flambda.mli
+++ b/middle_end/flambda/terms/flambda.mli
@@ -73,25 +73,7 @@ module rec Expr : sig
   (** Create a continuation application (in the zero-arity case, "goto"). *)
   val create_apply_cont : Apply_cont.t -> t
 
-  (** What happened when a [Switch]-expression was created. *)
-  type switch_creation_result = private
-    | Have_deleted_comparison_but_not_branch
-    | Have_deleted_comparison_and_branch
-    | Nothing_deleted
-
-  (** Create a [Switch] expression, save that zero-arm switches are converted
-      to [Invalid], and one-arm switches to [Apply_cont]. *)
-  val create_switch0
-     : scrutinee:Simple.t
-    -> arms:Apply_cont_expr.t Target_imm.Map.t
-    -> Expr.t * switch_creation_result
-
-  (** Like [create_switch0], but for use when the caller isn't interested in
-      whether something got deleted. *)
-  val create_switch
-     : scrutinee:Simple.t
-    -> arms:Apply_cont_expr.t Target_imm.Map.t
-    -> Expr.t
+  val create_switch : Switch_expr.t -> t
 
   (** Build a [Switch] corresponding to a traditional if-then-else. *)
   val create_if_then_else


### PR DESCRIPTION
The module `Expr` provides several methods (`create_let`, `create_apply`) to create various an of Expr.t from a flambda term. All of them are following the same convention: 
- First create a term
- Then pass this term to `create_xxx` l 

However, `Expr:create_switch` was not following the same pattern and was bypassing the explicit construction of the term. More specifically, to create a switch node one only had to do 
```
Expr.create_switch ~scrutinee ~arms
```
Instead of having to do (as with any other term):
```
let switch = Switch.create ~scrutinee ~arms in
Expr.create_switch switch
```

Furthermore, `Expr.create_switch` was trying to simplify the term before building it -- something which should be limited to functions in simplify.

This PR corrects the interface to `Expr.create_switch` and avoids simplifying switch statements outside of simplify.