### PR TITLE
Add a primitive for optimised out phantom bindings

### DIFF
--- a/.depend
+++ b/.depend
@@ -6154,6 +6154,7 @@ middle_end/flambda/simplify/simplify.cmo : \
     middle_end/flambda/terms/function_declarations.cmi \
     middle_end/flambda/terms/function_declaration.cmi \
     middle_end/flambda/terms/flambda_unit.cmi \
+    middle_end/flambda/terms/flambda_primitive.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/cmx/flambda_cmx_format.cmi \
     middle_end/flambda/cmx/flambda_cmx.cmi \
@@ -6225,6 +6226,7 @@ middle_end/flambda/simplify/simplify.cmx : \
     middle_end/flambda/terms/function_declarations.cmx \
     middle_end/flambda/terms/function_declaration.cmx \
     middle_end/flambda/terms/flambda_unit.cmx \
+    middle_end/flambda/terms/flambda_primitive.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/cmx/flambda_cmx_format.cmx \
     middle_end/flambda/cmx/flambda_cmx.cmx \
@@ -6539,27 +6541,41 @@ middle_end/flambda/simplify/simplify_import.cmi : \
     middle_end/flambda/basic/code_id_or_symbol.cmi \
     middle_end/flambda/basic/apply_cont_rewrite_id.cmi
 middle_end/flambda/simplify/simplify_let_cont_expr.rec.cmo : \
+    middle_end/flambda/naming/var_in_binding_pos.cmi \
     middle_end/flambda/unboxing/unbox_continuation_params.cmi \
     middle_end/flambda/simplify/simplify_import.cmi \
+    middle_end/flambda/simplify/basic/simplified_named.cmi \
     middle_end/flambda/basic/recursive.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
+    middle_end/flambda/naming/name_mode.cmi \
     utils/misc.cmi \
+    middle_end/flambda/terms/flambda_primitive.cmi \
     middle_end/flambda/terms/flambda.cmi \
+    middle_end/flambda/simplify/expr_builder.cmi \
+    lambda/debuginfo.cmi \
     middle_end/flambda/basic/continuation_extra_params_and_args.cmi \
     middle_end/flambda/simplify/env/continuation_env_and_param_types.cmi \
     middle_end/flambda/basic/continuation.cmi \
+    middle_end/flambda/naming/bindable_let_bound.cmi \
     middle_end/flambda/simplify/basic/apply_cont_rewrite.cmi \
     middle_end/flambda/simplify/simplify_let_cont_expr.rec.cmi
 middle_end/flambda/simplify/simplify_let_cont_expr.rec.cmx : \
+    middle_end/flambda/naming/var_in_binding_pos.cmx \
     middle_end/flambda/unboxing/unbox_continuation_params.cmx \
     middle_end/flambda/simplify/simplify_import.cmx \
+    middle_end/flambda/simplify/basic/simplified_named.cmx \
     middle_end/flambda/basic/recursive.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
+    middle_end/flambda/naming/name_mode.cmx \
     utils/misc.cmx \
+    middle_end/flambda/terms/flambda_primitive.cmx \
     middle_end/flambda/terms/flambda.cmx \
+    middle_end/flambda/simplify/expr_builder.cmx \
+    lambda/debuginfo.cmx \
     middle_end/flambda/basic/continuation_extra_params_and_args.cmx \
     middle_end/flambda/simplify/env/continuation_env_and_param_types.cmx \
     middle_end/flambda/basic/continuation.cmx \
+    middle_end/flambda/naming/bindable_let_bound.cmx \
     middle_end/flambda/simplify/basic/apply_cont_rewrite.cmx \
     middle_end/flambda/simplify/simplify_let_cont_expr.rec.cmi
 middle_end/flambda/simplify/simplify_let_cont_expr.rec.cmi : \
@@ -6637,11 +6653,36 @@ middle_end/flambda/simplify/simplify_named.rec.cmi : \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/simplify/env/downwards_acc.cmi \
     middle_end/flambda/naming/bindable_let_bound.cmi
