### PR TITLE
Renamed [Code_size] to [Cost_metrics]

### DIFF
--- a/.depend
+++ b/.depend
@@ -3781,11 +3781,13 @@ middle_end/flambda/flambda_middle_end.cmo : \
     middle_end/flambda/parser/flambda_to_fexpr.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/cmx/flambda_cmx_format.cmi \
+    middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/parser/fexpr.cmo \
     middle_end/flambda/cmx/exported_code.cmi \
     middle_end/flambda/from_lambda/eliminate_mutable_vars.cmi \
     middle_end/flambda/from_lambda/cps_conversion.cmi \
     middle_end/flambda/basic/continuation.cmi \
+    middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/from_lambda/closure_conversion.cmi \
     utils/clflags.cmi \
     middle_end/flambda/flambda_middle_end.cmi
@@ -3802,11 +3804,13 @@ middle_end/flambda/flambda_middle_end.cmx : \
     middle_end/flambda/parser/flambda_to_fexpr.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/cmx/flambda_cmx_format.cmx \
+    middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/parser/fexpr.cmx \
     middle_end/flambda/cmx/exported_code.cmx \
     middle_end/flambda/from_lambda/eliminate_mutable_vars.cmx \
     middle_end/flambda/from_lambda/cps_conversion.cmx \
     middle_end/flambda/basic/continuation.cmx \
+    middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/from_lambda/closure_conversion.cmx \
     utils/clflags.cmx \
     middle_end/flambda/flambda_middle_end.cmi
@@ -4066,11 +4070,13 @@ middle_end/flambda/flambda_middle_end.cmo : \
     middle_end/flambda/parser/flambda_to_fexpr.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/cmx/flambda_cmx_format.cmi \
+    middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/parser/fexpr.cmo \
     middle_end/flambda/cmx/exported_code.cmi \
     middle_end/flambda/from_lambda/eliminate_mutable_vars.cmi \
     middle_end/flambda/from_lambda/cps_conversion.cmi \
     middle_end/flambda/basic/continuation.cmi \
+    middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/from_lambda/closure_conversion.cmi \
     utils/clflags.cmi \
     middle_end/flambda/flambda_middle_end.cmi
@@ -4087,11 +4093,13 @@ middle_end/flambda/flambda_middle_end.cmx : \
     middle_end/flambda/parser/flambda_to_fexpr.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/cmx/flambda_cmx_format.cmx \
+    middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/parser/fexpr.cmx \
     middle_end/flambda/cmx/exported_code.cmx \
     middle_end/flambda/from_lambda/eliminate_mutable_vars.cmx \
     middle_end/flambda/from_lambda/cps_conversion.cmx \
     middle_end/flambda/basic/continuation.cmx \
+    middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/from_lambda/closure_conversion.cmx \
     utils/clflags.cmx \
     middle_end/flambda/flambda_middle_end.cmi
@@ -5226,6 +5234,7 @@ middle_end/flambda/inlining/inlining_report.cmo : \
     utils/misc.cmi \
     middle_end/flambda/inlining/inlining_decision.cmi \
     lambda/debuginfo.cmi \
+    middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/basic/code_id.cmi \
     utils/clflags.cmi \
     middle_end/flambda/inlining/inlining_report.cmi
@@ -5233,6 +5242,7 @@ middle_end/flambda/inlining/inlining_report.cmx : \
     utils/misc.cmx \
     middle_end/flambda/inlining/inlining_decision.cmx \
     lambda/debuginfo.cmx \
+    middle_end/flambda/compilenv_deps/compilation_unit.cmx \
     middle_end/flambda/basic/code_id.cmx \
     utils/clflags.cmx \
     middle_end/flambda/inlining/inlining_report.cmi
@@ -7649,42 +7659,6 @@ middle_end/flambda/terms/code.rec.cmi : \
     middle_end/flambda/types/kinds/flambda_arity.cmi \
     middle_end/flambda/naming/contains_names.cmo \
     middle_end/flambda/basic/code_id.cmi
-middle_end/flambda/terms/code_size.rec.cmo : \
-    utils/targetint.cmi \
-    lambda/switch.cmi \
-    middle_end/flambda/basic/simple.cmi \
-    middle_end/flambda/terms/set_of_closures.cmi \
-    middle_end/flambda/types/basic/or_unknown.cmi \
-    utils/misc.cmi \
-    middle_end/flambda/terms/function_declarations.cmi \
-    middle_end/flambda/terms/function_declaration.cmi \
-    middle_end/flambda/terms/flambda_primitive.cmi \
-    middle_end/flambda/types/kinds/flambda_kind.cmi \
-    middle_end/flambda/basic/continuation.cmi \
-    middle_end/flambda/basic/code_id.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    middle_end/flambda/terms/code_size.rec.cmi
-middle_end/flambda/terms/code_size.rec.cmx : \
-    utils/targetint.cmx \
-    lambda/switch.cmx \
-    middle_end/flambda/basic/simple.cmx \
-    middle_end/flambda/terms/set_of_closures.cmx \
-    middle_end/flambda/types/basic/or_unknown.cmx \
-    utils/misc.cmx \
-    middle_end/flambda/terms/function_declarations.cmx \
-    middle_end/flambda/terms/function_declaration.cmx \
-    middle_end/flambda/terms/flambda_primitive.cmx \
-    middle_end/flambda/types/kinds/flambda_kind.cmx \
-    middle_end/flambda/basic/continuation.cmx \
-    middle_end/flambda/basic/code_id.cmx \
-    middle_end/flambda/basic/closure_id.cmx \
-    middle_end/flambda/terms/code_size.rec.cmi
-middle_end/flambda/terms/code_size.rec.cmi : \
-    middle_end/flambda/basic/simple.cmi \
-    middle_end/flambda/terms/set_of_closures.cmi \
-    middle_end/flambda/types/basic/or_unknown.cmi \
-    middle_end/flambda/terms/flambda_primitive.cmi \
-    middle_end/flambda/basic/code_id.cmi
 middle_end/flambda/terms/continuation_handler.rec.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/simple.cmi \
@@ -7749,6 +7723,47 @@ middle_end/flambda/terms/continuation_handlers.rec.cmi : \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/naming/contains_names.cmo \
     middle_end/flambda/cmx/contains_ids.cmo
+middle_end/flambda/terms/cost_metrics.rec.cmo : \
+    utils/targetint.cmi \
+    lambda/switch.cmi \
+    middle_end/flambda/basic/simple.cmi \
+    middle_end/flambda/terms/set_of_closures.cmi \
+    middle_end/flambda/types/basic/or_unknown.cmi \
+    middle_end/flambda/naming/name_mode.cmi \
+    utils/misc.cmi \
+    middle_end/flambda/terms/function_declarations.cmi \
+    middle_end/flambda/terms/function_declaration.cmi \
+    middle_end/flambda/terms/flambda_primitive.cmi \
+    middle_end/flambda/types/kinds/flambda_kind.cmi \
+    middle_end/flambda/basic/continuation.cmi \
+    middle_end/flambda/basic/code_id.cmi \
+    middle_end/flambda/basic/closure_id.cmi \
+    middle_end/flambda/naming/bindable_let_bound.cmi \
+    middle_end/flambda/terms/cost_metrics.rec.cmi
+middle_end/flambda/terms/cost_metrics.rec.cmx : \
+    utils/targetint.cmx \
+    lambda/switch.cmx \
+    middle_end/flambda/basic/simple.cmx \
+    middle_end/flambda/terms/set_of_closures.cmx \
+    middle_end/flambda/types/basic/or_unknown.cmx \
+    middle_end/flambda/naming/name_mode.cmx \
+    utils/misc.cmx \
+    middle_end/flambda/terms/function_declarations.cmx \
+    middle_end/flambda/terms/function_declaration.cmx \
+    middle_end/flambda/terms/flambda_primitive.cmx \
+    middle_end/flambda/types/kinds/flambda_kind.cmx \
+    middle_end/flambda/basic/continuation.cmx \
+    middle_end/flambda/basic/code_id.cmx \
+    middle_end/flambda/basic/closure_id.cmx \
+    middle_end/flambda/naming/bindable_let_bound.cmx \
+    middle_end/flambda/terms/cost_metrics.rec.cmi
+middle_end/flambda/terms/cost_metrics.rec.cmi : \
+    lambda/switch.cmi \
+    middle_end/flambda/basic/simple.cmi \
+    middle_end/flambda/terms/set_of_closures.cmi \
+    middle_end/flambda/types/basic/or_unknown.cmi \
+    middle_end/flambda/terms/flambda_primitive.cmi \
+    middle_end/flambda/basic/code_id.cmi
 middle_end/flambda/terms/expr.rec.cmo : \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
     middle_end/flambda/compilenv_deps/target_imm.cmi \

