### PR TITLE
Type_descr.join: preserve aliases on join with Bottom

### DIFF
--- a/flambdatest/mlexamples/join_and_aliases.ml
+++ b/flambdatest/mlexamples/join_and_aliases.ml
@@ -1,0 +1,39 @@
+(* Example provided by Pierre Chambart and Guillaume Bury
+   This example was produced to test cases where a variant
+   can be unboxed but there isn't any existing variable that
+   refers to the field of the block.
+   However, it also triggered a few bugs in the join algorithm,
+   fixed by PRs #327 and #329, so it is included here.
+
+   The goal here is to propagate enough information to remove
+   the last assert false.
+   The main issue was that the type for v was Top, for two reasons:
+   - The fact that v is an alias to r was not correctly propagated,
+   because its type was the result of joining an alias with Bottom
+   (this is fixed by #327)
+   - Even without the alias, the join should have expanded the type
+   at the use site and found that it only had Foo (0) as possible tag,
+   but because the expansion was done in the wrong environment no
+   type was found and Top was returned instead.
+*)
+
+type t =
+  | Foo of int
+  | Bar of string
+
+let f r =
+  let v =
+    match r with
+    | (Foo x') as res -> res
+    | Bar _ -> raise Exit
+  in
+  let v' =
+    if Sys.opaque_identity false then
+      v
+    else
+      Foo 42
+  in
+  match v' with
+  | Foo i -> i
+  | Bar _ -> assert false
+

--- a/middle_end/flambda/types/type_descr.rec.ml
+++ b/middle_end/flambda/types/type_descr.rec.ml
@@ -499,9 +499,15 @@ module Make (Head : Type_head_intf.S
     (* CR mshinwell: Add shortcut when the canonical simples are equal *)
     let shared_aliases =
       let shared_aliases =
-        match canonical_simple1, canonical_simple2 with
-        | None, _ | _, None -> Simple.Set.empty
-        | Some simple1, Some simple2 ->
+        match canonical_simple1, head1, canonical_simple2, head2 with
+        | None, _, None, _
+        | None, (Ok _ | Unknown), _, _
+        | _, _, None, (Ok _ | Unknown) -> Simple.Set.empty
+        | Some simple1, _, _, Bottom ->
+          Simple.Set.singleton simple1
+        | _, Bottom, Some simple2, _ ->
+          Simple.Set.singleton simple2
+        | Some simple1, _, Some simple2, _ ->
           if Simple.same simple1 simple2
           then Simple.Set.singleton simple1
           else


### PR DESCRIPTION
I'm a bit surprised that `Type_descr.join` doesn't seem to care whether the resulting type is valid in the target env, but at least when coming from `Typing_env_level.join` the target env always contains all the names from both branches, so this should be safe.