### PR TITLE
Better extension from meet

### DIFF
--- a/.depend
+++ b/.depend
@@ -9177,6 +9177,7 @@ middle_end/flambda/types/flambda_type.cmo : \
     middle_end/flambda/naming/name_in_binding_pos.cmi \
     middle_end/flambda/basic/name.cmi \
     utils/misc.cmi \
+    middle_end/flambda/types/basic/meet_result.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     utils/identifiable.cmi \
@@ -9232,6 +9233,7 @@ middle_end/flambda/types/flambda_type.cmx : \
     middle_end/flambda/naming/name_in_binding_pos.cmx \
     middle_end/flambda/basic/name.cmx \
     utils/misc.cmx \
+    middle_end/flambda/types/basic/meet_result.cmx \
     middle_end/flambda/basic/kinded_parameter.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     utils/identifiable.cmx \
@@ -9277,6 +9279,7 @@ middle_end/flambda/types/flambda_type.cmi : \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/naming/name_in_binding_pos.cmi \
     middle_end/flambda/basic/name.cmi \
+    middle_end/flambda/types/basic/meet_result.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/basic/invariant_env.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
@@ -9315,6 +9318,7 @@ middle_end/flambda/types/type_descr.rec.cmo : \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     utils/misc.cmi \
+    middle_end/flambda/types/basic/meet_result.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/compilenv_deps/coercion.cmi \
@@ -9334,6 +9338,7 @@ middle_end/flambda/types/type_descr.rec.cmx : \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     utils/misc.cmx \
+    middle_end/flambda/types/basic/meet_result.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/compilenv_deps/coercion.cmx \
@@ -9350,6 +9355,7 @@ middle_end/flambda/types/type_descr_intf.cmo : \
     middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
     middle_end/flambda/basic/name.cmi \
+    middle_end/flambda/types/basic/meet_result.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/naming/contains_names.cmo \
     middle_end/flambda/cmx/contains_ids.cmo \
@@ -9361,6 +9367,7 @@ middle_end/flambda/types/type_descr_intf.cmx : \
     middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/types/basic/or_bottom.cmx \
     middle_end/flambda/basic/name.cmx \
+    middle_end/flambda/types/basic/meet_result.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
     middle_end/flambda/naming/contains_names.cmx \
     middle_end/flambda/cmx/contains_ids.cmx \
@@ -9428,6 +9435,7 @@ middle_end/flambda/types/type_grammar.rec.cmi : \
     middle_end/flambda/types/basic/or_bottom.cmi \
     utils/numbers.cmi \
     middle_end/flambda/basic/name.cmi \
+    middle_end/flambda/types/basic/meet_result.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
     lambda/debuginfo.cmi \
     middle_end/flambda/naming/contains_names.cmo \
@@ -9439,6 +9447,7 @@ middle_end/flambda/types/type_head_intf.cmo : \
     utils/printing_cache.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
+    middle_end/flambda/types/basic/meet_result.cmi \
     middle_end/flambda/naming/contains_names.cmo \
     middle_end/flambda/cmx/contains_ids.cmo \
     middle_end/flambda/compilenv_deps/coercion.cmi
@@ -9446,6 +9455,7 @@ middle_end/flambda/types/type_head_intf.cmx : \
     utils/printing_cache.cmx \
     middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/types/basic/or_bottom.cmx \
+    middle_end/flambda/types/basic/meet_result.cmx \
     middle_end/flambda/naming/contains_names.cmx \
     middle_end/flambda/cmx/contains_ids.cmx \
     middle_end/flambda/compilenv_deps/coercion.cmx
@@ -9506,6 +9516,11 @@ middle_end/flambda/types/basic/meet_or_join_op.cmo : \
 middle_end/flambda/types/basic/meet_or_join_op.cmx : \
     middle_end/flambda/types/basic/meet_or_join_op.cmi
 middle_end/flambda/types/basic/meet_or_join_op.cmi :
+middle_end/flambda/types/basic/meet_result.cmo : \
+    middle_end/flambda/types/basic/meet_result.cmi
+middle_end/flambda/types/basic/meet_result.cmx : \
+    middle_end/flambda/types/basic/meet_result.cmi
+middle_end/flambda/types/basic/meet_result.cmi :
 middle_end/flambda/types/basic/or_bottom.cmo : \
     middle_end/flambda/types/basic/or_bottom.cmi
 middle_end/flambda/types/basic/or_bottom.cmx : \
@@ -9690,6 +9705,7 @@ middle_end/flambda/types/env/typing_env.rec.cmo : \
     middle_end/flambda/naming/name_in_binding_pos.cmi \
     middle_end/flambda/basic/name.cmi \
     utils/misc.cmi \
+    middle_end/flambda/types/basic/meet_result.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
@@ -9715,6 +9731,7 @@ middle_end/flambda/types/env/typing_env.rec.cmx : \
     middle_end/flambda/naming/name_in_binding_pos.cmx \
     middle_end/flambda/basic/name.cmx \
     utils/misc.cmx \
+    middle_end/flambda/types/basic/meet_result.cmx \
     middle_end/flambda/basic/kinded_parameter.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
@@ -9865,6 +9882,7 @@ middle_end/flambda/types/structures/closures_entry.rec.cmo : \
     utils/printing_cache.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
+    middle_end/flambda/types/basic/meet_result.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/basic/closure_id.cmi \
     middle_end/flambda/types/structures/closures_entry.rec.cmi
@@ -9872,6 +9890,7 @@ middle_end/flambda/types/structures/closures_entry.rec.cmx : \
     utils/printing_cache.cmx \
     middle_end/flambda/types/basic/or_bottom.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
+    middle_end/flambda/types/basic/meet_result.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/basic/closure_id.cmx \
     middle_end/flambda/types/structures/closures_entry.rec.cmi
@@ -9912,6 +9931,7 @@ middle_end/flambda/types/structures/function_declaration_type.rec.cmo : \
     middle_end/flambda/types/basic/or_bottom.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
+    middle_end/flambda/types/basic/meet_result.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     lambda/debuginfo.cmi \
     middle_end/flambda/basic/code_id.cmi \
@@ -9924,6 +9944,7 @@ middle_end/flambda/types/structures/function_declaration_type.rec.cmx : \
     middle_end/flambda/types/basic/or_bottom.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
+    middle_end/flambda/types/basic/meet_result.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     lambda/debuginfo.cmx \
     middle_end/flambda/basic/code_id.cmx \
@@ -9946,6 +9967,7 @@ middle_end/flambda/types/structures/product.rec.cmo : \
     middle_end/flambda/types/basic/or_bottom.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     utils/misc.cmi \
+    middle_end/flambda/types/basic/meet_result.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/basic/closure_id.cmi \
@@ -9959,6 +9981,7 @@ middle_end/flambda/types/structures/product.rec.cmx : \
     middle_end/flambda/types/basic/or_bottom.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     utils/misc.cmx \
