### PR TITLE
Fix spill cache lookup

### DIFF
--- a/asmcomp/spill.ml
+++ b/asmcomp/spill.ml
@@ -423,20 +423,26 @@ let initial_env (reload_env : reload_env) =
 
 type spill_cache_entry =
   { at_exit_restricted : (int * Reg.Set.t) list;
+    after_handler : Reg.Set.t;
     result : (instruction * Reg.Set.t);
   }
 
 let spill_cache : spill_cache_entry Numbers.Int.Map.t ref =
   ref Numbers.Int.Map.empty
 
-let cache_spill_result nfail env handler before_handler =
+let cache_spill_result nfail env after_handler handler before_handler =
   let at_exit_restricted =
     List.filter (fun (n, _at_exit) ->
         Numbers.Int.Set.mem n
           (Numbers.Int.Map.find nfail env.free_conts_for_handlers))
       env.at_exit
   in
-  let entry = { at_exit_restricted; result = (handler, before_handler); } in
+  let entry =
+    { at_exit_restricted;
+      after_handler;
+      result = (handler, before_handler);
+    }
+  in
   spill_cache := Numbers.Int.Map.add nfail entry !spill_cache
 
 let spill_reg_no_add (env : spill_env) r =
@@ -456,12 +462,13 @@ let at_raise_from_trap_stack env ts =
   | Generic_trap _ -> env.last_regular_trywith_handler
   | Specific_trap (nfail, _) -> find_spill_at_exit env nfail
 
-let find_in_spill_cache nfail env =
+let find_in_spill_cache nfail at_join env =
   try
-    let { at_exit_restricted; result; } =
+    let { at_exit_restricted; after_handler; result; } =
       Numbers.Int.Map.find nfail !spill_cache
     in
-    if List.for_all (fun (n, at_exit) ->
+    if Reg.Set.subset at_join after_handler
+    && List.for_all (fun (n, at_exit) ->
         Reg.Set.subset (find_spill_at_exit env n) at_exit)
       at_exit_restricted
     then Some result
@@ -556,10 +563,10 @@ let rec spill :
                             catch = true;
                  }
                in
-               match find_in_spill_cache nfail env with
+               match find_in_spill_cache nfail at_join env with
                | None ->
                  spill env handler at_join (fun handler before_handler ->
-                   cache_spill_result nfail env handler before_handler;
+                   cache_spill_result nfail env at_join handler before_handler;
                    handler, before_handler)
                | Some result -> result)
             handlers


### PR DESCRIPTION
The actual input of the `spill` function, the set of registers live after the instruction, was not taken into account by the cache mechanism.