### PR TITLE
Add Reinterpret_int64_as_float ("float of bits")

### DIFF
--- a/flambdatest/mlexamples/nan.ml
+++ b/flambdatest/mlexamples/nan.ml
@@ -1,0 +1,6 @@
+external float_of_bits : int64 -> float
+  = "caml_int64_float_of_bits" "caml_int64_float_of_bits_unboxed"
+  [@@unboxed] [@@noalloc]
+
+let nan =
+  float_of_bits 0x7F_F0_00_00_00_00_00_01L

--- a/middle_end/flambda/simplify/simplify_named.rec.ml
+++ b/middle_end/flambda/simplify/simplify_named.rec.ml
@@ -105,6 +105,7 @@ let record_any_symbol_projection dacc (defining_expr : Simplified_named.t)
       | Float_arith _
       | Num_conv _
       | Boolean_not
+      | Reinterpret_int64_as_float
       | Unbox_number _
       | Box_number _
       | Select_closure _

--- a/middle_end/flambda/terms/cost_metrics.rec.ml
+++ b/middle_end/flambda/terms/cost_metrics.rec.ml
@@ -322,6 +322,7 @@ let unary_prim_size prim =
   | Float_arith _ -> 2
   | Num_conv { src; dst; } -> arith_conversion_size src dst
   | Boolean_not -> 1
+  | Reinterpret_int64_as_float -> 0
   | Unbox_number k -> unbox_number k
   | Box_number k -> box_number k
   | Select_closure _ -> 1 (* caddv *)
@@ -404,7 +405,7 @@ let set_of_closures ~find_cost_metrics set_of_closures =
 let increase_due_to_let_expr ~is_phantom ~cost_metrics_of_defining_expr =
   if is_phantom then zero else cost_metrics_of_defining_expr
 
-let apply apply = 
+let apply apply =
   match Apply.call_kind apply with
   | Function Direct _ -> direct_call_size
   (* CR mshinwell: Check / fix these numbers *)

--- a/middle_end/flambda/terms/flambda_primitive.mli
+++ b/middle_end/flambda/terms/flambda_primitive.mli
@@ -254,6 +254,7 @@ type unary_primitive =
      use a %-primitive instead of directly calling C stubs for conversions;
      then we could have a single primitive here taking two
      [Flambda_kind.Of_naked_number.t] arguments (one input, one output). *)
+  | Reinterpret_int64_as_float
   | Unbox_number of Flambda_kind.Boxable_number.t
   | Box_number of Flambda_kind.Boxable_number.t
   | Select_closure of {

--- a/middle_end/flambda/to_cmm/un_cps.ml
+++ b/middle_end/flambda/to_cmm/un_cps.ml
@@ -440,6 +440,15 @@ let unary_primitive env dbg f arg =
     arithmetic_conversion dbg src dst arg
   | Boolean_not ->
     None, C.mk_not dbg arg
+  | Reinterpret_int64_as_float ->
+    (* CR-someday mshinwell: We should add support for this operation in
+       the backend.  It isn't the identity as there may need to be a move
+       between different register kinds (e.g. integer to XMM registers
+       on x86-64). *)
+    None, C.extcall ~alloc:false ~returns:true
+      "caml_int64_float_of_bits_unboxed"
+      typ_float
+      [arg]
   | Unbox_number kind ->
     let extra =
       match kind with


### PR DESCRIPTION
This adds the "float of bits" operation, which I've given a more appropriate name, to Flambda.  This means that we can now simplify the float constant definitions in `stdlib.ml`, so for example `Stdlib.nan` is now a known value:
```
     (Stdlib.camlStdlib__nan1216 (Val (Boxed_float (Naked_float (= #nan)))))
```
This is a minimal patch, fixing a rather longstanding problem, which we can extend later with other similar cases as required.