--- a/middle_end/flambda/compare/compare.ml
+++ b/middle_end/flambda/compare/compare.ml
@@ -392,7 +392,9 @@ and subst_code env (code : Code.t)
     Option.map (subst_code_id env) (Code.newer_version_of code)
   in
   code
-  |> Code.with_params_and_body ~size:(Code.size code) params_and_body
+  |> Code.with_params_and_body
+       ~cost_metrics:(Code.cost_metrics code)
+       params_and_body
   |> Code.with_newer_version_of newer_version_of
 and subst_params_and_body env params_and_body =
   Function_params_and_body.pattern_match params_and_body
@@ -1223,7 +1225,8 @@ and codes env (code1 : Code.t) (code2 : Code.t) =
       in
       code1
       |> Code.with_code_id (Code.code_id code2)
-      |> Code.with_params_and_body ~size:(Code.size code2) params_and_body
+      |> Code.with_params_and_body
+           ~cost_metrics:(Code.cost_metrics code2) params_and_body
       |> Code.with_newer_version_of newer_version_of)
   |> Comparison.add_condition
       ~approximant:(fun () -> subst_code env code1)

--- a/middle_end/flambda/flambda_middle_end.ml
+++ b/middle_end/flambda/flambda_middle_end.ml
@@ -172,8 +172,8 @@ let middle_end ~ppf_dump:ppf ~prefixname ~backend ~filename ~module_ident
     | exception Not_found -> ()
     | _ ->
       Exported_code.iter simplify_result.all_code (fun id code ->
-        match Flambda.Code.size code with
-        | Known size -> Format.fprintf Format.std_formatter "%a %a\n" Code_id.print id Flambda.Code_size.print size
+        match Flambda.Code.cost_metrics code with
+        | Known size -> Format.fprintf Format.std_formatter "%a %a\n" Code_id.print id Flambda.Cost_metrics.print size
         | _ -> assert false);
     end;
     { cmx = simplify_result.cmx;

--- a/middle_end/flambda/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion.ml
@@ -883,7 +883,7 @@ and close_one_function t ~external_env ~by_closure_id decl
       ~is_a_functor:(Function_decl.is_a_functor decl)
       ~recursive
       ~newer_version_of:None
-      ~size:Unknown
+      ~cost_metrics:Unknown
   in
   t.code <- (code_id, code) :: t.code;
   Closure_id.Map.add my_closure_id fun_decl by_closure_id

--- a/middle_end/flambda/inlining/inlining_cost.ml
+++ b/middle_end/flambda/inlining/inlining_cost.ml
@@ -21,9 +21,9 @@ open! Flambda.Import
 (* Simple approximation of the space cost of an Flambda expression. *)
 
 let smaller' denv expr ~than:threshold =
-  let s = Code_size.expr_size ~find_code:(Downwards_env.find_code denv) expr in
-  if Code_size.smaller_than_threshold s ~threshold then
-    Some (Code_size.to_int s)
+  let s = Cost_metrics.expr_size ~find_code:(Downwards_env.find_code denv) expr in
+  if Cost_metrics.smaller_than_threshold s ~threshold then
+    Some (Cost_metrics.to_int s)
   else None
 
 let size denv expr =
@@ -134,8 +134,8 @@ module Benefit = struct
   let direct_call_of_indirect_unknown_arity t =
     { t with direct_call_of_indirect = t.direct_call_of_indirect + 1; }
 
-  let requested_inline denv t ~size_of =
-    let size = size denv size_of in
+  let requested_inline denv t ~cost_metrics_of =
+    let size = size denv cost_metrics_of in
     { t with requested_inline = t.requested_inline + size; }
 
   let print ppf b =

--- a/middle_end/flambda/inlining/inlining_cost.mli
+++ b/middle_end/flambda/inlining/inlining_cost.mli
@@ -84,7 +84,7 @@ module Benefit : sig
   val requested_inline
      : Downwards_env.t
     -> t
-    -> size_of:Expr.t
+    -> cost_metrics_of:Expr.t
     -> t
 
   val print : Format.formatter -> t -> unit

--- a/middle_end/flambda/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda/parser/fexpr_to_flambda.ml
@@ -674,7 +674,7 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
             ~inline
             ~is_a_functor:false
             ~recursive
-            ~size:Unknown
+            ~cost_metrics:Unknown
         in
         Code code
     in

--- a/middle_end/flambda/simplify/basic/apply_cont_rewrite.ml
+++ b/middle_end/flambda/simplify/basic/apply_cont_rewrite.ml
@@ -109,8 +109,8 @@ let extra_args t id =
 type rewrite_use_result =
   | Apply_cont of Apply_cont.t
   | Expr of (
-       apply_cont_to_expr:(Apply_cont.t -> (Expr.t * Code_size.t * Name_occurrences.t))
-    -> Expr.t * Code_size.t * Name_occurrences.t)
+       apply_cont_to_expr:(Apply_cont.t -> (Expr.t * Cost_metrics.t * Name_occurrences.t))
+    -> Expr.t * Cost_metrics.t * Name_occurrences.t)
 
 let no_rewrite apply_cont = Apply_cont apply_cont
 
@@ -141,7 +141,7 @@ let rewrite_use t id apply_cont : rewrite_use_result =
           let extra_args_rev = Simple.var temp :: extra_args_rev in
           let extra_lets =
             (Var_in_binding_pos.create temp Name_mode.normal,
-             Code_size.prim prim,
+             Cost_metrics.prim prim,
              Named.create_prim prim Debuginfo.none)
               :: extra_lets
           in
@@ -157,8 +157,8 @@ let rewrite_use t id apply_cont : rewrite_use_result =
   | [] -> Apply_cont apply_cont
   | _::_ ->
     let build_expr ~apply_cont_to_expr =
-      let body, size_of_body, free_names_of_body = apply_cont_to_expr apply_cont in
-      Expr.bind_no_simplification ~bindings:extra_lets ~body ~size_of_body ~free_names_of_body
+      let body, cost_metrics_of_body, free_names_of_body = apply_cont_to_expr apply_cont in
+      Expr.bind_no_simplification ~bindings:extra_lets ~body ~cost_metrics_of_body ~free_names_of_body
     in
     Expr build_expr
 

