### PR TITLE
Add flags for small and big function inlining threshold

### DIFF
--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -493,6 +493,16 @@ let read_one_param ppf position name v =
   | "flambda-debug-concrete-types-only-on-canonicals" ->
     set "flambda-debug-concrete-types-only-on-canonicals"
       [ Flambda.Debug.concrete_types_only_on_canonicals ] v
+  | "flambda-expert-small-function-threshold" ->
+     Int_arg_helper.parse v
+       "Bad syntax in OCAMLPARAM for \
+        'flambda-expert-small-function-threshold'"
+       Flambda.Expert.small_function_threshold
+  | "flambda-expert-big-function-threshold" ->
+     Int_arg_helper.parse v
+       "Bad syntax in OCAMLPARAM for \
+        'flambda-expert-big-function-threshold'"
+       Flambda.Expert.big_function_threshold
   | _ ->
     if not (List.mem name !can_discard) then begin
       can_discard := name :: !can_discard;

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -988,6 +988,20 @@ let mk_flambda_expert_max_inlining_depth f =
   " Set maximum inlining depth"
 ;;
 
+let mk_flambda_expert_small_function_threshold f =
+  "-flambda-expert-small-function-threshold", Arg.String f,
+  Printf.sprintf "<n>|<round>=<n>[,...] Functions with a cost less than this \
+                  threshold will always be inlined (default %d)."
+    Clflags.Flambda.Expert.default_small_function_threshold
+;;
+
+let mk_flambda_expert_big_function_threshold f =
+  "-flambda-expert-big-function-threshold", Arg.String f,
+  Printf.sprintf "<n>|<round>=<n>[,...] Functions with a cost greater than this \
+                  threshold will never be inlined (default %d)."
+    Clflags.Flambda.Expert.default_big_function_threshold
+;;
+
 let mk_flambda_expert_max_block_size_for_projections f =
   "-flambda-expert-max-block-size-for-projections", Arg.Int f,
   " Do not simplify projections from blocks if the block size exceeds \
@@ -1252,6 +1266,8 @@ module type Optcommon_options = sig
   val _flambda_expert_phantom_lets : unit -> unit
   val _no_flambda_expert_phantom_lets : unit -> unit
   val _flambda_expert_max_inlining_depth : int -> unit
+  val _flambda_expert_small_function_threshold : string -> unit
+  val _flambda_expert_big_function_threshold : string -> unit
   val _flambda_expert_max_block_size_for_projections : int -> unit
   val _flambda_debug_permute_every_name : unit -> unit
   val _no_flambda_debug_permute_every_name : unit -> unit
@@ -1618,6 +1634,10 @@ struct
       F._no_flambda_expert_phantom_lets;
     mk_flambda_expert_max_inlining_depth
       F._flambda_expert_max_inlining_depth;
+    mk_flambda_expert_small_function_threshold
+      F._flambda_expert_small_function_threshold;
+    mk_flambda_expert_big_function_threshold
+      F._flambda_expert_big_function_threshold;
     mk_flambda_expert_max_block_size_for_projections
       F._flambda_expert_max_block_size_for_projections;
     mk_flambda_debug_permute_every_name
@@ -1782,6 +1802,10 @@ module Make_opttop_options (F : Opttop_options) = struct
       F._no_flambda_expert_phantom_lets;
     mk_flambda_expert_max_inlining_depth
       F._flambda_expert_max_inlining_depth;
+    mk_flambda_expert_small_function_threshold
+      F._flambda_expert_small_function_threshold;
+    mk_flambda_expert_big_function_threshold
+      F._flambda_expert_big_function_threshold;
     mk_flambda_expert_max_block_size_for_projections
       F._flambda_expert_max_block_size_for_projections;
     mk_flambda_debug_permute_every_name
@@ -2096,6 +2120,16 @@ module Default = struct
       clear Flambda.Expert.phantom_lets
     let _flambda_expert_max_inlining_depth depth =
       Flambda.Expert.max_inlining_depth := depth
+    let _flambda_expert_small_function_threshold spec =
+      Int_arg_helper.parse spec
+        "Syntax: -flambda-expert-small-function-threshold <n> | \
+         <round>=<n>[,...]"
+      Flambda.Expert.small_function_threshold
+    let _flambda_expert_big_function_threshold spec =
+      Int_arg_helper.parse spec
+        "Syntax: -flambda-expert-big-function-threshold <n> | \
+         <round>=<n>[,...]"
+        Flambda.Expert.big_function_threshold
     let _flambda_expert_max_block_size_for_projections size =
       Flambda.Expert.max_block_size_for_projections := Some size
     let _flambda_debug_permute_every_name =

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -243,6 +243,8 @@ module type Optcommon_options = sig
   val _flambda_expert_phantom_lets : unit -> unit
   val _no_flambda_expert_phantom_lets : unit -> unit
   val _flambda_expert_max_inlining_depth : int -> unit
+  val _flambda_expert_small_function_threshold : string -> unit
+  val _flambda_expert_big_function_threshold : string -> unit
   val _flambda_expert_max_block_size_for_projections : int -> unit
   val _flambda_debug_permute_every_name : unit -> unit
   val _no_flambda_debug_permute_every_name : unit -> unit

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -439,6 +439,14 @@ module Flambda = struct
     let phantom_lets = ref true
     let max_inlining_depth = ref 1
     let max_block_size_for_projections = ref None
+
+    let default_small_function_threshold = 128
+    let default_big_function_threshold = 65536
+
+    let small_function_threshold =
+      ref (Int_arg_helper.default default_small_function_threshold)
+    let big_function_threshold =
+      ref (Int_arg_helper.default default_big_function_threshold)
   end
 
   module Debug = struct

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -258,6 +258,10 @@ module Flambda : sig
     val inline_effects_in_cmm : bool ref
     val phantom_lets : bool ref
     val max_inlining_depth : int ref
+    val default_small_function_threshold : int
+    val default_big_function_threshold : int
+    val small_function_threshold : Int_arg_helper.parsed ref
+    val big_function_threshold : Int_arg_helper.parsed ref
     val max_block_size_for_projections : int option ref
   end
 


### PR DESCRIPTION
Preparatory work for the inliner heuristics:
- Functions with a cost less than the specified small threshold
will always be inlined.
- Functions with a cost greater than the specified big threshold
will never be inlined.