+    middle_end/flambda/types/basic/meet_result.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
     middle_end/flambda/basic/closure_id.cmx \
@@ -10001,6 +10024,7 @@ middle_end/flambda/types/structures/row_like.rec.cmo : \
     utils/numbers.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     utils/misc.cmi \
+    middle_end/flambda/types/basic/meet_result.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     utils/identifiable.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
@@ -10024,6 +10048,7 @@ middle_end/flambda/types/structures/row_like.rec.cmx : \
     utils/numbers.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     utils/misc.cmx \
+    middle_end/flambda/types/basic/meet_result.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     utils/identifiable.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
@@ -10072,12 +10097,12 @@ middle_end/flambda/types/structures/set_of_closures_contents.cmi : \
     middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/types/structures/type_structure_intf.cmo : \
     utils/printing_cache.cmi \
-    middle_end/flambda/types/basic/or_bottom.cmi \
+    middle_end/flambda/types/basic/meet_result.cmi \
     middle_end/flambda/naming/contains_names.cmo \
     middle_end/flambda/cmx/contains_ids.cmo
 middle_end/flambda/types/structures/type_structure_intf.cmx : \
     utils/printing_cache.cmx \
-    middle_end/flambda/types/basic/or_bottom.cmx \
+    middle_end/flambda/types/basic/meet_result.cmx \
     middle_end/flambda/naming/contains_names.cmx \
     middle_end/flambda/cmx/contains_ids.cmx
 middle_end/flambda/types/type_of_kind/type_of_kind_naked_float0.rec.cmo : \
@@ -10085,6 +10110,7 @@ middle_end/flambda/types/type_of_kind/type_of_kind_naked_float0.rec.cmo : \
     middle_end/flambda/types/basic/or_bottom.cmi \
     utils/numbers.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
+    middle_end/flambda/types/basic/meet_result.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/compilenv_deps/coercion.cmi \
     middle_end/flambda/types/type_of_kind/type_of_kind_naked_float0.rec.cmi
@@ -10093,6 +10119,7 @@ middle_end/flambda/types/type_of_kind/type_of_kind_naked_float0.rec.cmx : \
     middle_end/flambda/types/basic/or_bottom.cmx \
     utils/numbers.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
+    middle_end/flambda/types/basic/meet_result.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/compilenv_deps/coercion.cmx \
     middle_end/flambda/types/type_of_kind/type_of_kind_naked_float0.rec.cmi
@@ -10106,6 +10133,7 @@ middle_end/flambda/types/type_of_kind/type_of_kind_naked_immediate0.rec.cmo : \
     middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
+    middle_end/flambda/types/basic/meet_result.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/compilenv_deps/coercion.cmi \
     middle_end/flambda/types/type_of_kind/type_of_kind_naked_immediate0.rec.cmi
@@ -10116,6 +10144,7 @@ middle_end/flambda/types/type_of_kind/type_of_kind_naked_immediate0.rec.cmx : \
     middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/types/basic/or_bottom.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
+    middle_end/flambda/types/basic/meet_result.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/compilenv_deps/coercion.cmx \
     middle_end/flambda/types/type_of_kind/type_of_kind_naked_immediate0.rec.cmi
@@ -10127,6 +10156,7 @@ middle_end/flambda/types/type_of_kind/type_of_kind_naked_int32_0.rec.cmo : \
     middle_end/flambda/types/basic/or_bottom.cmi \
     utils/numbers.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
+    middle_end/flambda/types/basic/meet_result.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/compilenv_deps/coercion.cmi \
     middle_end/flambda/types/type_of_kind/type_of_kind_naked_int32_0.rec.cmi
@@ -10135,6 +10165,7 @@ middle_end/flambda/types/type_of_kind/type_of_kind_naked_int32_0.rec.cmx : \
     middle_end/flambda/types/basic/or_bottom.cmx \
     utils/numbers.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
+    middle_end/flambda/types/basic/meet_result.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/compilenv_deps/coercion.cmx \
     middle_end/flambda/types/type_of_kind/type_of_kind_naked_int32_0.rec.cmi
@@ -10145,6 +10176,7 @@ middle_end/flambda/types/type_of_kind/type_of_kind_naked_int64_0.rec.cmo : \
     middle_end/flambda/types/basic/or_bottom.cmi \
     utils/numbers.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
+    middle_end/flambda/types/basic/meet_result.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/compilenv_deps/coercion.cmi \
     middle_end/flambda/types/type_of_kind/type_of_kind_naked_int64_0.rec.cmi
@@ -10153,6 +10185,7 @@ middle_end/flambda/types/type_of_kind/type_of_kind_naked_int64_0.rec.cmx : \
     middle_end/flambda/types/basic/or_bottom.cmx \
     utils/numbers.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
+    middle_end/flambda/types/basic/meet_result.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/compilenv_deps/coercion.cmx \
     middle_end/flambda/types/type_of_kind/type_of_kind_naked_int64_0.rec.cmi
@@ -10163,6 +10196,7 @@ middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.cmo : \
     middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
+    middle_end/flambda/types/basic/meet_result.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/compilenv_deps/coercion.cmi \
     middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.cmi
@@ -10171,6 +10205,7 @@ middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.cmx : \
     middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/types/basic/or_bottom.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
+    middle_end/flambda/types/basic/meet_result.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/compilenv_deps/coercion.cmx \
     middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.cmi
@@ -10198,6 +10233,7 @@ middle_end/flambda/types/type_of_kind/type_of_kind_value0.rec.cmo : \
     middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
+    middle_end/flambda/types/basic/meet_result.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/compilenv_deps/coercion.cmi \
     middle_end/flambda/types/type_of_kind/type_of_kind_value0.rec.cmi
@@ -10207,6 +10243,7 @@ middle_end/flambda/types/type_of_kind/type_of_kind_value0.rec.cmx : \
     middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/types/basic/or_bottom.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
+    middle_end/flambda/types/basic/meet_result.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/compilenv_deps/coercion.cmx \
     middle_end/flambda/types/type_of_kind/type_of_kind_value0.rec.cmi

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -263,6 +263,7 @@ MIDDLE_END_FLAMBDA_TYPES=\
   middle_end/flambda/types/env/aliases.cmo \
   middle_end/flambda/types/basic/meet_or_join_op.cmo \
   middle_end/flambda/types/basic/or_bottom.cmo \
+  middle_end/flambda/types/basic/meet_result.cmo \
   middle_end/flambda/types/basic/string_info.cmo \
   middle_end/flambda/types/basic/or_unknown_or_bottom.cmo \
   middle_end/flambda/types/structures/code_age_relation.cmo \

--- a/flambdatest/api_tests/Makefile
+++ b/flambdatest/api_tests/Makefile
@@ -60,7 +60,7 @@ CAMLDEP=$(CAMLRUN) $(ROOTDIR)/boot/ocamlc -depend
 DEPFLAGS=-slash
 DEPINCLUDES=$(INCLUDES)
 