+middle_end/flambda/simplify/simplify_nullary_primitive.cmo : \
+    middle_end/flambda/naming/var_in_binding_pos.cmi \
+    middle_end/flambda/simplify/simplify_import.cmi \
+    middle_end/flambda/simplify/basic/simplified_named.cmi \
+    middle_end/flambda/naming/name_mode.cmi \
+    middle_end/flambda/basic/name.cmi \
+    utils/misc.cmi \
+    middle_end/flambda/simplify/simplify_nullary_primitive.cmi
+middle_end/flambda/simplify/simplify_nullary_primitive.cmx : \
+    middle_end/flambda/naming/var_in_binding_pos.cmx \
+    middle_end/flambda/simplify/simplify_import.cmx \
+    middle_end/flambda/simplify/basic/simplified_named.cmx \
+    middle_end/flambda/naming/name_mode.cmx \
+    middle_end/flambda/basic/name.cmx \
+    utils/misc.cmx \
+    middle_end/flambda/simplify/simplify_nullary_primitive.cmi
+middle_end/flambda/simplify/simplify_nullary_primitive.cmi : \
+    middle_end/flambda/naming/var_in_binding_pos.cmi \
+    middle_end/flambda/simplify/basic/simplified_named.cmi \
+    middle_end/flambda/basic/simple.cmi \
+    middle_end/flambda/types/flambda_type.cmi \
+    middle_end/flambda/terms/flambda_primitive.cmi \
+    middle_end/flambda/simplify/env/downwards_acc.cmi \
+    lambda/debuginfo.cmi
 middle_end/flambda/simplify/simplify_primitive.cmo : \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
     middle_end/flambda/simplify/simplify_variadic_primitive.cmi \
     middle_end/flambda/simplify/simplify_unary_primitive.cmi \
     middle_end/flambda/simplify/simplify_ternary_primitive.cmi \
+    middle_end/flambda/simplify/simplify_nullary_primitive.cmi \
     middle_end/flambda/simplify/simplify_import.cmi \
     middle_end/flambda/simplify/simplify_binary_primitive.cmi \
     middle_end/flambda/simplify/basic/simplified_named.cmi \
@@ -6655,6 +6696,7 @@ middle_end/flambda/simplify/simplify_primitive.cmx : \
     middle_end/flambda/simplify/simplify_variadic_primitive.cmx \
     middle_end/flambda/simplify/simplify_unary_primitive.cmx \
     middle_end/flambda/simplify/simplify_ternary_primitive.cmx \
+    middle_end/flambda/simplify/simplify_nullary_primitive.cmx \
     middle_end/flambda/simplify/simplify_import.cmx \
     middle_end/flambda/simplify/simplify_binary_primitive.cmx \
     middle_end/flambda/simplify/basic/simplified_named.cmx \

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -327,6 +327,7 @@ MIDDLE_END_FLAMBDA_SIMPLIFY=\
   middle_end/flambda/simplify/simplify_common.cmo \
   middle_end/flambda/simplify/simplify_variadic_primitive.cmo \
   middle_end/flambda/simplify/typing_helpers/number_adjuncts.cmo \
+  middle_end/flambda/simplify/simplify_nullary_primitive.cmo \
   middle_end/flambda/simplify/simplify_unary_primitive.cmo \
   middle_end/flambda/simplify/simplify_ternary_primitive.cmo \
   middle_end/flambda/simplify/simplify_binary_primitive.cmo \

--- a/middle_end/flambda/inlining/inlining_cost.ml
+++ b/middle_end/flambda/inlining/inlining_cost.ml
@@ -368,6 +368,7 @@ let variadic_prim_size prim args =
 
 let prim_size (prim : Flambda_primitive.t) =
   match prim with
+  | Nullary Optimised_out _ -> 0
   | Unary (p, _) -> unary_prim_size p
   | Binary (p, _, _) -> binary_prim_size p
   | Ternary (p, _, _, _) -> ternary_prim_size p
@@ -381,6 +382,8 @@ let smaller' denv expr ~than:threshold =
     if !size > threshold then raise Exit;
     match Expr.descr expr with
     | Let let_expr ->
+      (* CR gbury/pchambart: phantom let-bindings should not be
+                             counted towards the size *)
       named_size denv (Let.defining_expr let_expr);
       Let.pattern_match let_expr
         ~f:(fun _bindable_let_bound ~body -> expr_size denv body)

--- a/middle_end/flambda/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda/parser/flambda_to_fexpr.ml
@@ -407,6 +407,8 @@ let varop (op : Flambda_primitive.variadic_primitive) : Fexpr.varop =
 
 let prim env (p : Flambda_primitive.t) : Fexpr.prim =
   match p with