--- a/middle_end/flambda/simplify/basic/apply_cont_rewrite.mli
+++ b/middle_end/flambda/simplify/basic/apply_cont_rewrite.mli
@@ -45,8 +45,8 @@ val extra_args
 type rewrite_use_result = private
   | Apply_cont of Apply_cont.t
   | Expr of (
-       apply_cont_to_expr:(Apply_cont.t -> (Expr.t * Code_size.t * Name_occurrences.t))
-    -> Expr.t * Code_size.t * Name_occurrences.t)
+       apply_cont_to_expr:(Apply_cont.t -> (Expr.t * Cost_metrics.t * Name_occurrences.t))
+    -> Expr.t * Cost_metrics.t * Name_occurrences.t)
 
 val no_rewrite : Apply_cont.t -> rewrite_use_result
 

--- a/middle_end/flambda/simplify/basic/continuation_in_env.ml
+++ b/middle_end/flambda/simplify/basic/continuation_in_env.ml
@@ -22,7 +22,7 @@ type t =
       params : Kinded_parameter.t list;
       handler : Flambda.Expr.t;
       free_names_of_handler : Name_occurrences.t;
-      size_of_handler : Flambda.Code_size.t;
+      cost_metrics_of_handler : Flambda.Cost_metrics.t;
     }
   | Other of {
       arity : Flambda_arity.With_subkinds.t;
@@ -34,7 +34,7 @@ type t =
 let print ppf t =
   match t with
   | Linearly_used_and_inlinable { arity = _; params = _; handler = _;
-      free_names_of_handler = _; size_of_handler = _ } ->
+      free_names_of_handler = _; cost_metrics_of_handler = _ } ->
     Format.pp_print_string ppf "Linearly_used_and_inlinable _"
   | Other { arity = _; handler = _; } ->
     Format.pp_print_string ppf "Other"
@@ -43,7 +43,7 @@ let print ppf t =
 let arity t =
   match t with
   | Linearly_used_and_inlinable { arity; params = _; handler = _;
-      free_names_of_handler = _; size_of_handler = _ }
+      free_names_of_handler = _; cost_metrics_of_handler = _ }
   | Other { arity; handler = _; }
   | Unreachable { arity; } ->
     arity

--- a/middle_end/flambda/simplify/basic/continuation_in_env.mli
+++ b/middle_end/flambda/simplify/basic/continuation_in_env.mli
@@ -27,8 +27,8 @@ type t =
       (** [free_names_of_handler] includes entries for any occurrences of the
           [params] in the [handler]. *)
       free_names_of_handler : Name_occurrences.t;
-      (** [size_of_handler] is the size of the handler. *)
-      size_of_handler : Flambda.Code_size.t;
+      (** [cost_metrics_of_handler] is the size of the handler. *)
+      cost_metrics_of_handler : Flambda.Cost_metrics.t;
     }
   | Other of {
       arity : Flambda_arity.With_subkinds.t;

--- a/middle_end/flambda/simplify/basic/simplified_named.ml
+++ b/middle_end/flambda/simplify/basic/simplified_named.ml
@@ -31,16 +31,16 @@ let to_named = function
 type t =
   | Reachable of {
       named : simplified_named;
-      size: Code_size.t;
+      cost_metrics: Cost_metrics.t;
       free_names : Name_occurrences.t;
     }
   | Invalid of Invalid_term_semantics.t
 
 let reachable (named : Named.t) =
-  let (simplified_named : simplified_named), size =
+  let (simplified_named : simplified_named), cost_metrics =
     match named with
-    | Simple simple -> Simple simple, Code_size.simple simple
-    | Prim (prim, dbg) -> Prim (prim, dbg), Code_size.prim prim
+    | Simple simple -> Simple simple, Cost_metrics.simple simple
+    | Prim (prim, dbg) -> Prim (prim, dbg), Cost_metrics.prim prim
     | Set_of_closures _ ->
       Misc.fatal_errorf "Cannot use [Simplified_named.reachable] on \
           [Set_of_closures];@ use [reachable_with_known_free_names] \
@@ -53,17 +53,17 @@ let reachable (named : Named.t) =
   in
   Reachable {
     named = simplified_named;
-    size;
+    cost_metrics;
     free_names = Named.free_names named;
   }
 
-let reachable_with_known_free_names ~find_code_size (named : Named.t) ~free_names =
-  let (simplified_named : simplified_named), size =
+let reachable_with_known_free_names ~find_cost_metrics (named : Named.t) ~free_names =
+  let (simplified_named : simplified_named), cost_metrics =
     match named with
-    | Simple simple -> Simple simple, Code_size.simple simple
-    | Prim (prim, dbg) -> Prim (prim, dbg), Code_size.prim prim
+    | Simple simple -> Simple simple, Cost_metrics.simple simple
+    | Prim (prim, dbg) -> Prim (prim, dbg), Cost_metrics.prim prim
     | Set_of_closures set ->
-      Set_of_closures set, Code_size.set_of_closures ~find_code_size set
+      Set_of_closures set, Cost_metrics.set_of_closures ~find_cost_metrics set
     | Static_consts _ ->
       Misc.fatal_errorf "Cannot create [Simplified_named] from \
           [Static_consts];@ use the lifted constant infrastructure instead:@ %a"
@@ -71,7 +71,7 @@ let reachable_with_known_free_names ~find_code_size (named : Named.t) ~free_name
   in
   Reachable {
     named = simplified_named;
-    size;
+    cost_metrics;
     free_names;
   }
 

--- a/middle_end/flambda/simplify/basic/simplified_named.mli
+++ b/middle_end/flambda/simplify/basic/simplified_named.mli
@@ -30,7 +30,7 @@ val to_named : simplified_named -> Named.t
 type t = private
   | Reachable of {
       named : simplified_named;
-      size: Code_size.t;
+      cost_metrics: Cost_metrics.t;
       free_names : Name_occurrences.t;
     }
   | Invalid of Invalid_term_semantics.t
@@ -43,7 +43,7 @@ val reachable : Named.t -> t
 
 (** It is an error to pass [Static_consts] to this function. *)
 val reachable_with_known_free_names
-  : find_code_size:(Code_id.t -> Code_size.t Or_unknown.t)
+  : find_cost_metrics:(Code_id.t -> Cost_metrics.t Or_unknown.t)
   -> Named.t
   -> free_names:Name_occurrences.t
   -> t

--- a/middle_end/flambda/simplify/env/upwards_acc.ml
+++ b/middle_end/flambda/simplify/env/upwards_acc.ml
@@ -32,13 +32,13 @@ type t = {
   name_occurrences : Name_occurrences.t;
   used_closure_vars : Name_occurrences.t;
   shareable_constants : Symbol.t Static_const.Map.t;
-  size: Flambda.Code_size.t;
+  cost_metrics: Flambda.Cost_metrics.t;
 }
 
 let print ppf
       { uenv; creation_dacc = _; code_age_relation; lifted_constants;
         name_occurrences; used_closure_vars; all_code = _;
-        shareable_constants; size } =
+        shareable_constants; cost_metrics } =
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(uenv@ %a)@]@ \
       @[<hov 1>(code_age_relation@ %a)@]@ \
@@ -46,7 +46,7 @@ let print ppf
       @[<hov 1>(name_occurrences@ %a)@]@ \
       @[<hov 1>(used_closure_vars@ %a)@]@ \
       @[<hov 1>(shareable_constants@ %a)@]\
-      @[<hov 1>(size %a)@]\
+      @[<hov 1>(cost_metrics %a)@]\
       )@]"
     UE.print uenv
     Code_age_relation.print code_age_relation