-SOURCES=extension_meet.ml import_test.ml
+SOURCES=extension_meet.ml import_test.ml join_tests.ml
 
 COMPILERLIBS=\
   $(ROOTDIR)/compilerlibs/ocamlcommon.cma \

--- a/flambdatest/api_tests/join_tests.ml
+++ b/flambdatest/api_tests/join_tests.ml
@@ -1,0 +1,89 @@
+(*
+   Continuation k has three parameters, three uses.
+   Variable x is defined after the fork but in all paths
+   Use types:
+   (=x, =x) { x : {0, 1} }
+   ({0, 1, 2}, {0, 1, 2}) { x : {0, 1, 2} }
+*)
+
+module T = Flambda_type
+module TE = Flambda_type.Typing_env
+
+let test_join () =
+  let env_at_fork =
+    TE.create
+      ~resolver:(fun _ -> None)
+      ~get_imported_names:(fun () -> Name.Set.empty)
+  in
+  let param_a = Variable.create "a" in
+  let param_b = Variable.create "b" in
+  let param_c = Variable.create "c" in
+  let n_a = Name.var param_a in
+  let n_b = Name.var param_b in
+  let n_c = Name.var param_c in
+  let kind_ni = Flambda_kind.With_subkind.naked_immediate in
+  let kp_a = Kinded_parameter.create param_a kind_ni in
+  let kp_b = Kinded_parameter.create param_b kind_ni in
+  let kp_c = Kinded_parameter.create param_c kind_ni in
+  let params = [kp_c; kp_b; kp_a] in
+  let env_at_fork = TE.add_definitions_of_params env_at_fork ~params in
+  let var_x = Variable.create "x" in
+  let n_x = Name.var var_x in
+  let nb_x = Name_in_binding_pos.create n_x Name_mode.normal in
+  let env = TE.add_definition env_at_fork nb_x Flambda_kind.naked_immediate in
+  let alias name = T.alias_type_of Flambda_kind.naked_immediate (Simple.name name) in
+  let imms_left =
+    T.these_naked_immediates Target_imm.all_bools
+  in
+  let imms_right =
+    T.these_naked_immediates Target_imm.zero_one_and_minus_one
+  in
+  let env_left = TE.add_equation env n_a imms_left in
+  let env_left = TE.add_equation env_left n_b (alias n_x) in
+  let env_left = TE.add_equation env_left n_c (alias n_x) in
+  let env_left =
+    TE.add_equation env_left n_x imms_left
+  in
+  let env_right =
+    TE.add_equation env n_a (alias n_x)
+  in
+  let env_right =
+    TE.add_equation env_right n_b imms_right
+  in
+  let env_right =
+    TE.add_equation env_right n_c (alias n_x)
+  in
+  let env_right =
+    TE.add_equation env_right n_x imms_right
+  in
+  let join_env =
+    TE.cut_and_n_way_join
+      env_at_fork
+      [env_left, Obj.magic 0, Obj.magic 0;
+       env_right, Obj.magic 0, Obj.magic 0]
+      ~params
+      ~unknown_if_defined_at_or_later_than:Scope.initial
+      ~extra_lifted_consts_in_use_envs:Symbol.Set.empty
+      ~extra_allowed_names:Name_occurrences.empty
+  in
+  Format.eprintf
+    "Environments:@.\
+     Env at fork:@ %a@.\
+     Left env:@ %a@.\
+     Right env:@ %a@.@.\
+     Join env:@ %a@.@."
+    TE.print env_at_fork
+    TE.print env_left
+    TE.print env_right
+    TE.print join_env;
+  ()
+
+let _ =
+  let comp_unit =
+    let id = Ident.create_persistent "Test" in
+    let linkage_name = Linkage_name.create "camlTest" in
+    Compilation_unit.create id linkage_name
+  in
+  Compilation_unit.set_current comp_unit;
+  test_join ()
+

