### PR TITLE
Flambda_type.prove_is_a_tagged_immediate: Avoid spurious Invalid and Unknown

### DIFF
--- a/middle_end/flambda/types/template/flambda_type.templ.ml
+++ b/middle_end/flambda/types/template/flambda_type.templ.ml
@@ -567,11 +567,18 @@ let prove_is_a_tagged_immediate env t : _ proof_allowing_kind_mismatch =
   | Value Unknown -> Unknown
   | Value (Ok (Variant { blocks; immediates; is_unique = _; })) ->
     begin match blocks, immediates with
-    | Unknown, Unknown | Unknown, Known _ | Known _, Unknown -> Unknown
-    | Known blocks, Known imms ->
-      if Row_like.For_blocks.is_bottom blocks && not (is_bottom env imms)
+    | Unknown, Unknown | Unknown, Known _ -> Unknown
+    | Known blocks, Unknown ->
+      if Row_like.For_blocks.is_bottom blocks
       then Proved ()
-      else Invalid
+      else Unknown
+    | Known blocks, Known imms ->
+      if is_bottom env imms
+      then Invalid
+      else begin if Row_like.For_blocks.is_bottom blocks
+        then Proved ()
+        else Unknown
+      end
     end
   | Value _ -> Invalid
   | _ -> Wrong_kind

--- a/middle_end/flambda/types/template/flambda_type.templ.ml
+++ b/middle_end/flambda/types/template/flambda_type.templ.ml
@@ -293,7 +293,12 @@ let prove_is_int env t : bool proof =
   | Const _ -> wrong_kind ()
   | Value (Ok (Variant blocks_imms)) ->
     begin match blocks_imms.blocks, blocks_imms.immediates with
-    | Unknown, Unknown | Unknown, Known _ | Known _, Unknown -> Unknown
+    | Unknown, Unknown | Unknown, Known _ -> Unknown
+    | Known blocks, Unknown ->
+      if Row_like.For_blocks.is_bottom blocks then
+        Proved true
+      else
+        Unknown
     | Known blocks, Known imms ->
       (* CR mshinwell: Should we tighten things up by causing fatal errors
          in cases such as [blocks] and [imms] both being bottom? *)

--- a/testsuite/tests/statmemprof/comballoc.opt.reference
+++ b/testsuite/tests/statmemprof/comballoc.opt.reference
@@ -9,8 +9,7 @@ Called from Comballoc.test in file "comballoc.ml", line 40, characters 25-48
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
 Called from Comballoc in file "comballoc.ml", line 70, characters 2-35
 4: 0.42 true
-Raised by primitive operation at Comballoc.f4 in file "comballoc.ml" (inlined), line 12, characters 11-20
-Called from Comballoc.f in file "comballoc.ml", line 15, characters 13-17
+Raised by primitive operation at Comballoc.f4 in file "comballoc.ml", line 12, characters 11-20
 Called from Comballoc.test in file "comballoc.ml", line 40, characters 25-48
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
 Called from Comballoc in file "comballoc.ml", line 70, characters 2-35
@@ -25,8 +24,7 @@ Called from Comballoc.test in file "comballoc.ml", line 40, characters 25-48
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
 Called from Comballoc in file "comballoc.ml", line 70, characters 2-35
 4: 0.01 true
-Raised by primitive operation at Comballoc.f4 in file "comballoc.ml" (inlined), line 12, characters 11-20
-Called from Comballoc.f in file "comballoc.ml", line 15, characters 13-17
+Raised by primitive operation at Comballoc.f4 in file "comballoc.ml", line 12, characters 11-20
 Called from Comballoc.test in file "comballoc.ml", line 40, characters 25-48
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
 Called from Comballoc in file "comballoc.ml", line 70, characters 2-35
@@ -41,8 +39,7 @@ Called from Comballoc.test in file "comballoc.ml", line 40, characters 25-48
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
 Called from Comballoc in file "comballoc.ml", line 70, characters 2-35
 4: 0.83 true
-Raised by primitive operation at Comballoc.f4 in file "comballoc.ml" (inlined), line 12, characters 11-20
-Called from Comballoc.f in file "comballoc.ml", line 15, characters 13-17
+Raised by primitive operation at Comballoc.f4 in file "comballoc.ml", line 12, characters 11-20
 Called from Comballoc.test in file "comballoc.ml", line 40, characters 25-48
 Called from Stdlib__list.iter in file "list.ml", line 110, characters 12-15
 Called from Comballoc in file "comballoc.ml", line 70, characters 2-35


### PR DESCRIPTION
A variant where the cases are known to be not bottom for both blocks and immediates like a known option, would be considered `Invalid` for `prove_is_a_tagged_immediate`, which is equivalent to saying that `meet this_type any_tagged_immediate` returns Bottom. This could not trigger anything really serious right now since it is only used for unboxing_decision, but could be.

Bottom blocks with unknown immediates is also considered `Unknown` which I think it shouldn't at least for our use case.

`prove_is_int` has the same problem. But the code is almost identical: should I factorise it instead ?