@@ -54,7 +54,7 @@ let print ppf
     Name_occurrences.print name_occurrences
     Name_occurrences.print used_closure_vars
     (Static_const.Map.print Symbol.print) shareable_constants
-    Flambda.Code_size.print size
+    Flambda.Cost_metrics.print cost_metrics
 
 let create uenv dacc =
   { uenv;
@@ -69,14 +69,14 @@ let create uenv dacc =
        dealing with a [Let_cont]). *)
     used_closure_vars = DA.used_closure_vars dacc;
     shareable_constants = DA.shareable_constants dacc;
-    size = Flambda.Code_size.zero;
+    cost_metrics = Flambda.Cost_metrics.zero;
   }
 
 let creation_dacc t = t.creation_dacc
 let uenv t = t.uenv
 let code_age_relation t = t.code_age_relation
 let lifted_constants t = t.lifted_constants
-let size t = t.size
+let cost_metrics t = t.cost_metrics
 
 (* Don't add empty LCS to the list *)
 
@@ -133,10 +133,9 @@ let remove_all_occurrences_of_free_names t to_remove =
   in
   { t with name_occurrences; }
 
-let increment_size code_size t =
-  let size = Flambda.Code_size.(+) t.size code_size in
-  { t with size}
+let clear_cost_metrics t = { t with cost_metrics = Flambda.Cost_metrics.zero }
 
-let clear_size t = { t with size = Flambda.Code_size.zero }
+let with_cost_metrics cost_metrics t = { t with cost_metrics }
 
-let with_size size t = { t with size }
+let cost_metrics_add ~added t =
+  { t with cost_metrics = Flambda.Cost_metrics.(+) added t.cost_metrics }

--- a/middle_end/flambda/simplify/env/upwards_acc.mli
+++ b/middle_end/flambda/simplify/env/upwards_acc.mli
@@ -28,7 +28,7 @@ val creation_dacc : t -> Downwards_acc.t
 (** Extract the environment component of the given upwards accumulator. *)
 val uenv : t -> Upwards_env.t
 
-val size : t -> Flambda.Code_size.t
+val cost_metrics : t -> Flambda.Cost_metrics.t
 
 val code_age_relation : t -> Code_age_relation.t
 
@@ -72,8 +72,8 @@ val used_closure_vars : t -> Name_occurrences.t
 
 val remove_all_occurrences_of_free_names : t -> Name_occurrences.t -> t
 
-val increment_size : Flambda.Code_size.t -> t -> t
+val clear_cost_metrics : t -> t
 
-val clear_size : t -> t
+val with_cost_metrics : Flambda.Cost_metrics.t -> t -> t
 
-val with_size : Flambda.Code_size.t -> t -> t
+val cost_metrics_add: added:Flambda.Cost_metrics.t -> t -> t

--- a/middle_end/flambda/simplify/env/upwards_env.ml
+++ b/middle_end/flambda/simplify/env/upwards_env.ml
@@ -142,10 +142,10 @@ let add_continuation_alias t cont arity ~alias_for =
   }
 
 let add_linearly_used_inlinable_continuation t cont scope arity ~params
-      ~handler ~free_names_of_handler ~size_of_handler =
+      ~handler ~free_names_of_handler ~cost_metrics_of_handler =
   add_continuation0 t cont scope
     (Linearly_used_and_inlinable { arity; handler; free_names_of_handler;
-      params; size_of_handler })
+      params; cost_metrics_of_handler })
 
 let add_exn_continuation t exn_cont scope =
   (* CR mshinwell: Think more about keeping these in both maps *)

--- a/middle_end/flambda/simplify/env/upwards_env.mli
+++ b/middle_end/flambda/simplify/env/upwards_env.mli
@@ -63,7 +63,7 @@ val add_linearly_used_inlinable_continuation
   -> params:Kinded_parameter.t list
   -> handler:Flambda.Expr.t
   -> free_names_of_handler:Name_occurrences.t
-  -> size_of_handler:Code_size.t
+  -> cost_metrics_of_handler:Cost_metrics.t
   -> t
 
 val add_exn_continuation

--- a/middle_end/flambda/simplify/simplify_apply_cont_expr.rec.ml
+++ b/middle_end/flambda/simplify/simplify_apply_cont_expr.rec.ml
@@ -19,7 +19,7 @@
 open! Simplify_import
 
 let inline_linearly_used_continuation uacc ~create_apply_cont ~params ~handler
-      ~free_names_of_handler ~size_of_handler =
+      ~free_names_of_handler ~cost_metrics_of_handler =
   (* CR mshinwell: With -g, we can end up with continuations that are
      just a sequence of phantom lets then "goto".  These would normally
      be treated as aliases, but of course aren't in this scenario,
@@ -53,12 +53,12 @@ let inline_linearly_used_continuation uacc ~create_apply_cont ~params ~handler
     let expr, uacc =
       let uacc =
         UA.with_name_occurrences uacc ~name_occurrences:free_names_of_handler
-        |> UA.increment_size size_of_handler
+        |> UA.cost_metrics_add ~added:cost_metrics_of_handler
       in
       Expr_builder.make_new_let_bindings uacc ~bindings_outermost_first
         ~body:handler
     in
-    expr, UA.size uacc, UA.name_occurrences uacc)
+    expr, UA.cost_metrics uacc, UA.name_occurrences uacc)
 
 let rebuild_apply_cont apply_cont ~args ~rewrite_id uacc ~after_rebuild =
   let uenv = UA.uenv uacc in
@@ -88,21 +88,27 @@ let rebuild_apply_cont apply_cont ~args ~rewrite_id uacc ~after_rebuild =
     in
     match rewrite_use_result with
     | Apply_cont apply_cont ->
-      let expr, size, free_names = apply_cont_to_expr apply_cont in
-      let uacc = UA.add_free_names uacc free_names |> UA.increment_size size in
+      let expr, cost_metrics, free_names = apply_cont_to_expr apply_cont in
+      let uacc =
+        UA.add_free_names uacc free_names
+        |> UA.cost_metrics_add ~added:cost_metrics
+      in
       after_rebuild expr uacc
     | Expr build_expr ->
-      let expr, size, free_names = build_expr ~apply_cont_to_expr in
-      let uacc = UA.add_free_names uacc free_names |> UA.increment_size size in
+      let expr, cost_metrics, free_names = build_expr ~apply_cont_to_expr in
+      let uacc =
+        UA.add_free_names uacc free_names
+        |> UA.cost_metrics_add ~added:cost_metrics
+      in
       after_rebuild expr uacc
   in
   match UE.find_continuation uenv cont with
   | Linearly_used_and_inlinable { arity = _; params; handler;
-      free_names_of_handler; size_of_handler } ->
+      free_names_of_handler; cost_metrics_of_handler } ->
     (* We must not fail to inline here, since we've already decided that the
        relevant [Let_cont] is no longer needed. *)
     inline_linearly_used_continuation uacc ~create_apply_cont ~params ~handler