--- a/flambdatest/mlexamples/alias_bug.ml
+++ b/flambdatest/mlexamples/alias_bug.ml
@@ -1,0 +1,22 @@
+
+type float_kind_conv =
+  | Float_f                        (*  %f | %+f | % f  *)
+  | Float_e                        (*  %e | %+e | % e  *)
+  | Float_E                        (*  %E | %+E | % E  *)
+  | Float_g                        (*  %g | %+g | % g  *)
+  | Float_G                        (*  %G | %+G | % G  *)
+  | Float_F                        (*  %F | %+F | % F  *)
+  | Float_h                        (*  %h | %+h | % h  *)
+  | Float_H                        (*  %H | %+H | % H  *)
+  | Float_CF                       (*  %#F| %+#F| % #F *)
+
+let char_of_fconv ?(cF='F') fconv = match snd fconv with
+  | Float_f -> 'f' | Float_e -> 'e'
+  | Float_E -> 'E' | Float_g -> 'g'
+  | Float_G -> 'G' | Float_F -> cF
+  | Float_h -> 'h' | Float_H -> 'H'
+  | Float_CF -> 'F'
+
+let f x = char_of_fconv x
+
+(* let g x = char_of_fconv ~cF:'g' x *)

--- a/middle_end/flambda/lifting/reification.ml
+++ b/middle_end/flambda/lifting/reification.ml
@@ -117,8 +117,7 @@ let try_to_reify dacc (term : Simplified_named.t) ~bound_to ~allow_lifting =
   match term with
   | Invalid _ ->
     let ty = T.bottom_like ty in
-    let denv = DE.add_equation_on_variable denv bound_to ty in
-    Simplified_named.invalid (), DA.with_denv dacc denv, ty
+    Simplified_named.invalid (), dacc, ty
   | Reachable _ ->
     let typing_env = DE.typing_env denv in
     let reify_result =

--- a/middle_end/flambda/types/basic/meet_result.ml
+++ b/middle_end/flambda/types/basic/meet_result.ml
@@ -1,0 +1,50 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Vincent Laviron, OCamlPro                        *)
+(*                                                                        *)
+(*   Copyright 2021 OCamlPro SAS                                          *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type 'a return_value =
+  | Left_input
+  | Right_input
+  | Both_inputs
+  | New_result of 'a
+
+type ('a, 'ext) t =
+  | Bottom
+  | Ok of 'a return_value * 'ext
+
+let map_result ~f = function
+  | Bottom -> Bottom
+  | Ok (Left_input, ext) -> Ok (Left_input, ext)
+  | Ok (Right_input, ext) -> Ok (Right_input, ext)
+  | Ok (Both_inputs, ext) -> Ok (Both_inputs, ext)
+  | Ok (New_result x, ext) -> Ok (New_result (f x), ext)
+
+let extract_value res left right =
+  match res with
+  | Left_input -> left
+  | Right_input -> right
+  | Both_inputs -> left
+  | New_result value -> value
+
+let set_meet (type a) ~no_extension (module S : Set.S with type t = a)
+      (s1 : a) (s2 : a) =
+  match S.subset s1 s2, S.subset s2 s1 with
+  | true, true -> Ok (Both_inputs, no_extension)
+  | true, false -> Ok (Left_input, no_extension)
+  | false, true -> Ok (Right_input, no_extension)
+  | false, false ->
+    let s = S.inter s1 s2 in
+    if S.is_empty s then Bottom
+    else Ok (New_result s, no_extension)

--- a/middle_end/flambda/types/basic/meet_result.mli
+++ b/middle_end/flambda/types/basic/meet_result.mli
@@ -1,0 +1,48 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Vincent Laviron, OCamlPro                        *)
+(*                                                                        *)
+(*   Copyright 2021 OCamlPro SAS                                          *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Type for the result of meet operations *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type 'a return_value =
+  | Left_input
+  | Right_input
+  | Both_inputs
+  | New_result of 'a
+
+type ('a, 'ext) t =
+  | Bottom
+  | Ok of 'a return_value * 'ext
+
+val map_result
+   : f:('a -> 'b)
+  -> ('a, 'ext) t
+  -> ('b, 'ext) t
+
+(** Given a result and the inputs used to generate it,
+    returns the corresponding value.
+    In the Both_inputs case, the left input is returned. *)
+val extract_value
+   : 'a return_value
+  -> 'a
+  -> 'a
+  -> 'a
+
+val set_meet
+   : no_extension:'ext
+  -> (module Set.S with type t = 'a)
+  -> 'a
+  -> 'a
+  -> ('a, 'ext) t

--- a/middle_end/flambda/types/env/typing_env.rec.ml
+++ b/middle_end/flambda/types/env/typing_env.rec.ml
@@ -771,8 +771,17 @@ let mem ?min_name_mode t name =
     ~symbol:(fun sym ->
       (* CR mshinwell: This might not take account of symbols in missing
          .cmx files *)
-      Symbol.Set.mem sym t.defined_symbols
-        || Name.Set.mem name (t.get_imported_names ()))
+      let comp_unit = Symbol.compilation_unit sym in
+      if Compilation_unit.equal comp_unit (Compilation_unit.get_current_exn ())
+      then
+        Symbol.Set.mem sym t.defined_symbols
+      else
+        match (resolver t) comp_unit with
+        | None ->
+          (* The cmx is unavailable, but the symbol is valid *)
+          true
+        | Some _ ->
+          Name.Set.mem name (t.get_imported_names ()))
 
 let mem_simple ?min_name_mode t simple =
   Simple.pattern_match simple

--- a/middle_end/flambda/types/env/typing_env.rec.ml
+++ b/middle_end/flambda/types/env/typing_env.rec.ml
@@ -934,18 +934,22 @@ let rec add_equation0 (t:t) name ty =
       | exception Not_found -> true
       | _ -> false
     in
-    if is_concrete then begin
-      let canonical =
-        Aliases.get_canonical_ignoring_name_mode (aliases t) name
-        |> Simple.without_coercion
-      in
-      if not (Simple.equal canonical (Simple.name name)) then begin
-        Misc.fatal_errorf "Trying to add equation giving concrete type on %a \
-            which is not canonical (its canonical is %a): %a"
-          Name.print name
-          Simple.print canonical
-          Type_grammar.print ty
-      end
+    let canonical =
+      Aliases.get_canonical_ignoring_name_mode (aliases t) name
+      |> Simple.without_coercion
+    in
+    if is_concrete && not (Simple.equal canonical (Simple.name name)) then begin
+      Misc.fatal_errorf "Trying to add equation giving concrete type on %a \
+          which is not canonical (its canonical is %a): %a"
+        Name.print name
+        Simple.print canonical
+        Type_grammar.print ty
+    end;
+    if not is_concrete && Simple.equal canonical (Simple.name name) then begin
+      Misc.fatal_errorf "Trying to add equation giving alias type on %a \
+          which is canonical: %a"
+        Name.print name
+        Type_grammar.print ty
     end
   end;
   invariant_for_new_equation t name ty;

--- a/middle_end/flambda/types/env/typing_env.rec.ml
+++ b/middle_end/flambda/types/env/typing_env.rec.ml
@@ -1101,14 +1101,14 @@ and add_equation t name ty =
   let ty, t =
     let [@inline always] name eqn_name ~coercion =
       assert (Coercion.is_id coercion); (* true by definition *)
-      if Name.equal name eqn_name then ty, t
-      else
-        let env = Meet_env.create t in
-        let existing_ty = find t eqn_name (Some (Type_grammar.kind ty)) in
-        match Type_grammar.meet env ty existing_ty with
-        | Bottom -> Type_grammar.bottom_like ty, t
-        | Ok (meet_ty, env_extension) ->
-          meet_ty, add_env_extension t env_extension
+      let env = Meet_env.create t in
+      let existing_ty = find t eqn_name (Some (Type_grammar.kind ty)) in
+      match Type_grammar.meet env ty existing_ty with
+      | Bottom ->
+        Type_grammar.bottom_like ty, t
+      | Ok (meet_result, env_extension) ->
+        let meet_ty = Meet_result.extract_value meet_result ty existing_ty in
+        meet_ty, add_env_extension t env_extension
     in
     Simple.pattern_match bare_lhs ~name ~const:(fun _ -> ty, t)
   in
@@ -1198,8 +1198,24 @@ let meet_equations_on_params t ~params ~param_types =
       let existing_type = find t name (Some kind) in
       let env = Meet_env.create t in
       match Type_grammar.meet env existing_type param_type with
-      | Bottom -> add_equation t name (Type_grammar.bottom kind)
-      | Ok (meet_ty, env_extension) ->
+      | Bottom ->
+        (* Ideally we should adapt the type of this function so
+           that the caller can handle this case.
+           In practice, this would likely mean treating the
+           corresponding continuation handler as unreachable. *)
+        Misc.fatal_errorf
+          "Bottom equation added on parameter:@.\
+           Parameter:@ %a@.\
+           Parameter type:@ %a@.\
+           Typing env:@ %a"
+          Kinded_parameter.print param
+          Type_grammar.print param_type
+          print t
+        (* add_equation t name (Type_grammar.bottom kind) *)
+      | Ok (meet_result, env_extension) ->
+        let meet_ty =
+          Meet_result.extract_value meet_result existing_type param_type
+        in
         let t = add_equation t name meet_ty in
         add_env_extension t env_extension)
     t

--- a/middle_end/flambda/types/env/typing_env.rec.ml
+++ b/middle_end/flambda/types/env/typing_env.rec.ml
@@ -1212,15 +1212,15 @@ let meet_equations_on_params t ~params ~param_types =
            that the caller can handle this case.
            In practice, this would likely mean treating the
            corresponding continuation handler as unreachable. *)