+  | Nullary _ ->
+    Misc.fatal_errorf "TODO: Nullary primitive"
   | Unary (op, arg) ->
     Unary (unop env op, simple env arg)
   | Binary (op, arg1, arg2) ->

--- a/middle_end/flambda/simplify/simplify_named.rec.ml
+++ b/middle_end/flambda/simplify/simplify_named.rec.ml
@@ -49,6 +49,7 @@ let record_any_symbol_projection dacc (defining_expr : Simplified_named.t)
        of the primitive, so we can directly read off whether they are
        symbols or constants, as needed. *)
     match prim with
+    | Nullary Optimised_out _ -> None
     | Unary (Project_var { project_from; var; }, _)
         when can_record_proj ->
       begin match args with

--- a/middle_end/flambda/simplify/simplify_nullary_primitive.ml
+++ b/middle_end/flambda/simplify/simplify_nullary_primitive.ml
@@ -1,0 +1,36 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*      Pierre Chambart & Guillaume Bury, OCamlPro                        *)
+(*                                                                        *)
+(*   Copyright 2013--2019 OCamlPro SAS                                    *)
+(*   Copyright 2014--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+open! Simplify_import
+
+let simplify_nullary_primitive dacc
+      (prim : P.nullary_primitive) dbg ~result_var =
+  match prim with
+  | Optimised_out result_kind ->
+    begin match Name_mode.descr (Var_in_binding_pos.name_mode result_var) with
+    | Phantom -> ()
+    | Normal | In_types ->
+      Misc.fatal_errorf "The 'optimised_out' primitive should only be used \
+                         in bindings of phantom variables"
+    end;
+    let named = Named.create_prim (Nullary prim) dbg in
+    let ty = T.unknown result_kind in
+    let var = Name.var (Var_in_binding_pos.var result_var) in
+    let env_extension = TEE.one_equation var ty in
+    Simplified_named.reachable named, env_extension, [], dacc
+
+

--- a/middle_end/flambda/simplify/simplify_nullary_primitive.mli
+++ b/middle_end/flambda/simplify/simplify_nullary_primitive.mli
@@ -1,0 +1,26 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*      Pierre Chambart & Guillaume Bury, OCamlPro                        *)
+(*                                                                        *)
+(*   Copyright 2013--2019 OCamlPro SAS                                    *)
+(*   Copyright 2014--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-9-30-40-41-42"]
+
+(** Simplification of primitives taking no argument. *)
+
+val simplify_nullary_primitive
+   : Downwards_acc.t
+  -> Flambda_primitive.nullary_primitive
+  -> Debuginfo.t
+  -> result_var:Var_in_binding_pos.t
+  -> Simplified_named.t * Flambda_type.Typing_env_extension.t
+       * Simple.t list * Downwards_acc.t

--- a/middle_end/flambda/simplify/simplify_primitive.ml
+++ b/middle_end/flambda/simplify/simplify_primitive.ml
@@ -85,6 +85,9 @@ let simplify_primitive dacc (prim : P.t) dbg ~result_var =
     | Applied result -> result
     | Not_applied dacc ->
       match prim, args with
+      | Nullary prim, [] ->
+        Simplify_nullary_primitive.simplify_nullary_primitive dacc
+          prim dbg ~result_var
       | Unary (prim, _), [arg, arg_ty] ->
         Simplify_unary_primitive.simplify_unary_primitive dacc
           prim ~arg ~arg_ty dbg ~result_var
@@ -98,7 +101,7 @@ let simplify_primitive dacc (prim : P.t) dbg ~result_var =
       | Variadic (variadic_prim, _), args_with_tys ->
         Simplify_variadic_primitive.simplify_variadic_primitive dacc
           variadic_prim ~args_with_tys dbg ~result_var
-      | (Unary _ | Binary _ | Ternary _), ([] | _::_) ->
+      | (Nullary _ | Unary _ | Binary _ | Ternary _), ([] | _::_) ->
         Misc.fatal_errorf "Mismatch between primitive %a and args %a"
           P.print prim
           Simple.List.print (List.map fst args)

--- a/middle_end/flambda/terms/flambda_primitive.ml
+++ b/middle_end/flambda/terms/flambda_primitive.ml
@@ -528,6 +528,40 @@ type result_kind =
   | Singleton of K.t
   | Unit
 
+type nullary_primitive =
+  | Optimised_out of K.t
+
+let nullary_primitive_eligible_for_cse = function
+  | Optimised_out _ -> false
+
+let compare_nullary_primitive p1 p2 =
+  match p1, p2 with
+  | Optimised_out k1, Optimised_out k2 -> K.compare k1 k2
+
+let equal_nullary_primitive p1 p2 =
+  compare_nullary_primitive p1 p2 = 0
+
+let print_nullary_primitive ppf p =
+  match p with
+  | Optimised_out _ ->
+    Format.fprintf ppf "@<0>%sOptimised_out@<0>%s"
+      (Flambda_colours.elide ())
+      (Flambda_colours.normal ())
+
+let result_kind_of_nullary_primitive p : result_kind =
+  match p with
+  | Optimised_out k -> Singleton k
+
+let effects_and_coeffects_of_nullary_primitive p =
+  match p with
+  | Optimised_out _ ->
+    Effects.No_effects, Coeffects.No_coeffects
+
+let nullary_classify_for_printing p =
+  match p with
+  | Optimised_out _ -> Neither
+
+
 type unary_primitive =
   | Duplicate_block of {
       kind : Duplicate_block_kind.t;
@@ -1320,6 +1354,7 @@ let variadic_classify_for_printing p =
   | Make_array _ -> Constructive
 
 type t =
+  | Nullary of nullary_primitive
   | Unary of unary_primitive * Simple.t
   | Binary of binary_primitive * Simple.t * Simple.t
   | Ternary of ternary_primitive * Simple.t * Simple.t * Simple.t
@@ -1330,6 +1365,7 @@ type primitive_application = t
 let invariant env t =
   let module E = Invariant_env in
   match t with
+  | Nullary Optimised_out _ -> ()
   | Unary (prim, x0) ->
     let kind0 = arg_kind_of_unary_primitive prim in
     E.check_simple_is_bound_and_of_kind env x0 kind0;
@@ -1404,6 +1440,7 @@ let invariant env t =
 
 let classify_for_printing t =
   match t with
+  | Nullary prim -> nullary_classify_for_printing prim
   | Unary (prim, _) -> unary_classify_for_printing prim
   | Binary (prim, _, _) -> binary_classify_for_printing prim
   | Ternary (prim, _, _, _) -> ternary_classify_for_printing prim
@@ -1417,12 +1454,15 @@ include Identifiable.Make (struct
     else
       let numbering t =
         match t with
-        | Unary _ -> 0
-        | Binary _ -> 1
-        | Ternary _ -> 2
-        | Variadic _ -> 3
+        | Nullary _ -> 0
+        | Unary _ -> 1
+        | Binary _ -> 2
+        | Ternary _ -> 3
+        | Variadic _ -> 4
       in
       match t1, t2 with
+      | Nullary p, Nullary p' ->
+        compare_nullary_primitive p p'
       | Unary (p, s1), Unary (p', s1') ->
         let c = compare_unary_primitive p p' in
         if c <> 0 then c
@@ -1448,7 +1488,7 @@ include Identifiable.Make (struct
         let c = compare_variadic_primitive p p' in
         if c <> 0 then c
         else Simple.List.compare s s'
-      | (Unary _ | Binary _ | Ternary _ | Variadic _), _ ->
+      | (Nullary _ | Unary _ | Binary _ | Ternary _ | Variadic _), _ ->
         Stdlib.compare (numbering t1) (numbering t2)
 
   let equal t1 t2 = (compare t1 t2 = 0)
@@ -1463,6 +1503,11 @@ include Identifiable.Make (struct
       | Neither -> Flambda_colours.prim_neither ()
     in
     match t with
+    | Nullary prim ->
+      Format.fprintf ppf "@[<hov 1>@<0>%s%a@<0>%s@]"
+        colour
+        print_nullary_primitive prim
+        (Flambda_colours.normal ())
     | Unary (prim, v0) ->
       Format.fprintf ppf "@[<hov 1>(@<0>%s%a@<0>%s@ %a)@]"
         colour
@@ -1500,6 +1545,7 @@ let equal t1 t2 =
 
 let free_names t =
   match t with
+  | Nullary _ -> Name_occurrences.empty
   | Unary (Project_var { var = clos_var; project_from = _ }, x0) ->
     Name_occurrences.add_closure_var (Simple.free_names x0)
       clos_var Name_mode.normal
@@ -1521,6 +1567,7 @@ let apply_name_permutation t perm =
   (* CR mshinwell: add phys-equal checks *)
   let apply simple = Simple.apply_name_permutation simple perm in
   match t with
+  | Nullary _ -> t
   | Unary (prim, x0) -> Unary (prim, apply x0)
   | Binary (prim, x0, x1) -> Binary (prim, apply x0, apply x1)
   | Ternary (prim, x0, x1, x2) -> Ternary (prim, apply x0, apply x1, apply x2)
@@ -1529,6 +1576,7 @@ let apply_name_permutation t perm =
 
 let all_ids_for_export t =
   match t with
+  | Nullary _ -> Ids_for_export.empty
   | Unary (_prim, x0) -> Ids_for_export.from_simple x0
   | Binary (_prim, x0, x1) ->
     Ids_for_export.add_simple (Ids_for_export.from_simple x0) x1
@@ -1541,6 +1589,7 @@ let all_ids_for_export t =
 
 let import import_map t =
   match t with
+  | Nullary _ -> t
   | Unary (prim, x0) ->
     let x0 = Ids_for_export.Import_map.simple import_map x0 in
     Unary (prim, x0)
@@ -1561,6 +1610,7 @@ let import import_map t =
 
 let args t =
   match t with
+  | Nullary _ -> []
   | Unary (_, x0) -> [x0]
   | Binary (_, x0, x1) -> [x0; x1]
   | Ternary (_, x0, x1, x2) -> [x0; x1; x2]
@@ -1568,6 +1618,7 @@ let args t =
 
 let result_kind (t : t) =
   match t with
+  | Nullary prim -> result_kind_of_nullary_primitive prim
   | Unary (prim, _) -> result_kind_of_unary_primitive prim
   | Binary (prim, _, _) -> result_kind_of_binary_primitive prim
   | Ternary (prim, _, _, _) -> result_kind_of_ternary_primitive prim
@@ -1575,6 +1626,12 @@ let result_kind (t : t) =
 
 let result_kind' t =
   match result_kind t with
+  | Singleton kind -> kind
+  | Unit -> K.value
+
+let result_kind_of_nullary_primitive' t =
+  match result_kind_of_nullary_primitive t with
+  (* CR mshinwell: factor out this mapping *)
   | Singleton kind -> kind
   | Unit -> K.value
 
@@ -1604,6 +1661,7 @@ let result_kind_of_variadic_primitive' t =
 
 let effects_and_coeffects (t : t) =
   match t with
+  | Nullary prim -> effects_and_coeffects_of_nullary_primitive prim
   | Unary (prim, _) -> effects_and_coeffects_of_unary_primitive prim
   | Binary (prim, _, _) -> effects_and_coeffects_of_binary_primitive prim
   | Ternary (prim, _, _, _) -> effects_and_coeffects_of_ternary_primitive prim
@@ -1633,6 +1691,7 @@ module Eligible_for_cse = struct
        primitives, sort the arguments here *)
     let prim_eligible =
       match t with
+      | Nullary prim -> nullary_primitive_eligible_for_cse prim
       | Unary (prim, arg) -> unary_primitive_eligible_for_cse prim ~arg
       | Binary (prim, _, _) -> binary_primitive_eligible_for_cse prim
       | Ternary (prim, _, _, _) -> ternary_primitive_eligible_for_cse prim
@@ -1660,6 +1719,7 @@ module Eligible_for_cse = struct
       | Some map_arg ->
         let t =
           match t with
+          | Nullary _ -> t
           | Unary (prim, arg) ->
             let arg' = map_arg arg in
             if arg == arg' then t
@@ -1702,6 +1762,7 @@ module Eligible_for_cse = struct
 
   let fold_args t ~init ~f =
     match t with
+    | Nullary _ -> init, t
     | Unary (prim, arg) ->
       let acc, arg = f init arg in
       acc, Unary (prim, arg)
@@ -1726,6 +1787,7 @@ module Eligible_for_cse = struct
 
   let filter_map_args t ~f =
     match t with
+    | Nullary _ -> Some t
     | Unary (prim, arg) ->
       begin match f arg with
       | None -> None
@@ -1782,6 +1844,7 @@ end
 
 let args t =
   match t with
+  | Nullary _ -> []
   | Unary (_, arg) -> [arg]
   | Binary (_, arg1, arg2) -> [arg1; arg2]
   | Ternary (_, arg1, arg2, arg3) -> [arg1; arg2; arg3]
@@ -1789,6 +1852,7 @@ let args t =
 
 module Without_args = struct
   type t =
+    | Nullary of nullary_primitive
     | Unary of unary_primitive
     | Binary of binary_primitive
     | Ternary of ternary_primitive
@@ -1796,6 +1860,7 @@ module Without_args = struct
 
   let print ppf (t : t) =
     match t with
+    | Nullary prim -> print_nullary_primitive ppf prim
     | Unary prim -> print_unary_primitive ppf prim
     | Binary prim -> print_binary_primitive ppf prim
     | Ternary prim -> print_ternary_primitive ppf prim

--- a/middle_end/flambda/terms/flambda_primitive.mli
+++ b/middle_end/flambda/terms/flambda_primitive.mli
@@ -187,6 +187,14 @@ type signed_or_unsigned =
   | Signed
   | Unsigned
 
+(** Primitive taking exactly zero arguments *)
+type nullary_primitive =
+  | Optimised_out of Flambda_kind.t
+  (** Used for phantom bindings for which there is not enough information
+      remaining to build a meaningful value.
+      Can only be used in a phantom let-binding. *)
+
+
 (** Untagged binary integer arithmetic operations.
 
     [Swap_byte_endianness] on a [Tagged_immediate] treats the immediate as
@@ -309,6 +317,7 @@ type variadic_primitive =
 
 (** The application of a primitive to its arguments. *)
 type t =
+  | Nullary of nullary_primitive
   | Unary of unary_primitive * Simple.t
   | Binary of binary_primitive * Simple.t * Simple.t
   | Ternary of ternary_primitive * Simple.t * Simple.t * Simple.t
@@ -328,6 +337,7 @@ val args : t -> Simple.t list
     primitive matters, not the arguments. *)
 module Without_args : sig
   type t =
+    | Nullary of nullary_primitive
     | Unary of unary_primitive
     | Binary of binary_primitive
     | Ternary of ternary_primitive
@@ -362,6 +372,7 @@ type result_kind =
   | Unit
   (** The primitive returns the constant unit value. *)
 
+val result_kind_of_nullary_primitive : nullary_primitive -> result_kind
 val result_kind_of_unary_primitive : unary_primitive -> result_kind
 val result_kind_of_binary_primitive : binary_primitive -> result_kind
 val result_kind_of_ternary_primitive : ternary_primitive -> result_kind
@@ -371,6 +382,7 @@ val result_kind_of_variadic_primitive : variadic_primitive -> result_kind
 val result_kind : t -> result_kind
 
 (** Like the [result_kind]s, but returns the appropriate [Flambda_kind]. *)
+val result_kind_of_nullary_primitive' : nullary_primitive -> Flambda_kind.t
 val result_kind_of_unary_primitive' : unary_primitive -> Flambda_kind.t
 val result_kind_of_binary_primitive' : binary_primitive -> Flambda_kind.t
 val result_kind_of_ternary_primitive' : ternary_primitive -> Flambda_kind.t
@@ -430,6 +442,7 @@ end
 include Identifiable.S with type t := t
 
 val equal : t -> t -> bool
+val equal_nullary_primitive : nullary_primitive -> nullary_primitive -> bool
 val equal_unary_primitive : unary_primitive -> unary_primitive -> bool
 val equal_binary_primitive : binary_primitive -> binary_primitive -> bool
 val equal_ternary_primitive : ternary_primitive -> ternary_primitive -> bool

--- a/middle_end/flambda/to_cmm/un_cps.ml
+++ b/middle_end/flambda/to_cmm/un_cps.ml
@@ -524,6 +524,8 @@ let arg_list env l =
    given to [Env.inline_variable]. *)
 let prim env dbg p =
   match (p : Flambda_primitive.t) with
+  | Nullary Optimised_out _ ->
+    Misc.fatal_errorf "TODO: phantom let-bindings in un_cps"
   | Unary (f, x) ->
     let x, env, eff = simple env x in
     let extra, res = unary_primitive env dbg f x in


### PR DESCRIPTION
This is the other solution mentioned in #312 , which in turns out, was far easier and quicker to implement, which is a strong point explaining why this approach is better.