-      ~free_names_of_handler ~size_of_handler
+      ~free_names_of_handler ~cost_metrics_of_handler
   | Unreachable { arity = _; } ->
     (* We allow this transformation even if there is a trap action, on the
        basis that there wouldn't be any opportunity to collect any backtrace,
@@ -111,7 +117,7 @@ let rebuild_apply_cont apply_cont ~args ~rewrite_id uacc ~after_rebuild =
   | Other { arity = _; handler = _; } ->
     create_apply_cont ~apply_cont_to_expr:(fun apply_cont ->
       Expr.create_apply_cont apply_cont,
-      Code_size.apply_cont apply_cont,
+      Cost_metrics.apply_cont apply_cont,
       Apply_cont.free_names apply_cont)
 
 let simplify_apply_cont dacc apply_cont ~down_to_up =

--- a/middle_end/flambda/simplify/simplify_apply_expr.rec.ml
+++ b/middle_end/flambda/simplify/simplify_apply_expr.rec.ml
@@ -78,7 +78,7 @@ let rebuild_non_inlined_direct_full_application apply ~use_id ~exn_cont_use_id
     match use_id with
     | None ->
       Expr.create_apply apply,
-      UA.increment_size (Code_size.apply apply) uacc
+      UA.cost_metrics_add ~added:(Cost_metrics.apply apply) uacc
     | Some use_id ->
       Simplify_common.add_wrapper_for_fixed_arity_apply uacc ~use_id
         result_arity apply
@@ -291,7 +291,7 @@ let simplify_direct_partial_application dacc apply ~callee's_code_id
         ~inline:Default_inline
         ~is_a_functor:false
         ~recursive
-        ~size:Unknown
+        ~cost_metrics:Unknown
     in
     let function_decl =
       Function_declaration.create ~code_id ~is_tupled:false ~dbg
@@ -729,7 +729,7 @@ let rebuild_c_call apply ~use_id ~exn_cont_use_id ~return_arity uacc
         (Flambda_arity.With_subkinds.of_arity return_arity) apply
     | None ->
       Expr.create_apply apply,
-      UA.increment_size (Code_size.apply apply) uacc
+      UA.cost_metrics_add ~added:(Cost_metrics.apply apply) uacc
   in
   let uacc = UA.add_free_names uacc (Expr.free_names expr) in
   after_rebuild expr uacc

--- a/middle_end/flambda/simplify/simplify_common.mli
+++ b/middle_end/flambda/simplify/simplify_common.mli
@@ -55,7 +55,7 @@ val simplify_projection
 
 type add_wrapper_for_switch_arm_result = private
   | Apply_cont of Flambda.Apply_cont.t
-  | New_wrapper of Continuation.t * Flambda.Continuation_handler.t * Flambda.Code_size.t
+  | New_wrapper of Continuation.t * Flambda.Continuation_handler.t * Flambda.Cost_metrics.t
 
 val add_wrapper_for_switch_arm
    : Upwards_acc.t

--- a/middle_end/flambda/simplify/simplify_expr.rec.ml
+++ b/middle_end/flambda/simplify/simplify_expr.rec.ml
@@ -71,20 +71,20 @@ let simplify_expr dacc expr ~down_to_up =
                 Expr.print expr
             end;
 
-            let code_size_uacc = UA.size uacc in
+            let code_size_uacc = UA.cost_metrics uacc in
             let denv = UA.creation_dacc uacc |> DA.denv in
             let code_size =
-              Code_size.expr_size expr ~find_code:(DE.find_code denv)
+              Cost_metrics.expr_size expr ~find_code:(DE.find_code denv)
             in
 
-            if not (Code_size.equal code_size_uacc code_size)
+            if not (Cost_metrics.equal code_size_uacc code_size)
             then begin
               Misc.fatal_errorf "Mismatch on code size:@ \n\
                   From UA:@ %a@ \n\
                   From expr:@ %a@ \n\
                   Expression:@ %a@"
-                Code_size.print code_size_uacc
-                Code_size.print code_size
+                Cost_metrics.print code_size_uacc
+                Cost_metrics.print code_size
                 Expr.print expr
             end;
 

--- a/middle_end/flambda/simplify/simplify_import.ml
+++ b/middle_end/flambda/simplify/simplify_import.ml
@@ -33,7 +33,7 @@ module Recursive_let_cont_handlers = Flambda.Recursive_let_cont_handlers
 module Set_of_closures = Flambda.Set_of_closures
 module Static_const = Flambda.Static_const
 module Switch = Flambda.Switch
-module Code_size = Flambda.Code_size
+module Cost_metrics = Flambda.Cost_metrics
 
 module AC = Apply_cont
 module CH = Continuation_handler

--- a/middle_end/flambda/simplify/simplify_import.mli
+++ b/middle_end/flambda/simplify/simplify_import.mli
@@ -33,7 +33,7 @@ module Recursive_let_cont_handlers = Flambda.Recursive_let_cont_handlers
 module Set_of_closures = Flambda.Set_of_closures
 module Static_const = Flambda.Static_const
 module Switch = Flambda.Switch
-module Code_size = Flambda.Code_size
+module Cost_metrics = Flambda.Cost_metrics
 
 module AC = Apply_cont
 module CH = Continuation_handler

--- a/middle_end/flambda/simplify/simplify_let_cont_expr.rec.ml
+++ b/middle_end/flambda/simplify/simplify_let_cont_expr.rec.ml
@@ -158,7 +158,7 @@ let rebuild_non_recursive_let_cont_handler cont
         (* We pass the parameters and the handler expression, rather than
            the [CH.t], to avoid re-opening the name abstraction. *)
         UE.add_linearly_used_inlinable_continuation uenv cont scope arity
-          ~params ~handler ~free_names_of_handler ~size_of_handler:(UA.size uacc)
+          ~params ~handler ~free_names_of_handler ~cost_metrics_of_handler:(UA.cost_metrics uacc)
       end else begin
         match CH.behaviour cont_handler with
         | Unreachable { arity; } ->
@@ -374,24 +374,24 @@ let simplify_non_recursive_let_cont dacc non_rec ~down_to_up =
                 let name_occurrences_subsequent_exprs =
                   UA.name_occurrences uacc
                 in
-                let size_of_subsequent_exprs =
-                  UA.size uacc
+                let cost_metrics_of_subsequent_exprs =
+                  UA.cost_metrics uacc
                 in
                 let uacc =
                   uacc
                   |> UA.clear_name_occurrences
-                  |> UA.clear_size
+                  |> UA.clear_cost_metrics
                 in
                 rebuild_handler uacc ~after_rebuild:(fun handler uacc ->
                   let name_occurrences_handler =
                     if continuation_has_zero_uses then Name_occurrences.empty
                     else UA.name_occurrences uacc
                   in
-                  let size_of_handler = UA.size uacc in
+                  let cost_metrics_of_handler = UA.cost_metrics uacc in
                   let uacc =
                     uacc
                     |> UA.clear_name_occurrences
-                    |> UA.clear_size
+                    |> UA.clear_cost_metrics
                   in
                   (* Having rebuilt the handler, we now rebuild the body. *)
                   rebuild_body uacc ~after_rebuild:(fun body uacc ->
@@ -438,7 +438,7 @@ let simplify_non_recursive_let_cont dacc non_rec ~down_to_up =
                           in
                           UA.with_name_occurrences uacc ~name_occurrences
                         in
-                        (* The size stored in uacc is the size of the body at
+                        (* The cost_metrics stored in uacc is the cost_metrics of the body at
                            this point *)
                         body, uacc
                       else
@@ -469,9 +469,9 @@ let simplify_non_recursive_let_cont dacc non_rec ~down_to_up =
                                 name_occurrences_subsequent_exprs
                             in
                             UA.with_name_occurrences uacc ~name_occurrences
-                            (* The body was discarded -- the size in uacc should
-                               be set to the size of handler.*)
-                            |>  UA.with_size size_of_handler
+                            (* The body was discarded -- the cost_metrics in uacc should
+                               be set to the cost_metrics of handler.*)
+                            |>  UA.with_cost_metrics cost_metrics_of_handler
                           in
                           handler, uacc
                         else
@@ -489,15 +489,21 @@ let simplify_non_recursive_let_cont dacc non_rec ~down_to_up =
                                 (Known num_free_occurrences_of_cont_in_body)
                               ~is_applied_with_traps
                           in
-                          let uacc =
-                            UA.increment_size
-                              (Code_size.increase_due_to_let_cont_non_recursive ~size_of_handler) uacc
+                          let added = 
+                            Cost_metrics.increase_due_to_let_cont_non_recursive
+                              ~cost_metrics_of_handler
                           in
+                          let uacc = UA.cost_metrics_add ~added uacc in
                           expr, uacc
                     in
-                    (* Add the size of subsequent expressions back on the accumulator
-                       as the accumulated size was cleared before rebuilding the let cont.*)
-                    let uacc = UA.increment_size size_of_subsequent_exprs uacc in
+                    (* Add the cost_metrics of subsequent expressions back on
+                       the accumulator as the accumulated cost_metrics was
+                       cleared before rebuilding the let cont.*)
+                    let uacc =
+                      UA.cost_metrics_add
+                        ~added:cost_metrics_of_subsequent_exprs
+                        uacc
+                    in
                     after_rebuild expr uacc)))))))
 
 let rebuild_recursive_let_cont_handlers cont arity ~original_cont_scope_level