-        Misc.fatal_errorf
-          "Bottom equation added on parameter:@.\
-           Parameter:@ %a@.\
-           Parameter type:@ %a@.\
-           Typing env:@ %a"
-          Kinded_parameter.print param
-          Type_grammar.print param_type
-          print t
-        (* add_equation t name (Type_grammar.bottom kind) *)
+        (* Misc.fatal_errorf
+         *   "Bottom equation added on parameter:@.\
+         *    Parameter:@ %a@.\
+         *    Parameter type:@ %a@.\
+         *    Typing env:@ %a"
+         *   Kinded_parameter.print param
+         *   Type_grammar.print param_type
+         *   print t *)
+        add_equation t name (Type_grammar.bottom kind)
       | Ok (meet_result, env_extension) ->
         let meet_ty =
           Meet_result.extract_value meet_result existing_type param_type

--- a/middle_end/flambda/types/env/typing_env_extension.rec.ml
+++ b/middle_end/flambda/types/env/typing_env_extension.rec.ml
@@ -115,9 +115,18 @@ let rec meet0 env (t1 : t) (t2 : t) extra_extensions =
         | Some ty0 ->
           begin match Type_grammar.meet env ty0 ty with
           | Bottom -> raise Bottom_meet
-          | Ok (ty, new_ext) ->
-            Type_grammar.check_equation name ty;
-            Name.Map.add (*replace*) name ty eqs, new_ext :: extra_extensions
+          | Ok (res, new_ext) ->
+            let extra_extensions = new_ext :: extra_extensions in
+            begin match res with
+            | Left_input | Both_inputs ->
+              (* The equation is already there *)
+              eqs, extra_extensions
+            | Right_input ->
+              Name.Map.add (*replace*) name ty eqs, extra_extensions
+            | New_result ty ->
+              Type_grammar.check_equation name ty;
+              Name.Map.add (*replace*) name ty eqs, extra_extensions
+            end
           end)
       t2.equations
       (t1.equations, extra_extensions)

--- a/middle_end/flambda/types/env/typing_env_extension.rec.mli
+++ b/middle_end/flambda/types/env/typing_env_extension.rec.mli
@@ -45,6 +45,8 @@ val from_map : Type_grammar.t Name.Map.t -> t
 
 val add_or_replace_equation : t -> Name.t -> Type_grammar.t -> t
 
+(* Note: this doesn't use Meet_result.t, as the meet function here is used
+   to merge extensions together. *)
 val meet : Meet_env.t -> t -> t -> t Or_bottom.t
 
 val join : Join_env.t -> t -> t -> t

--- a/middle_end/flambda/types/flambda_type.mli
+++ b/middle_end/flambda/types/flambda_type.mli
@@ -215,7 +215,7 @@ module Typing_env : sig
   end
 end
 
-val meet : Typing_env.t -> t -> t -> (t * Typing_env_extension.t) Or_bottom.t
+val meet : Typing_env.t -> t -> t -> (t, Typing_env_extension.t) Meet_result.t
 
 val meet_shape
    : Typing_env.t

--- a/middle_end/flambda/types/structures/type_structure_intf.ml
+++ b/middle_end/flambda/types/structures/type_structure_intf.ml
@@ -31,7 +31,7 @@ module type S = sig
 
   (* CR mshinwell: Add [bottom] here?  Probably [is_bottom] too *)
 