@@ -571,11 +577,16 @@ let simplify_recursive_let_cont_handlers ~denv_before_body ~dacc_after_body
           rebuild_recursive_let_cont_handlers cont arity
             ~original_cont_scope_level cont_handler uacc ~after_rebuild)))
 
-let rebuild_recursive_let_cont ~body handlers ~size_of_handlers ~uenv_without_cont uacc
+let rebuild_recursive_let_cont ~body handlers ~cost_metrics_of_handlers ~uenv_without_cont uacc
       ~after_rebuild : Expr.t * UA.t =
   let uacc = UA.with_uenv uacc uenv_without_cont in
   let expr = Flambda.Let_cont.create_recursive handlers ~body in
-  let uacc = UA.increment_size (Code_size.increase_due_to_let_cont_recursive ~size_of_handlers) uacc in
+  let uacc =
+    UA.cost_metrics_add
+      ~added:(Cost_metrics.increase_due_to_let_cont_recursive
+                ~cost_metrics_of_handlers)
+      uacc
+  in
   after_rebuild expr uacc
 
 (* CR mshinwell: We should not simplify recursive continuations with no
@@ -616,10 +627,10 @@ let simplify_recursive_let_cont dacc recs ~down_to_up : Expr.t * UA.t =
             ~down_to_up:(fun dacc ~rebuild:rebuild_handlers ->
               down_to_up dacc ~rebuild:(fun uacc ~after_rebuild ->
                 let uenv_without_cont = UA.uenv uacc in
-                let uacc = UA.clear_size uacc in
+                let uacc = UA.clear_cost_metrics uacc in
                 rebuild_handlers uacc ~after_rebuild:(fun handlers uacc ->
-                  let size_of_handlers = UA.size uacc in
-                  let uacc = UA.clear_size uacc in
+                  let cost_metrics_of_handlers = UA.cost_metrics uacc in
+                  let uacc = UA.clear_cost_metrics uacc in
                   rebuild_body uacc ~after_rebuild:(fun body uacc ->
                     (* We are passing back over a binder, so remove the
                        bound continuation from the free name information. *)
@@ -631,7 +642,7 @@ let simplify_recursive_let_cont dacc recs ~down_to_up : Expr.t * UA.t =
                       UA.with_name_occurrences uacc ~name_occurrences
                     in
                     rebuild_recursive_let_cont ~body handlers
-                      ~uenv_without_cont uacc ~size_of_handlers ~after_rebuild)))))))
+                      ~uenv_without_cont uacc ~cost_metrics_of_handlers ~after_rebuild)))))))
 
 let simplify_let_cont dacc (let_cont : Let_cont.t) ~down_to_up : Expr.t * UA.t =
   match let_cont with

--- a/middle_end/flambda/simplify/simplify_set_of_closures.rec.ml
+++ b/middle_end/flambda/simplify/simplify_set_of_closures.rec.ml
@@ -446,7 +446,7 @@ let simplify_function context ~used_closure_vars ~shareable_constants
             end;
             raise Misc.Fatal_error)
     in
-    let size = UA.size uacc_after_upwards_traversal in
+    let cost_metrics = UA.cost_metrics uacc_after_upwards_traversal in
     let old_code_id = code_id in
     let new_code_id =
       Code_id.Map.find old_code_id (C.old_to_new_code_ids_all_sets context)
@@ -456,7 +456,7 @@ let simplify_function context ~used_closure_vars ~shareable_constants
       |> Code.with_code_id new_code_id
       |> Code.with_newer_version_of (Some old_code_id)
       |> Code.with_params_and_body
-           ~size:(Known size)
+           ~cost_metrics:(Known cost_metrics)
            (Present (params_and_body, free_names_of_code))
     in
     let function_decl = FD.update_code_id function_decl new_code_id in
@@ -765,12 +765,12 @@ let simplify_non_lifted_set_of_closures0 dacc bound_vars ~closure_bound_vars
   in
   let defining_expr =
     let named = Named.create_set_of_closures set_of_closures in
-    let find_code_size code_id =
+    let find_cost_metrics code_id =
       let env = Downwards_acc.denv dacc in
       Downwards_env.find_code env code_id
-      |> Code.size
+      |> Code.cost_metrics
     in
-    Simplified_named.reachable_with_known_free_names ~find_code_size
+    Simplified_named.reachable_with_known_free_names ~find_cost_metrics
       (Named.create_set_of_closures set_of_closures)
       ~free_names:(Named.free_names named)
   in

--- a/middle_end/flambda/terms/code.rec.ml
+++ b/middle_end/flambda/terms/code.rec.ml
@@ -27,7 +27,7 @@ type t = {
   inline : Inline_attribute.t;
   is_a_functor : bool;
   recursive : Recursive.t;
-  size : Code_size.t Or_unknown.t;
+  cost_metrics : Cost_metrics.t Or_unknown.t;
 }
 
 let code_id { code_id; _ } = code_id
@@ -58,7 +58,7 @@ let is_a_functor { is_a_functor; _ } = is_a_functor
 
 let recursive { recursive; _ } = recursive
 
-let size {size; _} = size
+let cost_metrics {cost_metrics; _} = cost_metrics
 
 let check_params_and_body code_id (params_and_body : _ Or_deleted.t) =
   let free_names_of_params_and_body =
@@ -93,7 +93,7 @@ let create
       ~(inline:Inline_attribute.t)
       ~is_a_functor
       ~recursive
-      ~size =
+      ~cost_metrics =
   begin match stub, inline with
   | true, (Hint_inline | Never_inline | Default_inline)
   | false, (Never_inline | Default_inline | Always_inline | Hint_inline | Unroll _) -> ()
@@ -113,16 +113,16 @@ let create
     inline;
     is_a_functor;
     recursive;
-    size;
+    cost_metrics;
   }
 
 let with_code_id code_id t = { t with code_id }
 
-let with_params_and_body params_and_body ~size t =
+let with_params_and_body params_and_body ~cost_metrics t =
   let params_and_body, free_names_of_params_and_body =
     check_params_and_body t.code_id params_and_body
   in
-  { t with params_and_body; size; free_names_of_params_and_body; }
+  { t with params_and_body; cost_metrics; free_names_of_params_and_body; }
 
 let with_newer_version_of newer_version_of t = { t with newer_version_of }
 
@@ -136,7 +136,7 @@ let print_params_and_body_with_cache ~cache ppf params_and_body =
 let print_with_cache ~cache ppf
       { code_id = _; params_and_body; newer_version_of; stub; inline;
         is_a_functor; params_arity; result_arity; recursive;
-        free_names_of_params_and_body = _; size } =
+        free_names_of_params_and_body = _; cost_metrics } =
   let module C = Flambda_colours in
   match params_and_body with
   | Present _ ->
@@ -148,7 +148,7 @@ let print_with_cache ~cache ppf
         @[<hov 1>@<0>%s(params_arity@ @<0>%s%a@<0>%s)@<0>%s@]@ \
         @[<hov 1>@<0>%s(result_arity@ @<0>%s%a@<0>%s)@<0>%s@]@ \
         @[<hov 1>@<0>%s(recursive@ %a)@<0>%s@]@ \
-        @[<hov 1>@<0>%s(size@ %a)@<0>%s@]@ \
+        @[<hov 1>@<0>%s(cost_metrics@ %a)@<0>%s@]@ \
         %a\
         )@]"
       (if Option.is_none newer_version_of then Flambda_colours.elide ()
@@ -189,10 +189,10 @@ let print_with_cache ~cache ppf
       | Recursive -> Flambda_colours.normal ())
       Recursive.print recursive
       (Flambda_colours.normal ())
-      (match size with
+      (match cost_metrics with
        | Unknown -> Flambda_colours.elide ()
        | Known _ -> Flambda_colours.normal ())
-      (Or_unknown.print Code_size.print) size
+      (Or_unknown.print Cost_metrics.print) cost_metrics
       (Flambda_colours.normal ())
       (print_params_and_body_with_cache ~cache) params_and_body
   | Deleted ->
@@ -226,7 +226,7 @@ let free_names t =
 let apply_name_permutation
       ({ code_id; params_and_body; newer_version_of; params_arity = _;
          result_arity = _; stub = _; inline = _; is_a_functor = _;
-         recursive = _; size = _; free_names_of_params_and_body; } as t)
+         recursive = _; cost_metrics = _; free_names_of_params_and_body; } as t)
       perm =
   (* inlined and modified version of Option.map to preserve sharing *)
   let newer_version_of' =
@@ -269,7 +269,7 @@ let apply_name_permutation
 let all_ids_for_export { code_id; params_and_body; newer_version_of;
                          params_arity = _; result_arity = _; stub = _;
                          inline = _; is_a_functor = _; recursive = _;
-                         size = _; free_names_of_params_and_body = _; } =
+                         cost_metrics = _; free_names_of_params_and_body = _; } =
   let newer_version_of_ids =
     match newer_version_of with
     | None -> Ids_for_export.empty
@@ -289,7 +289,7 @@ let all_ids_for_export { code_id; params_and_body; newer_version_of;
 let import import_map
       ({ code_id; params_and_body; newer_version_of; params_arity = _;
          result_arity = _; stub = _; inline = _; is_a_functor = _;
-         size = _; recursive = _; free_names_of_params_and_body; } as t) =
+         cost_metrics = _; recursive = _; free_names_of_params_and_body; } as t) =
   let code_id = Ids_for_export.Import_map.code_id import_map code_id in
   let params_and_body : Function_params_and_body.t Or_deleted.t =
     match params_and_body with

--- a/middle_end/flambda/terms/code.rec.mli
+++ b/middle_end/flambda/terms/code.rec.mli
@@ -47,7 +47,7 @@ val is_a_functor : t -> bool
 
 val recursive : t -> Recursive.t
 
-val size : t -> Code_size.t Or_unknown.t
+val cost_metrics : t -> Cost_metrics.t Or_unknown.t
 
 val create
    : Code_id.t  (** needed for [compare], although useful otherwise too *)
@@ -60,14 +60,14 @@ val create
   -> inline:Inline_attribute.t
   -> is_a_functor:bool
   -> recursive:Recursive.t
-  -> size:Code_size.t Or_unknown.t
+  -> cost_metrics:Cost_metrics.t Or_unknown.t
   -> t
 
 val with_code_id : Code_id.t -> t -> t
 
 val with_params_and_body
    : (Function_params_and_body.t * Name_occurrences.t) Or_deleted.t
-  -> size:Code_size.t Or_unknown.t
+  -> cost_metrics:Cost_metrics.t Or_unknown.t
   -> t
   -> t
 

--- a/middle_end/flambda/terms/cost_metrics.rec.ml
+++ b/middle_end/flambda/terms/cost_metrics.rec.ml
@@ -388,12 +388,12 @@ let static_consts _ = 0
    functions it refers to. This is mainly due to the fact that if we do inline
    a function f where a set of closure is defined then we will copy the body of
    all functions referred by this set of closure as they are dependent upon f.*)
-let set_of_closures ~find_code_size set_of_closures =
+let set_of_closures ~find_cost_metrics set_of_closures =
   let func_decls = Set_of_closures.function_decls set_of_closures in
   let funs = Function_declarations.funs func_decls in
   Closure_id.Map.fold (fun _ func_decl size ->
     let code_id = Function_declaration.code_id func_decl in
-    match find_code_size code_id with
+    match find_cost_metrics code_id with
     | Or_unknown.Known s -> size + s
     | Or_unknown.Unknown ->
       Misc.fatal_errorf "Code size should have been computed for:@ %a"
@@ -401,8 +401,8 @@ let set_of_closures ~find_code_size set_of_closures =
   )
     funs (zero)
 
-let increase_due_to_let_expr ~is_phantom ~size_of_defining_expr =
-  if is_phantom then zero else size_of_defining_expr
+let increase_due_to_let_expr ~is_phantom ~cost_metrics_of_defining_expr =
+  if is_phantom then zero else cost_metrics_of_defining_expr
 
 let apply apply = 
   match Apply.call_kind apply with
@@ -425,11 +425,11 @@ let invalid _ = 0
 
 let switch switch = 0 + (5 * Switch.num_arms switch)
 
-let increase_due_to_let_cont_non_recursive ~size_of_handler =
-  size_of_handler
+let increase_due_to_let_cont_non_recursive ~cost_metrics_of_handler =
+  cost_metrics_of_handler
 
-let increase_due_to_let_cont_recursive ~size_of_handlers =
-  size_of_handlers
+let increase_due_to_let_cont_recursive ~cost_metrics_of_handlers =
+  cost_metrics_of_handlers
 
 let rec expr_size ~find_code expr size =
   match Expr.descr expr with

--- a/middle_end/flambda/terms/cost_metrics.rec.mli
+++ b/middle_end/flambda/terms/cost_metrics.rec.mli
@@ -35,12 +35,12 @@ val print : Format.formatter -> t -> unit
 val prim : Flambda_primitive.t -> t
 val simple : Simple.t -> t
 val static_consts : Static_const.Group.t -> t
-val set_of_closures : find_code_size:(Code_id.t -> Code_size.t Or_unknown.t) -> Set_of_closures.t -> t
+val set_of_closures : find_cost_metrics:(Code_id.t -> Cost_metrics.t Or_unknown.t) -> Set_of_closures.t -> t
 
 val apply : Apply.t -> t
 val apply_cont : Apply_cont.t -> t
 val switch : Switch.t -> t
 val invalid : unit -> t
-val increase_due_to_let_expr : is_phantom:bool -> size_of_defining_expr:t -> t
-val increase_due_to_let_cont_non_recursive : size_of_handler:t -> t
-val increase_due_to_let_cont_recursive : size_of_handlers:t -> t
+val increase_due_to_let_expr : is_phantom:bool -> cost_metrics_of_defining_expr:t -> t
+val increase_due_to_let_cont_non_recursive : cost_metrics_of_handler:t -> t
+val increase_due_to_let_cont_recursive : cost_metrics_of_handlers:t -> t