-  val meet : meet_env -> t -> t -> (t * typing_env_extension) Or_bottom.t
+  val meet : meet_env -> t -> t -> (t, typing_env_extension) Meet_result.t
 
   (* Note that unlike the [join] function on regular types, for structures
      the return type is [t] (and not [t Or_unknown.t]).

--- a/middle_end/flambda/types/template/flambda_type.templ.ml
+++ b/middle_end/flambda/types/template/flambda_type.templ.ml
@@ -35,7 +35,7 @@ include Type_grammar
 
 type flambda_type = t
 
-let meet env t1 t2 : _ Or_bottom.t =
+let meet env t1 t2 : _ Meet_result.t =
   let meet_env = Meet_env.create env in
   meet meet_env t1 t2
 

--- a/middle_end/flambda/types/type_descr.rec.ml
+++ b/middle_end/flambda/types/type_descr.rec.ml
@@ -470,10 +470,12 @@ module Make (Head : Type_head_intf.S
         | None, (Ok _ | Unknown), _, _
         | _, _, None, (Ok _ | Unknown) -> Aliases.Alias_set.empty
         | Some simple1, _, _, Bottom ->
-          assert (Typing_env.mem_simple (Join_env.target_join_env join_env) simple1);
+          if (Typing_env.mem_simple (Join_env.target_join_env join_env) simple1) then ()
+          else Misc.fatal_errorf "Missing simple %a in join target env" Simple.print simple1;
           Aliases.Alias_set.singleton simple1
         | _, Bottom, Some simple2, _ ->
-          assert (Typing_env.mem_simple (Join_env.target_join_env join_env) simple2);
+          if (Typing_env.mem_simple (Join_env.target_join_env join_env) simple2) then ()
+          else Misc.fatal_errorf "Missing simple %a in join target env" Simple.print simple2;
           Aliases.Alias_set.singleton simple2
         | Some simple1, _, Some simple2, _ ->
           if Simple.same simple1 simple2

--- a/middle_end/flambda/types/type_descr_intf.ml
+++ b/middle_end/flambda/types/type_descr_intf.ml
@@ -90,11 +90,9 @@ module type S = sig
     -> to_type:(t -> flambda_type)
     -> meet_env
     -> Flambda_kind.t
-    -> flambda_type
-    -> flambda_type
     -> t
     -> t
-    -> (flambda_type * typing_env_extension) Or_bottom.t
+    -> (flambda_type, typing_env_extension) Meet_result.t
 
   val join
      : ?bound_name:Name.t

--- a/middle_end/flambda/types/type_grammar.rec.ml
+++ b/middle_end/flambda/types/type_grammar.rec.ml
@@ -486,7 +486,7 @@ let these_tagged_immediates0 ~no_alias imms : t =
     else
       Value (T_V.create_no_alias (Ok (Variant (Variant.create
         ~is_unique:false
-        ~immediates:(Known (these_naked_immediates imms))
+        ~immediates:(Known (these_naked_immediates0 ~no_alias imms))
         ~blocks:(Known (Row_like.For_blocks.create_bottom ()))))))
 
 let these_tagged_immediates imms =
@@ -926,32 +926,32 @@ let meet env t1 t2 =
   match t1, t2 with
   | Value ty1, Value ty2 ->
     T_V.meet env
-      K.value t1 t2 ty1 ty2
+      K.value ty1 ty2
       ~force_to_kind:force_to_kind_value
       ~to_type:(fun ty -> Value ty)
   | Naked_immediate ty1, Naked_immediate ty2 ->
     T_NI.meet env
-      K.naked_immediate t1 t2 ty1 ty2
+      K.naked_immediate ty1 ty2
       ~force_to_kind:force_to_kind_naked_immediate
       ~to_type:(fun ty -> Naked_immediate ty)
   | Naked_float ty1, Naked_float ty2 ->
     T_Nf.meet env
-      K.naked_float t1 t2 ty1 ty2
+      K.naked_float ty1 ty2
       ~force_to_kind:force_to_kind_naked_float
       ~to_type:(fun ty -> Naked_float ty)
   | Naked_int32 ty1, Naked_int32 ty2 ->
     T_N32.meet env
-      K.naked_int32 t1 t2 ty1 ty2
+      K.naked_int32 ty1 ty2
       ~force_to_kind:force_to_kind_naked_int32
       ~to_type:(fun ty -> Naked_int32 ty)
   | Naked_int64 ty1, Naked_int64 ty2 ->
     T_N64.meet env
-      K.naked_int64 t1 t2 ty1 ty2
+      K.naked_int64 ty1 ty2
       ~force_to_kind:force_to_kind_naked_int64
       ~to_type:(fun ty -> Naked_int64 ty)
   | Naked_nativeint ty1, Naked_nativeint ty2 ->
     T_NN.meet env
-      K.naked_nativeint t1 t2 ty1 ty2
+      K.naked_nativeint ty1 ty2
       ~force_to_kind:force_to_kind_naked_nativeint
       ~to_type:(fun ty -> Naked_nativeint ty)
   | Rec_info ty1, Rec_info ty2 ->

--- a/middle_end/flambda/types/type_grammar.rec.ml
+++ b/middle_end/flambda/types/type_grammar.rec.ml
@@ -956,7 +956,7 @@ let meet env t1 t2 =
       ~to_type:(fun ty -> Naked_nativeint ty)
   | Rec_info ty1, Rec_info ty2 ->
     T_RI.meet env
-      K.rec_info t1 t2 ty1 ty2
+      K.rec_info ty1 ty2
       ~force_to_kind:force_to_kind_rec_info
       ~to_type:(fun ty -> Rec_info ty)
   | (Value _ | Naked_immediate _ | Naked_float _ | Naked_int32 _

--- a/middle_end/flambda/types/type_grammar.rec.mli
+++ b/middle_end/flambda/types/type_grammar.rec.mli
@@ -212,7 +212,7 @@ val make_suitable_for_environment
 val expand_head : t -> Typing_env.t -> Resolved_type.t
 
 (** Greatest lower bound of two types. *)
-val meet : Meet_env.t -> t -> t -> (t * Typing_env_extension.t) Or_bottom.t
+val meet : Meet_env.t -> t -> t -> (t, Typing_env_extension.t) Meet_result.t
 
 (** Least upper bound of two types. *)
 val join

--- a/middle_end/flambda/types/type_head_intf.ml
+++ b/middle_end/flambda/types/type_head_intf.ml
@@ -35,7 +35,7 @@ module type S = sig
      : meet_env
     -> t
     -> t
-    -> (t * typing_env_extension) Or_bottom.t
+    -> (t, typing_env_extension) Meet_result.t
 
   val join
      : join_env

--- a/middle_end/flambda/types/type_of_kind/type_of_kind_naked_float0.rec.ml
+++ b/middle_end/flambda/types/type_of_kind/type_of_kind_naked_float0.rec.ml
@@ -38,10 +38,9 @@ let apply_coercion t coercion : _ Or_bottom.t =
 
 let eviscerate _ : _ Or_unknown.t = Unknown
 
-let meet _env t1 t2 : _ Or_bottom.t =
-  let t = Float.Set.inter t1 t2 in
-  if Float.Set.is_empty t then Bottom
-  else Ok (t, TEE.empty ())
+let meet _env t1 t2 =
+  Meet_result.set_meet ~no_extension:(TEE.empty ())
+    (module Float.Set) t1 t2
 
 let join _env t1 t2 : _ Or_unknown.t =
   Known (Float.Set.union t1 t2)

--- a/middle_end/flambda/types/type_of_kind/type_of_kind_naked_int32_0.rec.ml
+++ b/middle_end/flambda/types/type_of_kind/type_of_kind_naked_int32_0.rec.ml
@@ -38,10 +38,9 @@ let apply_coercion t coercion : _ Or_bottom.t =
 
 let eviscerate _ : _ Or_unknown.t = Unknown
 
-let meet _env t1 t2 : _ Or_bottom.t =
-  let t = Int32.Set.inter t1 t2 in
-  if Int32.Set.is_empty t then Bottom
-  else Ok (t, TEE.empty ())
+let meet _env t1 t2 =
+  Meet_result.set_meet ~no_extension:(TEE.empty ())
+    (module Int32.Set) t1 t2
 
 let join _env t1 t2 : _ Or_unknown.t =
   Known (Int32.Set.union t1 t2)

--- a/middle_end/flambda/types/type_of_kind/type_of_kind_naked_int64_0.rec.ml
+++ b/middle_end/flambda/types/type_of_kind/type_of_kind_naked_int64_0.rec.ml
@@ -38,10 +38,9 @@ let apply_coercion t coercion : _ Or_bottom.t =
 
 let eviscerate _ : _ Or_unknown.t = Unknown
 
-let meet _env t1 t2 : _ Or_bottom.t =
-  let t = Int64.Set.inter t1 t2 in
-  if Int64.Set.is_empty t then Bottom
-  else Ok (t, TEE.empty ())
+let meet _env t1 t2 =
+  Meet_result.set_meet ~no_extension:(TEE.empty ())
+    (module Int64.Set) t1 t2
 
 let join _env t1 t2 : _ Or_unknown.t =
   Known (Int64.Set.union t1 t2)

--- a/middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.ml
+++ b/middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.ml
@@ -37,10 +37,9 @@ let apply_coercion t coercion : _ Or_bottom.t =
 
 let eviscerate _ : _ Or_unknown.t = Unknown
 
-let meet _env t1 t2 : _ Or_bottom.t =
-  let t = Targetint.Set.inter t1 t2 in
-  if Targetint.Set.is_empty t then Bottom
-  else Ok (t, TEE.empty ())
+let meet _env t1 t2 =
+  Meet_result.set_meet ~no_extension:(TEE.empty ())
+    (module Targetint.Set) t1 t2
 
 let join _env t1 t2 : _ Or_unknown.t =
   Known (Targetint.Set.union t1 t2)

--- a/middle_end/flambda/types/type_of_kind/type_of_kind_rec_info0.rec.ml
+++ b/middle_end/flambda/types/type_of_kind/type_of_kind_rec_info0.rec.ml
@@ -34,12 +34,12 @@ let apply_coercion t coercion : _ Or_bottom.t =
 
 let eviscerate _ : _ Or_unknown.t = Unknown
 
-let meet _env t1 t2 : _ Or_bottom.t =
+let meet _env t1 t2 : _ Meet_result.t =
   (* CR lmaurer: This could be doing things like discovering two depth
      variables are equal *)
   if Rec_info_expr.equal t1 t2 then
-    Ok (t1, Typing_env_extension.empty ())
-  else Bottom
+    Ok (Both_inputs, Typing_env_extension.empty ())
+  else Bottom (* CR vlaviron: this looks obviously wrong *)
 
 let join _env t1 t2 : _ Or_unknown.t =
   if Rec_info_expr.equal t1 t2 then Known t1 else Unknown

--- a/middle_end/flambda/types/type_of_kind/type_of_kind_value0.rec.ml
+++ b/middle_end/flambda/types/type_of_kind/type_of_kind_value0.rec.ml
@@ -189,26 +189,30 @@ let eviscerate t : _ Or_unknown.t =
 
 let meet_unknown meet_contents ~contents_is_bottom env
     (or_unknown1 : _ Or_unknown.t) (or_unknown2 : _ Or_unknown.t)
-    : ((_ Or_unknown.t) * TEE.t) Or_bottom.t =
+    : (_ Or_unknown.t, TEE.t) Meet_result.t =
   match or_unknown1, or_unknown2 with
-  | Unknown, Unknown -> Ok (Unknown, TEE.empty ())
+  | Unknown, Unknown -> Ok (Both_inputs, TEE.empty ())
   (* CR mshinwell: Think about the next two cases more *)
-  | Known contents, _ when contents_is_bottom contents -> Bottom
-  | _, Known contents when contents_is_bottom contents -> Bottom
-  | _, Unknown -> Ok (or_unknown1, TEE.empty ())
-  | Unknown, _ -> Ok (or_unknown2, TEE.empty ())
+  (* vlaviron: When at least one of the inputs is bottom we
+     will return a bottom value, but we can choose whether we want to
+     return the Bottom constructor directly or merely which inputs
+     are bottom. I chose the second version, because it allows the
+     meet_variant function to correctly propagate which input is
+     unchanged without calling is_bottom again. *)
+  | Known contents, _ when contents_is_bottom contents ->
+    begin match or_unknown2 with
+    | Known contents when contents_is_bottom contents ->
+      Ok (Both_inputs, TEE.empty ())
+    | _ ->
+      Ok (Left_input, TEE.empty ())
+    end
+  | _, Known contents when contents_is_bottom contents ->
+    Ok (Right_input, TEE.empty ())
+  | _, Unknown -> Ok (Left_input, TEE.empty ())
+  | Unknown, _ -> Ok (Right_input, TEE.empty ())
   | Known contents1, Known contents2 ->
-    let result =
-      Or_bottom.map (meet_contents env contents1 contents2)
-        ~f:(fun (contents, env_extension) ->
-          Or_unknown.Known contents, env_extension)
-    in
-    match result with
-    | Bottom | Ok (Unknown, _) -> result
-    | Ok (Known contents, _env_extension) ->
-      (* XXX Why isn't [meet_contents] returning bottom? *)
-      if contents_is_bottom contents then Bottom
-      else result
+    Meet_result.map_result (meet_contents env contents1 contents2)
+      ~f:(fun contents -> Or_unknown.Known contents)
 
 let join_unknown join_contents (env : Join_env.t)
     (or_unknown1 : _ Or_unknown.t) (or_unknown2 : _ Or_unknown.t)
@@ -220,96 +224,123 @@ let join_unknown join_contents (env : Join_env.t)
     join_contents env contents1 contents2
 
 let meet_variant env
-      ~blocks1 ~imms1 ~blocks2 ~imms2 : _ Or_bottom.t =
+      ~blocks1 ~imms1 ~blocks2 ~imms2 : _ Meet_result.t =
+  let blocks_is_bottom blocks =
+    match (blocks : _ Or_unknown.t) with
+    | Unknown -> false
+    | Known blocks -> Blocks.is_bottom blocks
+  in
+  let immediates_is_bottom immediates =
+    match (immediates : _ Or_unknown.t) with
+    | Unknown -> false
+    | Known imms -> T.is_obviously_bottom imms
+  in
   let blocks =
     meet_unknown Blocks.meet ~contents_is_bottom:Blocks.is_bottom
       env blocks1 blocks2
-  in
-  let blocks : _ Or_bottom.t =
-    (* XXX Clean this up *)
-    match blocks with
-    | Bottom | Ok (Or_unknown.Unknown, _) -> blocks
-    | Ok (Or_unknown.Known blocks', _) ->
-      if Blocks.is_bottom blocks' then Bottom else blocks
   in
   let imms =
     meet_unknown T.meet ~contents_is_bottom:T.is_obviously_bottom
       env imms1 imms2
   in
-  let imms : _ Or_bottom.t =
-    match imms with
-    | Bottom | Ok (Or_unknown.Unknown, _) -> imms
-    | Ok (Or_unknown.Known imms', _) ->
-      if T.is_obviously_bottom imms' then Bottom else imms
-  in
   match blocks, imms with
+  (* CR vlaviron: Note on the Bottom cases:
+     We're only expecting the underlying meets to return Bottom if
+     neither input was already Bottom (otherwise, we would have gotten
+     one of Both_inputs, Left_input or Right_input).
+     Since we want to return Bottom rather than New_result in the case
+     where the returned type is bottom, we check for bottom results
+     in the cases where it can occur.
+  *)
   | Bottom, Bottom -> Bottom
   | Ok (blocks, env_extension), Bottom ->
     let immediates : _ Or_unknown.t = Known (T.bottom K.naked_immediate) in
-    Ok (blocks, immediates, env_extension)
+    let blocks = Meet_result.extract_value blocks blocks1 blocks2 in
+    if blocks_is_bottom blocks then
+      Bottom
+    else
+      Ok (New_result (blocks, immediates), env_extension)
   | Bottom, Ok (immediates, env_extension) ->
     let blocks : _ Or_unknown.t = Known (Blocks.create_bottom ()) in
-    Ok (blocks, immediates, env_extension)
-  | Ok (blocks, env_extension1), Ok (immediates, env_extension2) ->
-    begin match (blocks : _ Or_unknown.t) with
-    | Unknown -> ()
-    | Known blocks -> assert (not (Blocks.is_bottom blocks));
-    end;
-    begin match (immediates : _ Or_unknown.t) with
-    | Unknown -> ()
-    | Known imms -> assert (not (T.is_obviously_bottom imms));
-    end;
+    let immediates = Meet_result.extract_value immediates imms1 imms2 in
+    if immediates_is_bottom immediates then
+      Bottom
+    else
+      Ok (New_result (blocks, immediates), env_extension)
+  | Ok (blocks_res, env_extension1), Ok (immediates_res, env_extension2) ->
+    let blocks = Meet_result.extract_value blocks_res blocks1 blocks2 in
+    let immediates = Meet_result.extract_value immediates_res imms1 imms2 in
+    let bottom_blocks = blocks_is_bottom blocks in
+    let bottom_immediates = immediates_is_bottom immediates in
     let env_extension =
-      let env = Meet_env.env env in
-      let join_env =
-        Join_env.create env ~left_env:env ~right_env:env
-      in
-      TEE.join join_env env_extension1 env_extension2
+      if bottom_immediates then env_extension1
+      else if bottom_blocks then env_extension2
+      else
+        let env = Meet_env.env env in
+        let join_env =
+          Join_env.create env ~left_env:env ~right_env:env
+        in
+        TEE.join join_env env_extension1 env_extension2
     in
-    Ok (blocks, immediates, env_extension)
+    begin match blocks_res, immediates_res with
+    | Both_inputs, Both_inputs ->
+      Ok (Both_inputs, env_extension)
+    | (Left_input | Both_inputs), (Left_input | Both_inputs) ->
+      Ok (Left_input, env_extension)
+    | (Right_input | Both_inputs), (Right_input | Both_inputs) ->
+      Ok (Right_input, env_extension)
+    | Left_input, Right_input
+    | Right_input, Left_input
+    | New_result _, _
+    | _, New_result _ ->
+      if bottom_blocks && bottom_immediates then
+        Bottom
+      else
+        Ok (New_result (blocks, immediates), env_extension)
+    end
 
-let meet env t1 t2 : _ Or_bottom.t =
+let meet env t1 t2 : _ Meet_result.t =
   match t1, t2 with
   | Variant { blocks = blocks1; immediates = imms1; is_unique = is_unique1; },
     Variant { blocks = blocks2; immediates = imms2; is_unique = is_unique2; } ->
-    Or_bottom.map
+    Meet_result.map_result
       (meet_variant env ~blocks1 ~imms1 ~blocks2 ~imms2)
-      ~f:(fun (blocks, immediates, env_extension) ->
+      ~f:(fun (blocks, immediates) ->
         (* Uniqueness tracks whether duplication/lifting is allowed.
            It must always be propagated, both for meet and join. *)
         let is_unique = is_unique1 || is_unique2 in
-        Variant (Variant.create ~is_unique ~blocks ~immediates), env_extension)
+        Variant (Variant.create ~is_unique ~blocks ~immediates))
   | Boxed_float n1, Boxed_float n2 ->
-    Or_bottom.map
+    Meet_result.map_result
       (T.meet env n1 n2)
-      ~f:(fun (n, env_extension) -> Boxed_float n, env_extension)
+      ~f:(fun n -> Boxed_float n)
   | Boxed_int32 n1, Boxed_int32 n2 ->
-    Or_bottom.map
+    Meet_result.map_result
       (T.meet env n1 n2)
-      ~f:(fun (n, env_extension) -> Boxed_int32 n, env_extension)
+      ~f:(fun n -> Boxed_int32 n)
   | Boxed_int64 n1, Boxed_int64 n2 ->
-    Or_bottom.map
+    Meet_result.map_result
       (T.meet env n1 n2)
-      ~f:(fun (n, env_extension) -> Boxed_int64 n, env_extension)
+      ~f:(fun n -> Boxed_int64 n)
   | Boxed_nativeint n1, Boxed_nativeint n2 ->
-    Or_bottom.map
+    Meet_result.map_result
       (T.meet env n1 n2)
-      ~f:(fun (n, env_extension) -> Boxed_nativeint n, env_extension)
+      ~f:(fun n -> Boxed_nativeint n)
   | Closures { by_closure_id = by_closure_id1; },
     Closures { by_closure_id = by_closure_id2; } ->
     let module C = Row_like.For_closures_entry_by_set_of_closures_contents in
-    Or_bottom.map
+    Meet_result.map_result
       (C.meet env by_closure_id1 by_closure_id2)
-      ~f:(fun (by_closure_id, env_extension) ->
-        Closures { by_closure_id; }, env_extension)
+      ~f:(fun by_closure_id -> Closures { by_closure_id; })
   | String strs1, String strs2 ->
-    let strs = String_info.Set.inter strs1 strs2 in
-    if String_info.Set.is_empty strs then Bottom
-    else Or_bottom.Ok (String strs, TEE.empty ())
+    Meet_result.map_result
+      (Meet_result.set_meet ~no_extension:(TEE.empty ())
+         (module String_info.Set) strs1 strs2)
+      ~f:(fun strs -> String strs)
   | Array { length = length1; }, Array { length = length2; } ->
-    Or_bottom.map
+    Meet_result.map_result
       (T.meet env length1 length2)
-      ~f:(fun (length, env_extension) -> Array { length; }, env_extension)
+      ~f:(fun length -> Array { length; })
   | (Variant _
     | Boxed_float _
     | Boxed_int32 _


### PR DESCRIPTION
The goal of this PR is to prevent meet functions from generating spurious extensions, in particular extensions that merely add again the type that is already present.
To do this, I introduce the module `Meet_result`, whose main type is defined as follows:
```ocaml
type 'a return_value =
  | Left_input
  | Right_input
  | Both_inputs
  | New_result of 'a

type ('a, 'ext) t =
  | Bottom
  | Ok of 'a return_value * 'ext
```

Most `meet` functions are patched to return `(t, Typing_env_extension.t) Meet_result.t` instead of `(t * Typing_env_extension.t) Or_bottom.t`.
Note that in many cases several results are correct. For instance, if both inputs are `Bottom`, then any return value is sound, and purely in terms of approximation all of them except `New_result x`, with `x` non-bottom, are a best approximation.
However, correct detection of spurious extensions require that the following rules are followed:
- If both inputs are equivalent and any of them can be used as the result, then `Both_inputs` must be returned
- If the result is equivalent to one of the inputs, and the input could have been returned as the result, then the corresponding constructor (`Left_input` or `Right_input`) must be used
- Otherwise, if the result is obviously bottom then `Bottom` should be returned, if not then `New_result`.

This PR also contains two adjacent changes:
- Adding equations that are obviously bottom to a typing environment will generate a compile error. This is probably not going to stay in the final version (either the errors will be removed or a proper `Or_bottom` type will be used instead).
- Some `Typing_env` functions have changed to stricter semantics. In particular, `add_equation` will always meet the new equation with the existing env, so it is not suitable for replacing existing equations. `Typing_env_level.join` has been patched to not rely on this anymore (the previous implementation was likely buggy anyway, as `add_equation` would end up doing a meet in some cases anyway). This patch could be extracted and submitted independently with a bit of work.

It also contains a few small fixes for bugs that only showed up with this patch (commits c0dfa82 and 52f85a6). I haven't investigated why they were harmless before the patch, but the fix seems clearly better in both cases.

I've managed to compile Coq with the version of this PR at the time of submission.