--- a/middle_end/flambda/terms/dune
+++ b/middle_end/flambda/terms/dune
@@ -5,8 +5,8 @@
     template/flambda.templ.ml
     code.rec.ml
     code.rec.mli
-    code_size.rec.ml
-    code_size.rec.mli
+    cost_metrics.rec.ml
+    cost_metrics.rec.mli
     continuation_handler.rec.ml
     continuation_handler.rec.mli
     continuation_handlers.rec.ml

--- a/middle_end/flambda/terms/expr.rec.ml
+++ b/middle_end/flambda/terms/expr.rec.ml
@@ -185,9 +185,9 @@ let create_if_then_else ~scrutinee ~if_true ~if_false =
   in
   create_switch (Switch_expr.create ~scrutinee ~arms)
 
-let bind_no_simplification ~bindings ~body ~size_of_body ~free_names_of_body =
+let bind_no_simplification ~bindings ~body ~cost_metrics_of_body ~free_names_of_body =
   ListLabels.fold_left (List.rev bindings)
-    ~init:(body, size_of_body, free_names_of_body)
+    ~init:(body, cost_metrics_of_body, free_names_of_body)
     ~f:(fun (expr, size, free_names) (var, size_expr, defining_expr) ->
       let expr =
         Let_expr.create (Bindable_let_bound.singleton var)
@@ -200,7 +200,7 @@ let bind_no_simplification ~bindings ~body ~size_of_body ~free_names_of_body =
         Name_occurrences.union (Named.free_names defining_expr)
           (Name_occurrences.remove_var free_names (Var_in_binding_pos.var var))
       in
-      let size = Code_size.(+) size size_expr in
+      let size = Cost_metrics.(+) size size_expr in
       expr, size, free_names)
 
 let bind_parameters_to_args_no_simplification ~params ~args ~body =

--- a/middle_end/flambda/terms/expr.rec.mli
+++ b/middle_end/flambda/terms/expr.rec.mli
@@ -68,11 +68,11 @@ val create_if_then_else
 val create_invalid : ?semantics:Invalid_term_semantics.t -> unit -> t
 
 val bind_no_simplification
-   : bindings:(Var_in_binding_pos.t * Code_size.t * Named.t) list
+   : bindings:(Var_in_binding_pos.t * Cost_metrics.t * Named.t) list
   -> body:Expr.t
-  -> size_of_body:Code_size.t
+  -> cost_metrics_of_body:Cost_metrics.t
   -> free_names_of_body:Name_occurrences.t
-  -> Expr.t * Code_size.t * Name_occurrences.t
+  -> Expr.t * Cost_metrics.t * Name_occurrences.t
 
 val bind_parameters_to_args_no_simplification
    : params:Kinded_parameter.t list

--- a/middle_end/flambda/terms/flambda.mli
+++ b/middle_end/flambda/terms/flambda.mli
@@ -86,11 +86,11 @@ module rec Expr : sig
   val create_invalid : ?semantics:Invalid_term_semantics.t -> unit -> t
 
   val bind_no_simplification
-     : bindings:(Var_in_binding_pos.t * Code_size.t * Named.t) list
+     : bindings:(Var_in_binding_pos.t * Cost_metrics.t * Named.t) list
     -> body:Expr.t
-    -> size_of_body:Code_size.t
+    -> cost_metrics_of_body:Cost_metrics.t
     -> free_names_of_body:Name_occurrences.t
-    -> Expr.t * Code_size.t * Name_occurrences.t
+    -> Expr.t * Cost_metrics.t * Name_occurrences.t
 
   val bind_parameters_to_args_no_simplification
      : params:Kinded_parameter.t list
@@ -638,7 +638,7 @@ end and Code : sig
 
   val recursive : t -> Recursive.t
 
-  val size : t -> Code_size.t Or_unknown.t
+  val cost_metrics : t -> Cost_metrics.t Or_unknown.t
 
   val create
      : Code_id.t
@@ -651,15 +651,15 @@ end and Code : sig
     -> inline:Inline_attribute.t
     -> is_a_functor:bool
     -> recursive:Recursive.t
-    -> size: Code_size.t Or_unknown.t
+    -> cost_metrics: Cost_metrics.t Or_unknown.t
     -> t
 
   val with_code_id : Code_id.t -> t -> t
 
   val with_params_and_body
      : (Function_params_and_body.t * Name_occurrences.t) Or_deleted.t
-     (* CR poechsel: remove Or_unknown.t and force size to be provided *)
-    -> size:Code_size.t Or_unknown.t
+     (* CR poechsel: remove Or_unknown.t and force cost_metrics to be provided *)
+    -> cost_metrics:Cost_metrics.t Or_unknown.t
     -> t
     -> t
 
@@ -676,7 +676,7 @@ end and Code : sig
   val make_deleted : t -> t
 
   val is_deleted : t -> bool
-end and Code_size : sig
+end and Cost_metrics : sig
   type t
 
   val expr_size : find_code:(Code_id.t -> Code.t) -> Expr.t -> t
@@ -689,15 +689,15 @@ end and Code_size : sig
 
   val prim : Flambda_primitive.t -> t
   val simple : Simple.t -> t
-  val set_of_closures : find_code_size:(Code_id.t -> t Or_unknown.t) -> Set_of_closures.t -> t
+  val set_of_closures : find_cost_metrics:(Code_id.t -> t Or_unknown.t) -> Set_of_closures.t -> t
   val static_consts : Static_const.Group.t -> t
   val apply : Apply.t -> t
   val apply_cont : Apply_cont.t -> t
   val switch : Switch.t -> t
   val invalid : unit -> t
-  val increase_due_to_let_expr : is_phantom:bool -> size_of_defining_expr:t -> t
-  val increase_due_to_let_cont_non_recursive : size_of_handler:t -> t
-  val increase_due_to_let_cont_recursive : size_of_handlers:t -> t
+  val increase_due_to_let_expr : is_phantom:bool -> cost_metrics_of_defining_expr:t -> t
+  val increase_due_to_let_cont_non_recursive : cost_metrics_of_handler:t -> t
+  val increase_due_to_let_cont_recursive : cost_metrics_of_handlers:t -> t
 end
 
 module Function_declaration = Function_declaration
@@ -726,5 +726,5 @@ module Import : sig
   module Set_of_closures = Set_of_closures
   module Static_const = Static_const
   module Switch = Switch
-  module Code_size = Code_size
+  module Cost_metrics = Cost_metrics
 end

--- a/middle_end/flambda/terms/rec_modules
+++ b/middle_end/flambda/terms/rec_modules
@@ -9,4 +9,4 @@ named.rec.ml
 non_recursive_let_cont_handler.rec.ml
 recursive_let_cont_handlers.rec.ml
 static_const.rec.ml
-code_size.rec.ml
+cost_metrics.rec.ml

--- a/middle_end/flambda/terms/template/flambda.templ.ml
+++ b/middle_end/flambda/terms/template/flambda.templ.ml
@@ -63,5 +63,5 @@ module Import = struct
   module Set_of_closures = Set_of_closures
   module Static_const = Static_const
   module Switch = Switch
-  module Code_size = Code_size
+  module Cost_metrics = Cost_metrics
 end


### PR DESCRIPTION
Renamed [Code_size] to [Cost_metrics] to show that metrics other than just size
might be tracked during simplify (which will be the case in the near-future).