### PR TITLE
Apply Import_map lazily

### DIFF
--- a/.depend
+++ b/.depend
@@ -4263,7 +4263,7 @@ middle_end/flambda/basic/effects_and_coeffects.cmi : \
     middle_end/flambda/basic/coeffects.cmi
 middle_end/flambda/basic/exn_continuation.cmo : \
     middle_end/flambda/basic/simple.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     utils/misc.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
@@ -4274,7 +4274,7 @@ middle_end/flambda/basic/exn_continuation.cmo : \
     middle_end/flambda/basic/exn_continuation.cmi
 middle_end/flambda/basic/exn_continuation.cmx : \
     middle_end/flambda/basic/simple.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     utils/misc.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
@@ -4380,7 +4380,7 @@ middle_end/flambda/basic/invariant_env.cmi : \
 middle_end/flambda/basic/kinded_parameter.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/simple.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/basic/name.cmi \
@@ -4393,7 +4393,7 @@ middle_end/flambda/basic/kinded_parameter.cmo : \
 middle_end/flambda/basic/kinded_parameter.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
     middle_end/flambda/basic/simple.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/basic/name.cmx \
@@ -4448,19 +4448,19 @@ middle_end/flambda/basic/or_deleted.cmx : \
 middle_end/flambda/basic/or_deleted.cmi :
 middle_end/flambda/basic/or_variable.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/basic/or_variable.cmi
 middle_end/flambda/basic/or_variable.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/basic/or_variable.cmi
 middle_end/flambda/basic/or_variable.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/naming/name_occurrences.cmi
 middle_end/flambda/basic/recursive.cmo : \
     middle_end/flambda/basic/recursive.cmi
@@ -4506,10 +4506,10 @@ middle_end/flambda/basic/set_of_closures_origin.cmi : \
     utils/identifiable.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi
 middle_end/flambda/basic/simple.cmo : \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/compilenv_deps/reg_width_things.cmi \
     middle_end/flambda/basic/reg_width_const.cmi \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/basic/name.cmi \
@@ -4518,10 +4518,10 @@ middle_end/flambda/basic/simple.cmo : \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/basic/simple.cmi
 middle_end/flambda/basic/simple.cmx : \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/compilenv_deps/reg_width_things.cmx \
     middle_end/flambda/basic/reg_width_const.cmx \
     middle_end/flambda/compilenv_deps/rec_info.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/basic/name.cmx \
@@ -4547,20 +4547,21 @@ middle_end/flambda/basic/symbol_scoping_rule.cmx : \
     middle_end/flambda/basic/symbol_scoping_rule.cmi
 middle_end/flambda/basic/symbol_scoping_rule.cmi :
 middle_end/flambda/basic/trap_action.cmo : \
-    middle_end/flambda/naming/name_permutation.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/basic/trap_action.cmi
 middle_end/flambda/basic/trap_action.cmx : \
-    middle_end/flambda/naming/name_permutation.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/basic/continuation.cmx \
     middle_end/flambda/basic/trap_action.cmi
 middle_end/flambda/basic/trap_action.cmi : \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/basic/expr_std.cmo \
     middle_end/flambda/basic/continuation.cmi
@@ -4585,6 +4586,7 @@ middle_end/flambda/cmx/contains_ids.cmo : \
 middle_end/flambda/cmx/contains_ids.cmx : \
     middle_end/flambda/cmx/ids_for_export.cmx
 middle_end/flambda/cmx/exported_code.cmo : \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     utils/misc.cmi \
@@ -4595,6 +4597,7 @@ middle_end/flambda/cmx/exported_code.cmo : \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/cmx/exported_code.cmi
 middle_end/flambda/cmx/exported_code.cmx : \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     utils/misc.cmx \
@@ -4605,6 +4608,7 @@ middle_end/flambda/cmx/exported_code.cmx : \
     middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/cmx/exported_code.cmi
 middle_end/flambda/cmx/exported_code.cmi : \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/types/kinds/flambda_arity.cmi \
     middle_end/flambda/terms/flambda.cmi \
@@ -4663,6 +4667,7 @@ middle_end/flambda/cmx/flambda_cmx_format.cmo : \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/basic/simple.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/compilenv_deps/reg_width_things.cmi \
     utils/misc.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
@@ -4678,6 +4683,7 @@ middle_end/flambda/cmx/flambda_cmx_format.cmx : \
     middle_end/flambda/basic/var_within_closure.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/basic/simple.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/compilenv_deps/reg_width_things.cmx \
     utils/misc.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
@@ -4698,7 +4704,6 @@ middle_end/flambda/cmx/ids_for_export.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/compilenv_deps/reg_width_things.cmi \
     middle_end/flambda/basic/name.cmi \
     middle_end/flambda/basic/continuation.cmi \
@@ -4708,7 +4713,6 @@ middle_end/flambda/cmx/ids_for_export.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
     middle_end/flambda/basic/var_within_closure.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
-    middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/compilenv_deps/reg_width_things.cmx \
     middle_end/flambda/basic/name.cmx \
     middle_end/flambda/basic/continuation.cmx \
@@ -4718,7 +4722,6 @@ middle_end/flambda/cmx/ids_for_export.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/compilenv_deps/reg_width_things.cmi \
     middle_end/flambda/basic/name.cmi \
     middle_end/flambda/basic/continuation.cmi \
@@ -4734,10 +4737,10 @@ middle_end/flambda/compare/compare.cmo : \
     lambda/switch.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/terms/set_of_closures.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/basic/reg_width_const.cmi \
     middle_end/flambda/basic/recursive.cmi \
     middle_end/flambda/basic/or_deleted.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/basic/name.cmi \
     middle_end/flambda/basic/mutability.cmi \
     utils/misc.cmi \
@@ -4771,10 +4774,10 @@ middle_end/flambda/compare/compare.cmx : \
     lambda/switch.cmx \
     middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/terms/set_of_closures.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/basic/reg_width_const.cmx \
     middle_end/flambda/basic/recursive.cmx \
     middle_end/flambda/basic/or_deleted.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/basic/name.cmx \
     middle_end/flambda/basic/mutability.cmx \
     utils/misc.cmx \
@@ -5256,8 +5259,8 @@ middle_end/flambda/inlining/inlining_transforms.cmo : \
     middle_end/flambda/basic/trap_action.cmi \
     middle_end/flambda/simplify/simplify_import.cmi \
     middle_end/flambda/basic/simple.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/types/inlining/inlining_state.cmi \
@@ -5275,8 +5278,8 @@ middle_end/flambda/inlining/inlining_transforms.cmx : \
     middle_end/flambda/basic/trap_action.cmx \
     middle_end/flambda/simplify/simplify_import.cmx \
     middle_end/flambda/basic/simple.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/compilenv_deps/rec_info.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/basic/kinded_parameter.cmx \
     middle_end/flambda/types/inlining/inlining_state.cmx \
@@ -5433,27 +5436,27 @@ middle_end/flambda/lifting/sort_lifted_constants.cmx : \
 middle_end/flambda/lifting/sort_lifted_constants.cmi : \
     middle_end/flambda/simplify/simplify_import.cmi
 middle_end/flambda/naming/bindable.cmo : \
+    middle_end/flambda/naming/renaming.cmi \
     utils/printing_cache.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     utils/identifiable.cmi \
     middle_end/flambda/naming/contains_names.cmo \
     middle_end/flambda/cmx/contains_ids.cmo
 middle_end/flambda/naming/bindable.cmx : \
+    middle_end/flambda/naming/renaming.cmx \
     utils/printing_cache.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     utils/identifiable.cmx \
     middle_end/flambda/naming/contains_names.cmx \
     middle_end/flambda/cmx/contains_ids.cmx
 middle_end/flambda/naming/bindable_continuation.cmo : \
-    middle_end/flambda/naming/name_permutation.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/naming/bindable_continuation.cmi
 middle_end/flambda/naming/bindable_continuation.cmx : \
-    middle_end/flambda/naming/name_permutation.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/basic/continuation.cmx \
@@ -5462,13 +5465,13 @@ middle_end/flambda/naming/bindable_continuation.cmi : \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/naming/bindable.cmo
 middle_end/flambda/naming/bindable_exn_continuation.cmo : \
-    middle_end/flambda/naming/name_permutation.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/basic/exn_continuation.cmi \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/naming/bindable_exn_continuation.cmi
 middle_end/flambda/naming/bindable_exn_continuation.cmx : \
-    middle_end/flambda/naming/name_permutation.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/basic/exn_continuation.cmx \
     middle_end/flambda/basic/continuation.cmx \
@@ -5480,7 +5483,7 @@ middle_end/flambda/naming/bindable_let_bound.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
     middle_end/flambda/basic/symbol_scoping_rule.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     utils/misc.cmi \
@@ -5492,7 +5495,7 @@ middle_end/flambda/naming/bindable_let_bound.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
     middle_end/flambda/naming/var_in_binding_pos.cmx \
     middle_end/flambda/basic/symbol_scoping_rule.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     utils/misc.cmx \
@@ -5510,14 +5513,14 @@ middle_end/flambda/naming/bindable_let_bound.cmi : \
     middle_end/flambda/naming/bindable.cmo
 middle_end/flambda/naming/bindable_variable_in_terms.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/naming/bindable_variable_in_terms.cmi
 middle_end/flambda/naming/bindable_variable_in_terms.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
@@ -5527,14 +5530,14 @@ middle_end/flambda/naming/bindable_variable_in_terms.cmi : \
     middle_end/flambda/naming/bindable.cmo
 middle_end/flambda/naming/bindable_variable_in_types.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/naming/bindable_variable_in_types.cmi
 middle_end/flambda/naming/bindable_variable_in_types.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
@@ -5543,14 +5546,14 @@ middle_end/flambda/naming/bindable_variable_in_types.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/naming/bindable.cmo
 middle_end/flambda/naming/contains_names.cmo : \
-    middle_end/flambda/naming/name_permutation.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/naming/name_occurrences.cmi
 middle_end/flambda/naming/contains_names.cmx : \
-    middle_end/flambda/naming/name_permutation.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/naming/name_occurrences.cmx
 middle_end/flambda/naming/name_abstraction.cmo : \
+    middle_end/flambda/naming/renaming.cmi \
     utils/printing_cache.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     utils/misc.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
@@ -5560,8 +5563,8 @@ middle_end/flambda/naming/name_abstraction.cmo : \
     middle_end/flambda/naming/bindable.cmo \
     middle_end/flambda/naming/name_abstraction.cmi
 middle_end/flambda/naming/name_abstraction.cmx : \
+    middle_end/flambda/naming/renaming.cmx \
     utils/printing_cache.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     utils/misc.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
@@ -5613,8 +5616,8 @@ middle_end/flambda/naming/name_mode.cmi : \
 middle_end/flambda/naming/name_occurrences.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/var_within_closure.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/naming/num_occurrences.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/basic/name.cmi \
     utils/misc.cmi \
@@ -5627,8 +5630,8 @@ middle_end/flambda/naming/name_occurrences.cmo : \
 middle_end/flambda/naming/name_occurrences.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
     middle_end/flambda/basic/var_within_closure.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/naming/num_occurrences.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/basic/name.cmx \
     utils/misc.cmx \
@@ -5642,34 +5645,12 @@ middle_end/flambda/naming/name_occurrences.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/naming/num_occurrences.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/basic/name.cmi \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/basic/code_id_or_symbol.cmi \
-    middle_end/flambda/basic/code_id.cmi
-middle_end/flambda/naming/name_permutation.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/naming/permutation.cmi \
-    middle_end/flambda/basic/name.cmi \
-    middle_end/flambda/basic/continuation.cmi \
-    middle_end/flambda/basic/code_id.cmi \
-    middle_end/flambda/naming/name_permutation.cmi
-middle_end/flambda/naming/name_permutation.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/compilenv_deps/symbol.cmx \
-    middle_end/flambda/naming/permutation.cmx \
-    middle_end/flambda/basic/name.cmx \
-    middle_end/flambda/basic/continuation.cmx \
-    middle_end/flambda/basic/code_id.cmx \
-    middle_end/flambda/naming/name_permutation.cmi
-middle_end/flambda/naming/name_permutation.cmi : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/basic/name.cmi \
-    middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/basic/code_id.cmi
 middle_end/flambda/naming/num_occurrences.cmo : \
     middle_end/flambda/naming/num_occurrences.cmi
@@ -5684,10 +5665,39 @@ middle_end/flambda/naming/permutation.cmx : \
     middle_end/flambda/naming/permutation.cmi
 middle_end/flambda/naming/permutation.cmi : \
     utils/identifiable.cmi
+middle_end/flambda/naming/renaming.cmo : \
+    middle_end/flambda/compilenv_deps/variable.cmi \
+    middle_end/flambda/compilenv_deps/symbol.cmi \
+    middle_end/flambda/compilenv_deps/reg_width_things.cmi \
+    middle_end/flambda/naming/permutation.cmi \
+    middle_end/flambda/basic/name.cmi \
+    middle_end/flambda/cmx/ids_for_export.cmi \
+    middle_end/flambda/basic/continuation.cmi \
+    middle_end/flambda/basic/code_id.cmi \
+    middle_end/flambda/naming/renaming.cmi
+middle_end/flambda/naming/renaming.cmx : \
+    middle_end/flambda/compilenv_deps/variable.cmx \
+    middle_end/flambda/compilenv_deps/symbol.cmx \
+    middle_end/flambda/compilenv_deps/reg_width_things.cmx \
+    middle_end/flambda/naming/permutation.cmx \
+    middle_end/flambda/basic/name.cmx \
+    middle_end/flambda/cmx/ids_for_export.cmx \
+    middle_end/flambda/basic/continuation.cmx \
+    middle_end/flambda/basic/code_id.cmx \
+    middle_end/flambda/naming/renaming.cmi
+middle_end/flambda/naming/renaming.cmi : \
+    middle_end/flambda/compilenv_deps/variable.cmi \
+    middle_end/flambda/basic/var_within_closure.cmi \
+    middle_end/flambda/compilenv_deps/symbol.cmi \
+    middle_end/flambda/compilenv_deps/reg_width_things.cmi \
+    middle_end/flambda/basic/name.cmi \
+    middle_end/flambda/cmx/ids_for_export.cmi \
+    middle_end/flambda/basic/continuation.cmi \
+    middle_end/flambda/basic/code_id.cmi
 middle_end/flambda/naming/var_in_binding_pos.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/simple.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     utils/misc.cmi \
@@ -5696,7 +5706,7 @@ middle_end/flambda/naming/var_in_binding_pos.cmo : \
 middle_end/flambda/naming/var_in_binding_pos.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
     middle_end/flambda/basic/simple.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     utils/misc.cmx \
@@ -5709,14 +5719,14 @@ middle_end/flambda/naming/var_in_binding_pos.cmi : \
     utils/identifiable.cmi \
     middle_end/flambda/naming/contains_names.cmo
 middle_end/flambda/naming/with_delayed_permutation.cmo : \
+    middle_end/flambda/naming/renaming.cmi \
     utils/printing_cache.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/contains_names.cmo \
     middle_end/flambda/naming/with_delayed_permutation.cmi
 middle_end/flambda/naming/with_delayed_permutation.cmx : \
+    middle_end/flambda/naming/renaming.cmx \
     utils/printing_cache.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/contains_names.cmx \
     middle_end/flambda/naming/with_delayed_permutation.cmi
@@ -6940,7 +6950,6 @@ middle_end/flambda/simplify/simplify_unary_primitive.cmo : \
     middle_end/flambda/basic/simple.cmi \
     utils/numbers.cmi \
     middle_end/flambda/simplify/typing_helpers/number_adjuncts.cmi \
-    middle_end/flambda/naming/name_in_binding_pos.cmi \
     middle_end/flambda/basic/name.cmi \
     middle_end/flambda/basic/closure_id.cmi \
     middle_end/flambda/simplify/simplify_unary_primitive.cmi
@@ -6955,7 +6964,6 @@ middle_end/flambda/simplify/simplify_unary_primitive.cmx : \
     middle_end/flambda/basic/simple.cmx \
     utils/numbers.cmx \
     middle_end/flambda/simplify/typing_helpers/number_adjuncts.cmx \
-    middle_end/flambda/naming/name_in_binding_pos.cmx \
     middle_end/flambda/basic/name.cmx \
     middle_end/flambda/basic/closure_id.cmx \
     middle_end/flambda/simplify/simplify_unary_primitive.cmi
@@ -7473,7 +7481,7 @@ middle_end/flambda/simplify/typing_helpers/one_continuation_use.cmi : \
 middle_end/flambda/terms/apply_cont_expr.cmo : \
     middle_end/flambda/basic/trap_action.cmi \
     middle_end/flambda/basic/simple.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     utils/misc.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
@@ -7485,7 +7493,7 @@ middle_end/flambda/terms/apply_cont_expr.cmo : \
 middle_end/flambda/terms/apply_cont_expr.cmx : \
     middle_end/flambda/basic/trap_action.cmx \
     middle_end/flambda/basic/simple.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     utils/misc.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
@@ -7504,7 +7512,7 @@ middle_end/flambda/terms/apply_cont_expr.cmi : \
     middle_end/flambda/cmx/contains_ids.cmo
 middle_end/flambda/terms/apply_expr.cmo : \
     middle_end/flambda/basic/simple.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     utils/misc.cmi \
     middle_end/flambda/basic/invariant_env.cmi \
@@ -7522,7 +7530,7 @@ middle_end/flambda/terms/apply_expr.cmo : \
     middle_end/flambda/terms/apply_expr.cmi
 middle_end/flambda/terms/apply_expr.cmx : \
     middle_end/flambda/basic/simple.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     utils/misc.cmx \
     middle_end/flambda/basic/invariant_env.cmx \
@@ -7552,7 +7560,7 @@ middle_end/flambda/terms/apply_expr.cmi : \
     middle_end/flambda/terms/call_kind.cmi
 middle_end/flambda/terms/bound_symbols.cmo : \
     middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     utils/misc.cmi \
@@ -7563,7 +7571,7 @@ middle_end/flambda/terms/bound_symbols.cmo : \
     middle_end/flambda/terms/bound_symbols.cmi
 middle_end/flambda/terms/bound_symbols.cmx : \
     middle_end/flambda/compilenv_deps/symbol.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     utils/misc.cmx \
@@ -7581,7 +7589,7 @@ middle_end/flambda/terms/bound_symbols.cmi : \
     middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/terms/call_kind.cmo : \
     middle_end/flambda/basic/simple.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     utils/misc.cmi \
@@ -7594,7 +7602,7 @@ middle_end/flambda/terms/call_kind.cmo : \
     middle_end/flambda/terms/call_kind.cmi
 middle_end/flambda/terms/call_kind.cmx : \
     middle_end/flambda/basic/simple.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     utils/misc.cmx \
@@ -7613,39 +7621,33 @@ middle_end/flambda/terms/call_kind.cmi : \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/terms/code.rec.cmo : \
-    middle_end/flambda/compilenv_deps/variable.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/basic/recursive.cmi \
     utils/printing_cache.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/basic/or_deleted.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
-    middle_end/flambda/basic/name.cmi \
     utils/misc.cmi \
     middle_end/flambda/basic/inline_attribute.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/types/kinds/flambda_arity.cmi \
-    middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/terms/code.rec.cmi
 middle_end/flambda/terms/code.rec.cmx : \
-    middle_end/flambda/compilenv_deps/variable.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/basic/recursive.cmx \
     utils/printing_cache.cmx \
     middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/basic/or_deleted.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
-    middle_end/flambda/basic/name.cmx \
     utils/misc.cmx \
     middle_end/flambda/basic/inline_attribute.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/types/kinds/flambda_arity.cmx \
-    middle_end/flambda/basic/continuation.cmx \
     middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/terms/code.rec.cmi
 middle_end/flambda/terms/code.rec.cmi : \
@@ -7662,11 +7664,11 @@ middle_end/flambda/terms/code.rec.cmi : \
 middle_end/flambda/terms/continuation_handler.rec.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/simple.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/basic/recursive.cmi \
     utils/printing_cache.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/naming/num_occurrences.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_abstraction.cmi \
     utils/misc.cmi \
@@ -7679,11 +7681,11 @@ middle_end/flambda/terms/continuation_handler.rec.cmo : \
 middle_end/flambda/terms/continuation_handler.rec.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
     middle_end/flambda/basic/simple.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/basic/recursive.cmx \
     utils/printing_cache.cmx \
     middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/naming/num_occurrences.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_abstraction.cmx \
     utils/misc.cmx \
@@ -7706,14 +7708,14 @@ middle_end/flambda/terms/continuation_handler.rec.cmi : \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/cmx/contains_ids.cmo
 middle_end/flambda/terms/continuation_handlers.rec.cmo : \
-    middle_end/flambda/naming/name_permutation.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     utils/misc.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/terms/continuation_handlers.rec.cmi
 middle_end/flambda/terms/continuation_handlers.rec.cmx : \
-    middle_end/flambda/naming/name_permutation.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     utils/misc.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
@@ -7770,8 +7772,8 @@ middle_end/flambda/terms/expr.rec.cmo : \
     middle_end/flambda/terms/switch_expr.cmi \
     lambda/switch.cmi \
     middle_end/flambda/basic/simple.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     utils/printing_cache.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     utils/misc.cmi \
@@ -7787,8 +7789,8 @@ middle_end/flambda/terms/expr.rec.cmx : \
     middle_end/flambda/terms/switch_expr.cmx \
     lambda/switch.cmx \
     middle_end/flambda/basic/simple.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     utils/printing_cache.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     utils/misc.cmx \
@@ -7820,6 +7822,7 @@ middle_end/flambda/terms/flambda.cmo : \
     middle_end/flambda/terms/switch_expr.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/terms/set_of_closures.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/basic/reg_width_const.cmi \
     middle_end/flambda/basic/recursive.cmi \
     utils/printing_cache.cmi \
@@ -7828,7 +7831,6 @@ middle_end/flambda/terms/flambda.cmo : \
     middle_end/flambda/basic/or_deleted.cmi \
     utils/numbers.cmi \
     middle_end/flambda/naming/num_occurrences.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/naming/name_abstraction.cmi \
@@ -7875,6 +7877,7 @@ middle_end/flambda/terms/flambda.cmx : \
     middle_end/flambda/terms/switch_expr.cmx \
     middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/terms/set_of_closures.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/basic/reg_width_const.cmx \
     middle_end/flambda/basic/recursive.cmx \
     utils/printing_cache.cmx \
@@ -7883,7 +7886,6 @@ middle_end/flambda/terms/flambda.cmx : \
     middle_end/flambda/basic/or_deleted.cmx \
     utils/numbers.cmx \
     middle_end/flambda/naming/num_occurrences.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/naming/name_abstraction.cmx \
@@ -8024,8 +8026,8 @@ middle_end/flambda/terms/flambda_unit.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
     utils/misc.cmi \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/basic/continuation.cmi \
@@ -8037,8 +8039,8 @@ middle_end/flambda/terms/flambda_unit.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
     middle_end/flambda/basic/var_within_closure.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/types/basic/or_unknown.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
     utils/misc.cmx \
     middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/basic/continuation.cmx \
@@ -8055,8 +8057,8 @@ middle_end/flambda/terms/flambda_unit.cmi : \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/terms/function_declaration.cmo : \
+    middle_end/flambda/naming/renaming.cmi \
     utils/printing_cache.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
@@ -8065,8 +8067,8 @@ middle_end/flambda/terms/function_declaration.cmo : \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/terms/function_declaration.cmi
 middle_end/flambda/terms/function_declaration.cmx : \
+    middle_end/flambda/naming/renaming.cmx \
     utils/printing_cache.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
@@ -8171,10 +8173,10 @@ middle_end/flambda/terms/let_expr.rec.cmo : \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/terms/set_of_closures.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     utils/printing_cache.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/naming/num_occurrences.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/naming/name_abstraction.cmi \
@@ -8196,10 +8198,10 @@ middle_end/flambda/terms/let_expr.rec.cmx : \
     middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/terms/set_of_closures.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     utils/printing_cache.cmx \
     middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/naming/num_occurrences.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/naming/name_abstraction.cmx \
@@ -8304,6 +8306,7 @@ middle_end/flambda/terms/recursive_let_cont_handlers.rec.cmi : \
 middle_end/flambda/terms/set_of_closures.cmo : \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/basic/simple.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     utils/printing_cache.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     utils/misc.cmi \
@@ -8315,6 +8318,7 @@ middle_end/flambda/terms/set_of_closures.cmo : \
 middle_end/flambda/terms/set_of_closures.cmx : \
     middle_end/flambda/basic/var_within_closure.cmx \
     middle_end/flambda/basic/simple.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     utils/printing_cache.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     utils/misc.cmx \
@@ -8339,10 +8343,10 @@ middle_end/flambda/terms/static_const.rec.cmo : \
     lambda/tag.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/terms/set_of_closures.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     utils/printing_cache.cmi \
     middle_end/flambda/basic/or_variable.cmi \
     utils/numbers.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/basic/mutability.cmi \
@@ -8363,10 +8367,10 @@ middle_end/flambda/terms/static_const.rec.cmx : \
     lambda/tag.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/terms/set_of_closures.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     utils/printing_cache.cmx \
     middle_end/flambda/basic/or_variable.cmx \
     utils/numbers.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/basic/mutability.cmx \
@@ -8423,7 +8427,7 @@ middle_end/flambda/terms/symbol_projection.cmo : \
     middle_end/flambda/basic/var_within_closure.cmi \
     utils/targetint.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
@@ -8433,7 +8437,7 @@ middle_end/flambda/terms/symbol_projection.cmx : \
     middle_end/flambda/basic/var_within_closure.cmx \
     utils/targetint.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
@@ -8859,6 +8863,7 @@ middle_end/flambda/types/flambda_type.cmo : \
     middle_end/flambda/types/structures/set_of_closures_contents.cmi \
     middle_end/flambda/basic/scope.cmi \
     middle_end/flambda/types/structures/row_like_maps_to_intf.cmo \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/basic/reg_width_const.cmi \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
     middle_end/flambda/types/structures/product_intf.cmo \
@@ -8867,7 +8872,6 @@ middle_end/flambda/types/flambda_type.cmo : \
     middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
     utils/numbers.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/naming/name_in_binding_pos.cmi \
@@ -8912,6 +8916,7 @@ middle_end/flambda/types/flambda_type.cmx : \
     middle_end/flambda/types/structures/set_of_closures_contents.cmx \
     middle_end/flambda/basic/scope.cmx \
     middle_end/flambda/types/structures/row_like_maps_to_intf.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/basic/reg_width_const.cmx \
     middle_end/flambda/compilenv_deps/rec_info.cmx \
     middle_end/flambda/types/structures/product_intf.cmx \
@@ -8920,7 +8925,6 @@ middle_end/flambda/types/flambda_type.cmx : \
     middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/types/basic/or_bottom.cmx \
     utils/numbers.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/naming/name_in_binding_pos.cmx \
@@ -8957,6 +8961,7 @@ middle_end/flambda/types/flambda_type.cmi : \
     middle_end/flambda/types/basic/string_info.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/basic/scope.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/basic/reg_width_const.cmi \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
     utils/printing_cache.cmi \
@@ -8995,12 +9000,12 @@ middle_end/flambda/types/type_descr.rec.cmo : \
     middle_end/flambda/naming/with_delayed_permutation.cmi \
     middle_end/flambda/types/type_head_intf.cmo \
     middle_end/flambda/basic/simple.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/basic/reg_width_const.cmi \
     utils/printing_cache.cmi \
     middle_end/flambda/types/basic/or_unknown_or_bottom.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     utils/misc.cmi \
@@ -9012,12 +9017,12 @@ middle_end/flambda/types/type_descr.rec.cmx : \
     middle_end/flambda/naming/with_delayed_permutation.cmx \
     middle_end/flambda/types/type_head_intf.cmx \
     middle_end/flambda/basic/simple.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/basic/reg_width_const.cmx \
     utils/printing_cache.cmx \
     middle_end/flambda/types/basic/or_unknown_or_bottom.cmx \
     middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/types/basic/or_bottom.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     utils/misc.cmx \
@@ -9059,12 +9064,12 @@ middle_end/flambda/types/type_grammar.rec.cmo : \
     middle_end/flambda/types/basic/string_info.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/types/structures/set_of_closures_contents.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/basic/reg_width_const.cmi \
     utils/printing_cache.cmi \
     middle_end/flambda/types/basic/or_unknown_or_bottom.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/basic/name.cmi \
@@ -9082,12 +9087,12 @@ middle_end/flambda/types/type_grammar.rec.cmx : \
     middle_end/flambda/types/basic/string_info.cmx \
     middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/types/structures/set_of_closures_contents.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/basic/reg_width_const.cmx \
     utils/printing_cache.cmx \
     middle_end/flambda/types/basic/or_unknown_or_bottom.cmx \
     middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/types/basic/or_bottom.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/basic/name.cmx \
@@ -9209,6 +9214,7 @@ middle_end/flambda/types/basic/or_unknown.cmx : \
     utils/clflags.cmx \
     middle_end/flambda/types/basic/or_unknown.cmi
 middle_end/flambda/types/basic/or_unknown.cmi : \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     utils/identifiable.cmi
@@ -9289,6 +9295,7 @@ middle_end/flambda/types/basic/var_within_closure_set.cmi : \
 middle_end/flambda/types/env/aliases.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/simple.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/basic/name.cmi \
     utils/misc.cmi \
@@ -9299,6 +9306,7 @@ middle_end/flambda/types/env/aliases.cmo : \
 middle_end/flambda/types/env/aliases.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
     middle_end/flambda/basic/simple.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/basic/name.cmx \
     utils/misc.cmx \
@@ -9308,6 +9316,7 @@ middle_end/flambda/types/env/aliases.cmx : \
     middle_end/flambda/types/env/aliases.cmi
 middle_end/flambda/types/env/aliases.cmi : \
     middle_end/flambda/basic/simple.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/basic/name.cmi \
     middle_end/flambda/cmx/contains_ids.cmo \
@@ -9347,6 +9356,7 @@ middle_end/flambda/types/env/typing_env.rec.cmo : \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/basic/scope.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
     utils/printing_cache.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
@@ -9370,6 +9380,7 @@ middle_end/flambda/types/env/typing_env.rec.cmx : \
     middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/basic/scope.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/compilenv_deps/rec_info.cmx \
     utils/printing_cache.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
@@ -9393,6 +9404,7 @@ middle_end/flambda/types/env/typing_env.rec.cmi : \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/basic/scope.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/naming/name_in_binding_pos.cmi \
@@ -9429,8 +9441,8 @@ middle_end/flambda/types/env/typing_env_level.rec.cmo : \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
     middle_end/flambda/terms/symbol_projection.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     utils/printing_cache.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/naming/name_in_binding_pos.cmi \
@@ -9449,8 +9461,8 @@ middle_end/flambda/types/env/typing_env_level.rec.cmx : \
     middle_end/flambda/naming/var_in_binding_pos.cmx \
     middle_end/flambda/terms/symbol_projection.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     utils/printing_cache.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/naming/name_in_binding_pos.cmx \
@@ -9531,35 +9543,35 @@ middle_end/flambda/types/structures/closures_entry.rec.cmi : \
     middle_end/flambda/types/basic/or_bottom.cmi \
     middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/types/structures/code_age_relation.cmo : \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     utils/misc.cmi \
-    middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/types/structures/code_age_relation.cmi
 middle_end/flambda/types/structures/code_age_relation.cmx : \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/types/basic/or_bottom.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     utils/misc.cmx \
-    middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
     middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/types/structures/code_age_relation.cmi
 middle_end/flambda/types/structures/code_age_relation.cmi : \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
-    middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/basic/code_id.cmi
 middle_end/flambda/types/structures/function_declaration_type.rec.cmo : \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
     middle_end/flambda/types/basic/or_unknown_or_bottom.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
-    middle_end/flambda/naming/name_permutation.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
@@ -9568,10 +9580,10 @@ middle_end/flambda/types/structures/function_declaration_type.rec.cmo : \
     middle_end/flambda/types/structures/code_age_relation.cmi \
     middle_end/flambda/types/structures/function_declaration_type.rec.cmi
 middle_end/flambda/types/structures/function_declaration_type.rec.cmx : \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/compilenv_deps/rec_info.cmx \
     middle_end/flambda/types/basic/or_unknown_or_bottom.cmx \
     middle_end/flambda/types/basic/or_bottom.cmx \
-    middle_end/flambda/naming/name_permutation.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
@@ -9589,6 +9601,7 @@ middle_end/flambda/types/structures/function_declaration_type.rec.cmi : \
 middle_end/flambda/types/structures/product.rec.cmo : \
     middle_end/flambda/basic/var_within_closure.cmi \
     utils/targetint.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/types/structures/product_intf.cmo \
     middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
@@ -9601,6 +9614,7 @@ middle_end/flambda/types/structures/product.rec.cmo : \
 middle_end/flambda/types/structures/product.rec.cmx : \
     middle_end/flambda/basic/var_within_closure.cmx \
     utils/targetint.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/types/structures/product_intf.cmx \
     middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/types/basic/or_bottom.cmx \
@@ -9619,26 +9633,28 @@ middle_end/flambda/types/structures/product.rec.cmi : \
 middle_end/flambda/types/structures/product_intf.cmo : \
     middle_end/flambda/types/structures/type_structure_intf.cmo \
     utils/targetint.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
-    middle_end/flambda/cmx/ids_for_export.cmi \
     utils/identifiable.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi
 middle_end/flambda/types/structures/product_intf.cmx : \
     middle_end/flambda/types/structures/type_structure_intf.cmx \
     utils/targetint.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/types/basic/or_bottom.cmx \
-    middle_end/flambda/cmx/ids_for_export.cmx \
     utils/identifiable.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx
 middle_end/flambda/types/structures/row_like.rec.cmo : \
+    middle_end/flambda/basic/var_within_closure.cmi \
     utils/targetint.cmi \
     middle_end/flambda/compilenv_deps/target_imm.cmi \
     middle_end/flambda/types/basic/tag_or_unknown_and_size.cmi \
     lambda/tag.cmi \
     middle_end/flambda/types/structures/set_of_closures_contents.cmi \
     middle_end/flambda/types/structures/row_like_maps_to_intf.cmo \
+    middle_end/flambda/naming/renaming.cmi \
     utils/printing_cache.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
@@ -9653,12 +9669,14 @@ middle_end/flambda/types/structures/row_like.rec.cmo : \
     utils/clflags.cmi \
     middle_end/flambda/types/structures/row_like.rec.cmi
 middle_end/flambda/types/structures/row_like.rec.cmx : \
+    middle_end/flambda/basic/var_within_closure.cmx \
     utils/targetint.cmx \
     middle_end/flambda/compilenv_deps/target_imm.cmx \
     middle_end/flambda/types/basic/tag_or_unknown_and_size.cmx \
     lambda/tag.cmx \
     middle_end/flambda/types/structures/set_of_closures_contents.cmx \
     middle_end/flambda/types/structures/row_like_maps_to_intf.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     utils/printing_cache.cmx \
     middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/types/basic/or_bottom.cmx \
@@ -9673,6 +9691,7 @@ middle_end/flambda/types/structures/row_like.rec.cmx : \
     utils/clflags.cmx \
     middle_end/flambda/types/structures/row_like.rec.cmi
 middle_end/flambda/types/structures/row_like.rec.cmi : \
+    middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/types/structures/type_structure_intf.cmo \
     utils/targetint.cmi \
     middle_end/flambda/compilenv_deps/target_imm.cmi \
@@ -9689,24 +9708,24 @@ middle_end/flambda/types/structures/row_like_maps_to_intf.cmx : \
     middle_end/flambda/types/structures/type_structure_intf.cmx
 middle_end/flambda/types/structures/set_of_closures_contents.cmo : \
     middle_end/flambda/basic/var_within_closure.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
     utils/misc.cmi \
-    middle_end/flambda/cmx/ids_for_export.cmi \
     utils/identifiable.cmi \
     middle_end/flambda/basic/closure_id.cmi \
     middle_end/flambda/types/structures/set_of_closures_contents.cmi
 middle_end/flambda/types/structures/set_of_closures_contents.cmx : \
     middle_end/flambda/basic/var_within_closure.cmx \
+    middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/types/basic/or_unknown.cmx \
     utils/misc.cmx \
-    middle_end/flambda/cmx/ids_for_export.cmx \
     utils/identifiable.cmx \
     middle_end/flambda/basic/closure_id.cmx \
     middle_end/flambda/types/structures/set_of_closures_contents.cmi
 middle_end/flambda/types/structures/set_of_closures_contents.cmi : \
     middle_end/flambda/basic/var_within_closure.cmi \
+    middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
-    middle_end/flambda/cmx/ids_for_export.cmi \
     utils/identifiable.cmi \
     middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/types/structures/type_structure_intf.cmo : \

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -206,13 +206,13 @@ MIDDLE_END_FLAMBDA_BASIC=\
   middle_end/flambda/basic/mutability.cmo \
   middle_end/flambda/naming/name_mode.cmo \
   middle_end/flambda/naming/permutation.cmo \
-  middle_end/flambda/naming/name_permutation.cmo \
+  middle_end/flambda/cmx/ids_for_export.cmo \
+  middle_end/flambda/naming/renaming.cmo \
   middle_end/flambda/naming/num_occurrences.cmo \
   middle_end/flambda/naming/name_occurrences.cmo \
   middle_end/flambda/basic/or_variable.cmo \
   middle_end/flambda/basic/simple.cmo \
   middle_end/flambda/basic/closure_id.cmo \
-  middle_end/flambda/cmx/ids_for_export.cmo \
   middle_end/flambda/cmx/contains_ids.cmo \
   middle_end/flambda/basic/kinded_parameter.cmo \
   middle_end/flambda/basic/invariant_env.cmo \

--- a/middle_end/flambda/basic/exn_continuation.ml
+++ b/middle_end/flambda/basic/exn_continuation.ml
@@ -97,11 +97,11 @@ let free_names { exn_handler; extra_args; } =
     (Name_occurrences.singleton_continuation exn_handler)
     (Simple.List.free_names extra_args)
 
-let apply_name_permutation ({ exn_handler; extra_args; } as t) perm =
-  let exn_handler' = Name_permutation.apply_continuation perm exn_handler in
+let apply_renaming ({ exn_handler; extra_args; } as t) perm =
+  let exn_handler' = Renaming.apply_continuation perm exn_handler in
   let extra_args' =
     List.map (fun ((simple, kind) as extra_arg) ->
-        let simple' = Simple.apply_name_permutation simple perm in
+        let simple' = Simple.apply_renaming simple perm in
         if simple == simple' then extra_arg
         else simple', kind)
       extra_args
@@ -127,15 +127,3 @@ let all_ids_for_export { exn_handler; extra_args; } =
       Ids_for_export.add_simple ids arg)
     (Ids_for_export.add_continuation Ids_for_export.empty exn_handler)
     extra_args
-
-let import import_map { exn_handler; extra_args; } =
-  let exn_handler =
-    Ids_for_export.Import_map.continuation import_map exn_handler
-  in
-  let extra_args =
-    List.map (fun (arg, kind) ->
-        let arg = Ids_for_export.Import_map.simple import_map arg in
-        (arg, kind))
-      extra_args
-  in
-  { exn_handler; extra_args; }

--- a/middle_end/flambda/basic/kinded_parameter.ml
+++ b/middle_end/flambda/basic/kinded_parameter.ml
@@ -69,26 +69,22 @@ let equal_kinds t1 t2 =
 let free_names ({ param = _; kind = _; } as t) =
   Name_occurrences.singleton_variable (var t) Name_mode.normal
 
-let apply_name_permutation ({ param = _; kind; } as t) perm =
-  Name.pattern_match (Name_permutation.apply_name perm (name t))
+let apply_renaming ({ param = _; kind; } as t) perm =
+  Name.pattern_match (Renaming.apply_name perm (name t))
     ~var:(fun var -> create var kind)
     ~symbol:(fun _ ->
       Misc.fatal_errorf "Illegal name permutation on [Kinded_parameter]: %a"
-        Name_permutation.print perm)
+        Renaming.print perm)
 
 let all_ids_for_export { param; kind = _; } =
   Ids_for_export.add_variable Ids_for_export.empty param
 
-let import import_map { param; kind; } =
-  let param = Ids_for_export.Import_map.variable import_map param in
-  { param; kind; }
-
 let add_to_name_permutation t ~guaranteed_fresh perm =
-  Name_permutation.add_fresh_variable perm (var t)
+  Renaming.add_fresh_variable perm (var t)
     ~guaranteed_fresh:(var guaranteed_fresh)
 
 let name_permutation t ~guaranteed_fresh =
-  add_to_name_permutation t ~guaranteed_fresh Name_permutation.empty
+  add_to_name_permutation t ~guaranteed_fresh Renaming.empty
 
 let singleton_occurrence_in_terms t =
   Name_occurrences.singleton_variable (var t) Name_mode.normal
@@ -137,6 +133,6 @@ module List = struct
       (Name_occurrences.empty)
       t
 
-  let apply_name_permutation t perm =
-    List.map (fun param -> apply_name_permutation param perm) t
+  let apply_renaming t perm =
+    List.map (fun param -> apply_renaming param perm) t
 end

--- a/middle_end/flambda/basic/or_variable.ml
+++ b/middle_end/flambda/basic/or_variable.ml
@@ -37,11 +37,11 @@ let free_names t =
   | Const _ -> Name_occurrences.empty
   | Var var -> Name_occurrences.singleton_variable var Name_mode.normal
 
-let apply_name_permutation t perm =
+let apply_renaming t perm =
   match t with
   | Const _ -> t
   | Var var ->
-    let var' = Name_permutation.apply_variable perm var in
+    let var' = Renaming.apply_variable perm var in
     if var == var' then t
     else Var var'
 

--- a/middle_end/flambda/basic/or_variable.mli
+++ b/middle_end/flambda/basic/or_variable.mli
@@ -16,6 +16,8 @@
 
 [@@@ocaml.warning "+a-30-40-41-42"]
 
+(** Values of type ['a] must not contain names! *)
+
 type 'a t =
   | Const of 'a
   | Var of Variable.t
@@ -28,4 +30,4 @@ val value_map : 'a t -> default:'b -> f:('a -> 'b) -> 'b
 
 val free_names : _ t -> Name_occurrences.t
 
-val apply_name_permutation : 'a t -> Name_permutation.t -> 'a t
+val apply_renaming : 'a t -> Renaming.t -> 'a t

--- a/middle_end/flambda/basic/simple.mli
+++ b/middle_end/flambda/basic/simple.mli
@@ -23,6 +23,8 @@ include module type of struct include Reg_width_things.Simple end
 
 include Contains_names.S with type t := t
 
+val has_rec_info : t -> bool
+
 val merge_rec_info : t -> newer_rec_info:Rec_info.t option -> t option
 
 val without_rec_info : t -> t

--- a/middle_end/flambda/basic/trap_action.mli
+++ b/middle_end/flambda/basic/trap_action.mli
@@ -50,11 +50,11 @@ module Option : sig
 
   val all_ids_for_export : t -> Ids_for_export.t
 
-  val import : Ids_for_export.Import_map.t -> t -> t
+  val apply_renaming : t -> Renaming.t -> t
 end
 
 val compare : t -> t -> int
 
 val all_ids_for_export : t -> Ids_for_export.t
 
-val import : Ids_for_export.Import_map.t -> t -> t
+val apply_renaming : t -> Renaming.t -> t

--- a/middle_end/flambda/cmx/contains_ids.ml
+++ b/middle_end/flambda/cmx/contains_ids.ml
@@ -19,8 +19,4 @@ module type S = sig
 
   (** Gather all table identifiers to export them. *)
   val all_ids_for_export : t -> Ids_for_export.t
-
-  (** Imported identifiers may have been given a different id.
-      This rewrites the element with the new ids. *)
-  val import : Ids_for_export.Import_map.t -> t -> t
 end

--- a/middle_end/flambda/cmx/exported_code.mli
+++ b/middle_end/flambda/cmx/exported_code.mli
@@ -25,6 +25,12 @@ type t
 
 include Contains_ids.S with type t := t
 
+val apply_renaming
+   : Code_id.t Code_id.Map.t
+  -> Renaming.t
+  -> t
+  -> t
+
 val print : Format.formatter -> t -> unit
 
 val empty : t

--- a/middle_end/flambda/cmx/flambda_cmx_format.ml
+++ b/middle_end/flambda/cmx/flambda_cmx_format.ml
@@ -140,7 +140,8 @@ let import_typing_env_and_code0 t =
       ~used_closure_vars
   in
   let import_simple_without_rec_info simple =
-    (* [simple] will never have [Rec_info]; see [Reg_width_things.Simple]. *)
+    (* [simple] will never have [Rec_info] since it is the [Simple] component
+       of a [Simple_data.t].  See [Reg_width_things.Simple_data]. *)
     assert (not (Simple.has_rec_info simple));
     Simple.pattern_match simple
       ~const:(fun c ->

--- a/middle_end/flambda/cmx/flambda_cmx_format.ml
+++ b/middle_end/flambda/cmx/flambda_cmx_format.ml
@@ -139,13 +139,22 @@ let import_typing_env_and_code0 t =
       ~continuations
       ~used_closure_vars
   in
-  let map_simple = Ids_for_export.Import_map.simple import_map in
+  let import_simple_without_rec_info simple =
+    (* [simple] will never have [Rec_info]; see [Reg_width_things.Simple]. *)
+    assert (not (Simple.has_rec_info simple));
+    Simple.pattern_match simple
+      ~const:(fun c ->
+        Simple.const (Ids_for_export.Import_map.const import_map c))
+      ~name:(fun n ->
+        Simple.name (Ids_for_export.Import_map.name import_map n))
+  in
   (* Then convert the simples *)
   let simples =
-    Simple.Map.filter_map (filter (Simple.import map_simple))
+    Simple.Map.filter_map
+      (filter (Simple.import import_simple_without_rec_info))
       t.table_data.simples
   in
-  let import_map =
+  let renaming =
     Ids_for_export.Import_map.create
       ~symbols
       ~variables
@@ -154,11 +163,13 @@ let import_typing_env_and_code0 t =
       ~code_ids
       ~continuations
       ~used_closure_vars
+    |> Renaming.of_import_map
   in
   let typing_env =
-    Flambda_type.Typing_env.Serializable.import import_map t.final_typing_env
+    Flambda_type.Typing_env.Serializable.apply_renaming t.final_typing_env
+      renaming
   in
-  let all_code = Exported_code.import import_map t.all_code in
+  let all_code = Exported_code.apply_renaming code_ids renaming t.all_code in
   typing_env, all_code
 
 let import_typing_env_and_code t =

--- a/middle_end/flambda/cmx/ids_for_export.mli
+++ b/middle_end/flambda/cmx/ids_for_export.mli
@@ -13,7 +13,9 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type t = {
+module Simple = Reg_width_things.Simple
+
+type t = private {
   symbols : Symbol.Set.t;
   variables : Variable.Set.t;
   simples : Simple.Set.t;
@@ -41,8 +43,6 @@ val singleton_continuation : Continuation.t -> t
 val singleton_symbol : Symbol.t -> t
 
 val from_simple : Simple.t -> t
-
-val add_const : t -> Reg_width_things.Const.t -> t
 
 val add_variable : t -> Variable.t -> t
 
@@ -73,6 +73,10 @@ module Import_map : sig
     -> used_closure_vars : Var_within_closure.Set.t
     -> t
 
+  val is_empty : t -> bool
+
+  val has_no_action : t -> bool
+
   val const : t -> Reg_width_things.Const.t -> Reg_width_things.Const.t
   val variable : t -> Variable.t -> Variable.t
   val symbol : t -> Symbol.t -> Symbol.t
@@ -81,5 +85,7 @@ module Import_map : sig
   val code_id : t -> Code_id.t -> Code_id.t
   val continuation : t -> Continuation.t -> Continuation.t
   val closure_var_is_used : t -> Var_within_closure.t -> bool
+
+  val union : t -> t -> t
 end
 

--- a/middle_end/flambda/compare/compare.ml
+++ b/middle_end/flambda/compare/compare.ml
@@ -1314,20 +1314,20 @@ let flambda_units u1 u2 =
   let ret_cont = Continuation.create ~sort:Toplevel_return () in
   let exn_cont = Continuation.create ~sort:Exn () in
   let mk_perm u =
-    let perm = Name_permutation.empty in
+    let perm = Renaming.empty in
     let perm =
-      Name_permutation.add_fresh_continuation perm
+      Renaming.add_fresh_continuation perm
         (Flambda_unit.return_continuation u) ~guaranteed_fresh:ret_cont
     in
     let perm =
-      Name_permutation.add_fresh_continuation perm
+      Renaming.add_fresh_continuation perm
         (Flambda_unit.exn_continuation u) ~guaranteed_fresh:exn_cont
     in
     perm
   in
   let env = Env.create () in
-  let body1 = Expr.apply_name_permutation (Flambda_unit.body u1) (mk_perm u1) in
-  let body2 = Expr.apply_name_permutation (Flambda_unit.body u2) (mk_perm u2) in
+  let body1 = Expr.apply_renaming (Flambda_unit.body u1) (mk_perm u1) in
+  let body2 = Expr.apply_renaming (Flambda_unit.body u2) (mk_perm u2) in
   exprs env body1 body2
   |> Comparison.map ~f:(fun body ->
        let module_symbol = Flambda_unit.module_symbol u1 in

--- a/middle_end/flambda/compilenv_deps/reg_width_things.ml
+++ b/middle_end/flambda/compilenv_deps/reg_width_things.ml
@@ -610,12 +610,11 @@ module Simple = struct
     (* [old_simple] never has [Rec_info].  See [Simple_data], above. *)
     assert (Id.flags old_simple <> simple_flags);
     let t = map old_simple in
+    (* The import converter should never affect the flags. *)
+    assert (Id.flags t <> simple_flags);
     let rec_info = data.rec_info in
-    if Rec_info.is_initial rec_info then begin
-      assert (Id.flags t <> simple_flags);
-      t
-    end else begin
-      assert (Id.flags t = simple_flags);
+    if Rec_info.is_initial rec_info then t
+    else begin
       let data : Simple_data.t = { simple = t; rec_info; } in
       Table.add !grand_table_of_simples data
     end

--- a/middle_end/flambda/compilenv_deps/reg_width_things.ml
+++ b/middle_end/flambda/compilenv_deps/reg_width_things.ml
@@ -165,12 +165,12 @@ module Variable_data = struct
     else
       let { compilation_unit = compilation_unit1;
             previous_compilation_units = previous_compilation_units1;
-            name = _; name_stamp = name_stamp1; user_visible = _; 
+            name = _; name_stamp = name_stamp1; user_visible = _;
           } = t1
       in
       let { compilation_unit = compilation_unit2;
             previous_compilation_units = previous_compilation_units2;
-            name = _; name_stamp = name_stamp2; user_visible = _; 
+            name = _; name_stamp = name_stamp2; user_visible = _;
           } = t2
       in
       let rec previous_compilation_units_match l1 l2 =
@@ -516,6 +516,9 @@ module Simple = struct
 
   let find_data t = Table.find !grand_table_of_simples t
 
+  let has_rec_info t =
+    Id.flags t = simple_flags
+
   let name n = n
   let var v = v
   let vars vars = vars
@@ -602,11 +605,20 @@ module Simple = struct
   let export t = find_data t
 
   let import map (data : exported) =
-    let simple = map data.simple in
-    let data : Simple_data.t =
-      { simple; rec_info = data.rec_info; }
-    in
-    Table.add !grand_table_of_simples data
+    (* The grand table of [Simple]s only holds those with [Rec_info]. *)
+    let old_simple = data.simple in
+    (* [old_simple] never has [Rec_info].  See [Simple_data], above. *)
+    assert (Id.flags old_simple <> simple_flags);
+    let t = map old_simple in
+    let rec_info = data.rec_info in
+    if Rec_info.is_initial rec_info then begin
+      assert (Id.flags t <> simple_flags);
+      t
+    end else begin
+      assert (Id.flags t = simple_flags);
+      let data : Simple_data.t = { simple = t; rec_info; } in
+      Table.add !grand_table_of_simples data
+    end
 
   let map_compilation_unit _f data =
     (* The compilation unit is not associated with the simple directly,

--- a/middle_end/flambda/compilenv_deps/reg_width_things.mli
+++ b/middle_end/flambda/compilenv_deps/reg_width_things.mli
@@ -158,6 +158,9 @@ module Simple : sig
 
   val with_rec_info : t -> Rec_info.t -> t
 
+  (* This does not consult the grand table of [Simple]s. *)
+  val has_rec_info : t -> bool
+
   val pattern_match
      : t
     -> name:(Name.t -> 'a)

--- a/middle_end/flambda/inlining/inlining_transforms.ml
+++ b/middle_end/flambda/inlining/inlining_transforms.ml
@@ -26,16 +26,16 @@ module VB = Var_in_binding_pos
 let make_inlined_body ~callee ~unroll_to ~params ~args ~my_closure ~body
       ~exn_continuation ~return_continuation ~apply_exn_continuation
       ~apply_return_continuation =
-  let perm = Name_permutation.empty in
+  let perm = Renaming.empty in
   let perm =
     match (apply_return_continuation : Apply.Result_continuation.t) with
     | Return k ->
-       Name_permutation.add_continuation perm
+       Renaming.add_continuation perm
          return_continuation k
     | Never_returns -> perm
   in
   let perm =
-    Name_permutation.add_continuation perm
+    Renaming.add_continuation perm
       (Exn_continuation.exn_handler exn_continuation)
       apply_exn_continuation
   in
@@ -44,7 +44,7 @@ let make_inlined_body ~callee ~unroll_to ~params ~args ~my_closure ~body
       ~newer_rec_info:(Some (Rec_info.create ~depth:1 ~unroll_to))
     |> Option.get  (* CR mshinwell: improve *)
   in
-  Expr.apply_name_permutation
+  Expr.apply_renaming
     (Expr.bind_parameters_to_args_no_simplification
        ~params ~args
        ~body:(Let.create

--- a/middle_end/flambda/naming/bindable.ml
+++ b/middle_end/flambda/naming/bindable.ml
@@ -31,13 +31,13 @@ module type S = sig
 
   val rename : t -> t
 
-  val name_permutation : t -> guaranteed_fresh:t -> Name_permutation.t
+  val name_permutation : t -> guaranteed_fresh:t -> Renaming.t
 
   val add_to_name_permutation
      : t
     -> guaranteed_fresh:t
-    -> Name_permutation.t
-    -> Name_permutation.t
+    -> Renaming.t
+    -> Renaming.t
 
   (* CR mshinwell: Check why this and [free_names] are here *)
   val singleton_occurrence_in_terms : t -> Name_occurrences.t

--- a/middle_end/flambda/naming/bindable_continuation.ml
+++ b/middle_end/flambda/naming/bindable_continuation.ml
@@ -20,19 +20,16 @@ include Continuation
 
 let free_names t = Name_occurrences.singleton_continuation t
 
-let apply_name_permutation t perm = Name_permutation.apply_continuation perm t
+let apply_renaming t perm = Renaming.apply_continuation perm t
 
 let all_ids_for_export t =
   Ids_for_export.add_continuation Ids_for_export.empty t
 
-let import import_map t =
-  Ids_for_export.Import_map.continuation import_map t
-
 let add_to_name_permutation t ~guaranteed_fresh perm =
-  Name_permutation.add_fresh_continuation perm t ~guaranteed_fresh
+  Renaming.add_fresh_continuation perm t ~guaranteed_fresh
 
 let name_permutation t ~guaranteed_fresh =
-  add_to_name_permutation t ~guaranteed_fresh Name_permutation.empty
+  add_to_name_permutation t ~guaranteed_fresh Renaming.empty
 
 let singleton_occurrence_in_terms t = Name_occurrences.singleton_continuation t
 

--- a/middle_end/flambda/naming/bindable_exn_continuation.ml
+++ b/middle_end/flambda/naming/bindable_exn_continuation.ml
@@ -19,11 +19,11 @@
 include Exn_continuation
 
 let add_to_name_permutation t ~guaranteed_fresh perm =
-  Name_permutation.add_fresh_continuation perm (exn_handler t)
+  Renaming.add_fresh_continuation perm (exn_handler t)
     ~guaranteed_fresh:(exn_handler guaranteed_fresh)
 
 let name_permutation t ~guaranteed_fresh =
-  add_to_name_permutation t ~guaranteed_fresh Name_permutation.empty
+  add_to_name_permutation t ~guaranteed_fresh Renaming.empty
 
 let singleton_occurrence_in_terms t =
   Name_occurrences.singleton_continuation (exn_handler t)

--- a/middle_end/flambda/naming/bindable_let_bound.ml
+++ b/middle_end/flambda/naming/bindable_let_bound.ml
@@ -79,23 +79,23 @@ let free_names t =
   | Symbols { bound_symbols; scoping_rule = _; } ->
     Bound_symbols.free_names bound_symbols
 
-let apply_name_permutation t perm =
+let apply_renaming t perm =
   match t with
   | Singleton var ->
-    let var' = Var_in_binding_pos.apply_name_permutation var perm in
+    let var' = Var_in_binding_pos.apply_renaming var perm in
     if var == var' then t
     else Singleton var'
   | Set_of_closures { name_mode; closure_vars; } ->
     let closure_vars' =
       Misc.Stdlib.List.map_sharing (fun var ->
-          Var_in_binding_pos.apply_name_permutation var perm)
+          Var_in_binding_pos.apply_renaming var perm)
         closure_vars
     in
     if closure_vars == closure_vars' then t
     else Set_of_closures { name_mode; closure_vars = closure_vars'; }
   | Symbols { bound_symbols; scoping_rule; } ->
     let bound_symbols' =
-      Bound_symbols.apply_name_permutation bound_symbols perm
+      Bound_symbols.apply_renaming bound_symbols perm
     in
     if bound_symbols == bound_symbols' then t
     else Symbols { scoping_rule; bound_symbols = bound_symbols'; }
@@ -113,28 +113,6 @@ let all_ids_for_export t =
   | Symbols { bound_symbols; scoping_rule = _; } ->
     Bound_symbols.all_ids_for_export bound_symbols
 
-let import import_map t =
-  match t with
-  | Singleton var ->
-    let raw_var =
-      Ids_for_export.Import_map.variable import_map (Var_in_binding_pos.var var)
-    in
-    Singleton
-      (Var_in_binding_pos.create raw_var (Var_in_binding_pos.name_mode var))
-  | Set_of_closures { name_mode; closure_vars; } ->
-    let closure_vars =
-      List.map (fun var ->
-          Var_in_binding_pos.create
-            (Ids_for_export.Import_map.variable import_map
-               (Var_in_binding_pos.var var))
-            (Var_in_binding_pos.name_mode var))
-        closure_vars
-    in
-    Set_of_closures { name_mode; closure_vars; }
-  | Symbols { bound_symbols; scoping_rule; } ->
-    let bound_symbols = Bound_symbols.import import_map bound_symbols in
-    Symbols { bound_symbols; scoping_rule; }
-
 let rename t =
   match t with
   | Singleton var -> Singleton (Var_in_binding_pos.rename var)
@@ -148,7 +126,7 @@ let rename t =
 let add_to_name_permutation t1 ~guaranteed_fresh:t2 perm =
   match t1, t2 with
   | Singleton var1, Singleton var2 ->
-    Name_permutation.add_fresh_variable perm
+    Renaming.add_fresh_variable perm
       (Var_in_binding_pos.var var1)
       ~guaranteed_fresh:(Var_in_binding_pos.var var2)
   | Set_of_closures { name_mode = _; closure_vars = closure_vars1; },
@@ -158,7 +136,7 @@ let add_to_name_permutation t1 ~guaranteed_fresh:t2 perm =
     then
       List.fold_left2
         (fun perm var1 var2 ->
-          Name_permutation.add_fresh_variable perm
+          Renaming.add_fresh_variable perm
             (Var_in_binding_pos.var var1)
             ~guaranteed_fresh:(Var_in_binding_pos.var var2))
         perm
@@ -175,7 +153,7 @@ let add_to_name_permutation t1 ~guaranteed_fresh:t2 perm =
       print t2
 
 let name_permutation t ~guaranteed_fresh =
-  add_to_name_permutation t ~guaranteed_fresh Name_permutation.empty
+  add_to_name_permutation t ~guaranteed_fresh Renaming.empty
 
 let singleton_occurrence_in_terms t = free_names t
 

--- a/middle_end/flambda/naming/bindable_variable_in_terms.ml
+++ b/middle_end/flambda/naming/bindable_variable_in_terms.ml
@@ -23,21 +23,18 @@ let print_with_cache ~cache:_ ppf t = print ppf t
 let free_names t =
   Name_occurrences.singleton_variable t Name_mode.normal
 
-let apply_name_permutation t perm = Name_permutation.apply_variable perm t
+let apply_renaming t perm = Renaming.apply_variable perm t
 
 let all_ids_for_export t =
   Ids_for_export.add_variable Ids_for_export.empty t
 
-let import import_map t =
-  Ids_for_export.Import_map.variable import_map t
-
 let rename t = rename t
 
 let add_to_name_permutation t ~guaranteed_fresh perm =
-  Name_permutation.add_fresh_variable perm t ~guaranteed_fresh
+  Renaming.add_fresh_variable perm t ~guaranteed_fresh
 
 let name_permutation t1 ~guaranteed_fresh =
-  add_to_name_permutation t1 ~guaranteed_fresh Name_permutation.empty
+  add_to_name_permutation t1 ~guaranteed_fresh Renaming.empty
 
 let singleton_occurrence_in_terms t =
   Name_occurrences.singleton_variable t Name_mode.normal

--- a/middle_end/flambda/naming/bindable_variable_in_types.ml
+++ b/middle_end/flambda/naming/bindable_variable_in_types.ml
@@ -23,21 +23,18 @@ let print_with_cache ~cache:_ ppf t = print ppf t
 let free_names t =
   Name_occurrences.singleton_variable t Name_mode.in_types
 
-let apply_name_permutation t perm = Name_permutation.apply_variable perm t
+let apply_renaming t perm = Renaming.apply_variable perm t
 
 let all_ids_for_export t =
   Ids_for_export.add_variable Ids_for_export.empty t
 
-let import import_map t =
-  Ids_for_export.Import_map.variable import_map t
-
 let rename t = rename t
 
 let add_to_name_permutation t ~guaranteed_fresh perm =
-  Name_permutation.add_fresh_variable perm t ~guaranteed_fresh
+  Renaming.add_fresh_variable perm t ~guaranteed_fresh
 
 let name_permutation t ~guaranteed_fresh =
-  add_to_name_permutation t ~guaranteed_fresh Name_permutation.empty
+  add_to_name_permutation t ~guaranteed_fresh Renaming.empty
 
 (* CR mshinwell: These shouldn't have "in_terms" on their names *)
 let singleton_occurrence_in_terms t =

--- a/middle_end/flambda/naming/contains_names.ml
+++ b/middle_end/flambda/naming/contains_names.ml
@@ -22,7 +22,7 @@ module type S = sig
   (** Compute the free names of a term.  Such computation covers all kinds
       of bindable names (variables, continuations, ...) *)
   val free_names : t -> Name_occurrences.t
- 
-  (** Permute various names throughout a term. *)
-  val apply_name_permutation : t -> Name_permutation.t -> t
+
+  (** Apply a renaming throughout a term. *)
+  val apply_renaming : t -> Renaming.t -> t
 end

--- a/middle_end/flambda/naming/name_occurrences.mli
+++ b/middle_end/flambda/naming/name_occurrences.mli
@@ -35,7 +35,7 @@ val print : Format.formatter -> t -> unit
 
 val equal : t -> t -> bool
 
-val apply_name_permutation : t -> Name_permutation.t -> t
+val apply_renaming : t -> Renaming.t -> t
 
 val singleton_continuation : Continuation.t -> t
 
@@ -197,12 +197,3 @@ val fold_code_ids
   -> init:'a
   -> f:('a -> Code_id.t -> 'a)
   -> 'a
-
-(** [import] cannot use [Ids_for_export] due to a circular dependency through
-    [Simple]. *)
-val import
-   : t
-  -> import_name:(Name.t -> Name.t)
-  -> import_continuation:(Continuation.t -> Continuation.t)
-  -> import_code_id:(Code_id.t -> Code_id.t)
-  -> t

--- a/middle_end/flambda/naming/renaming.ml
+++ b/middle_end/flambda/naming/renaming.ml
@@ -2,11 +2,11 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*    Pierre Chambart and Guillaume Bury, OCamlPro                        *)
+(*           Pierre Chambart and Guillaume Bury, OCamlPro                 *)
 (*           Mark Shinwell and Leo White, Jane Street Europe              *)
 (*                                                                        *)
-(*   Copyright 2018--2019 OCamlPro SAS                                    *)
-(*   Copyright 2018--2019 Jane Street Group LLC                           *)
+(*   Copyright 2018--2021 OCamlPro SAS                                    *)
+(*   Copyright 2018--2021 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -14,7 +14,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-[@@@ocaml.warning "+a-4-30-40-41-42-55"]
+[@@@ocaml.warning "+a-30-40-41-42-55"]
 
 (* CR mshinwell: Disabling warning 55 is required to satisfy Closure, work
    out something better... *)
@@ -24,11 +24,15 @@ module Variables = (Permutation.Make [@inlined hint]) (Variable)
 module Code_ids = (Permutation.Make [@inlined hint]) (Code_id)
 module Symbols = (Permutation.Make [@inlined hint]) (Symbol)
 
+module Import_map = Ids_for_export.Import_map
+module Simple = Reg_width_things.Simple
+
 type t = {
   continuations : Continuations.t;
   variables : Variables.t;
   code_ids : Code_ids.t;
   symbols : Symbols.t;
+  import_map : Import_map.t option;
 }
 
 let empty =
@@ -36,13 +40,19 @@ let empty =
     variables = Variables.empty;
     code_ids = Code_ids.empty;
     symbols = Symbols.empty;
+    import_map = None;
   }
 
-let print ppf { continuations; variables; code_ids; symbols; } =
+let of_import_map import_map =
+  if Import_map.is_empty import_map then empty
+  else { empty with import_map = Some import_map; }
+
+let print ppf
+      { continuations; variables; code_ids; symbols; import_map = _; } =
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(continuations@ %a)@]@ \
-      @[<hov 1>(variables@ %a)@])\
-      @[<hov 1>(code_ids@ %a)@])\
+      @[<hov 1>(variables@ %a)@])@ \
+      @[<hov 1>(code_ids@ %a)@])@ \
       @[<hov 1>(symbols@ %a)@])\
       @]"
     Continuations.print continuations
@@ -50,11 +60,25 @@ let print ppf { continuations; variables; code_ids; symbols; } =
     Code_ids.print code_ids
     Symbols.print symbols
 
-let is_empty { continuations; variables; code_ids; symbols; }  =
+let has_no_action
+      { continuations; variables; code_ids; symbols; import_map; } =
   Continuations.is_empty continuations
   && Variables.is_empty variables
   && Code_ids.is_empty code_ids
   && Symbols.is_empty symbols
+  && match import_map with
+     | None -> true
+     | Some import_map -> Import_map.has_no_action import_map
+
+let is_empty
+      { continuations; variables; code_ids; symbols; import_map; } =
+  Continuations.is_empty continuations
+  && Variables.is_empty variables
+  && Code_ids.is_empty code_ids
+  && Symbols.is_empty symbols
+  && match import_map with
+     | None -> true
+     | Some import_map -> Import_map.is_empty import_map
 
 let compose0
       ~second:
@@ -62,27 +86,35 @@ let compose0
           variables = variables2;
           code_ids = code_ids2;
           symbols = symbols2;
+          import_map = import_map2;
         }
       ~first:
         { continuations = continuations1;
           variables = variables1;
           code_ids = code_ids1;
           symbols = symbols1;
+          import_map = import_map1;
         } =
   { continuations =
       Continuations.compose ~second:continuations2 ~first:continuations1;
     variables = Variables.compose ~second:variables2 ~first:variables1;
     code_ids = Code_ids.compose ~second:code_ids2 ~first:code_ids1;
     symbols = Symbols.compose ~second:symbols2 ~first:symbols1;
+    (* The import map substitution is always to fresh names, so this doesn't
+       need a "proper" substitution composition operation. *)
+    import_map =
+      match import_map1, import_map2 with
+      | None, None -> None
+      | Some import_map, None | None, Some import_map ->
+        Some import_map
+      | Some import_map1, Some import_map2 ->
+        Some (Import_map.union import_map1 import_map2);
   }
 
 let compose ~second ~first =
   if is_empty second then first
   else if is_empty first then second
   else compose0 ~second ~first
-
-
-(* variables *)
 
 let add_variable t var1 var2 =
   { t with
@@ -96,6 +128,11 @@ let add_fresh_variable t var1 ~guaranteed_fresh:var2 =
   }
 
 let apply_variable t var =
+  let var =
+    match t.import_map with
+    | None -> var
+    | Some import_map -> Import_map.variable import_map var
+  in
   Variables.apply t.variables var
 
 let apply_variable_set t vars =
@@ -104,9 +141,6 @@ let apply_variable_set t vars =
       Variable.Set.add var result)
     vars
     Variable.Set.empty
-
-
-(* symbols *)
 
 let add_symbol t symbol1 symbol2 =
   { t with
@@ -119,6 +153,11 @@ let add_fresh_symbol t symbol1 ~guaranteed_fresh:symbol2 =
   }
 
 let apply_symbol t symbol =
+  let symbol =
+    match t.import_map with
+    | None -> symbol
+    | Some import_map -> Import_map.symbol import_map symbol
+  in
   Symbols.apply t.symbols symbol
 
 let apply_symbol_set t symbols =
@@ -128,16 +167,10 @@ let apply_symbol_set t symbols =
     symbols
     Symbol.Set.empty
 
-
-(* application of permutations *)
-
 let apply_name t name =
   Name.pattern_match name
     ~var:(fun var -> Name.var (apply_variable t var))
     ~symbol:(fun symbol -> Name.symbol (apply_symbol t symbol))
-
-
-(* continuations *)
 
 let add_continuation t k1 k2 =
   { t with
@@ -151,10 +184,12 @@ let add_fresh_continuation t k1 ~guaranteed_fresh:k2 =
   }
 
 let apply_continuation t k =
+  let k =
+    match t.import_map with
+    | None -> k
+    | Some import_map -> Import_map.continuation import_map k
+  in
   Continuations.apply t.continuations k
-
-
-(* Code ids *)
 
 let add_code_id t code_id1 code_id2 =
   { t with
@@ -167,6 +202,31 @@ let add_fresh_code_id t code_id1 ~guaranteed_fresh:code_id2 =
   }
 
 let apply_code_id t code_id =
+  let code_id =
+    match t.import_map with
+    | None -> code_id
+    | Some import_map -> Import_map.code_id import_map code_id
+  in
   Code_ids.apply t.code_ids code_id
 
+let apply_simple t simple =
+  let simple =
+    match t.import_map with
+    | None -> simple
+    | Some import_map -> Import_map.simple import_map simple
+  in
+  let [@inline always] name old_name =
+    let new_name = apply_name t old_name in
+    if old_name == new_name then simple
+    else
+      match Simple.rec_info simple with
+      | None -> Simple.name new_name
+      | Some rec_info -> Simple.with_rec_info (Simple.name new_name) rec_info
+  in
+  (* Constants are never permuted, only freshened upon import. *)
+  Simple.pattern_match simple ~const:(fun _ -> simple) ~name
 
+let closure_var_is_used t closure_var =
+  match t.import_map with
+  | None -> true  (* N.B. not false! *)
+  | Some import_map -> Import_map.closure_var_is_used import_map closure_var

--- a/middle_end/flambda/naming/renaming.mli
+++ b/middle_end/flambda/naming/renaming.mli
@@ -5,8 +5,8 @@
 (*                       Pierre Chambart, OCamlPro                        *)
 (*           Mark Shinwell and Leo White, Jane Street Europe              *)
 (*                                                                        *)
-(*   Copyright 2018--2019 OCamlPro SAS                                    *)
-(*   Copyright 2018--2019 Jane Street Group LLC                           *)
+(*   Copyright 2018--2021 OCamlPro SAS                                    *)
+(*   Copyright 2018--2021 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -14,12 +14,13 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Handling of permutations upon all kinds of bindable names.
+(** Handling of permutations and import freshening upon all kinds of
+    bindable names and other identifiers (e.g. constants).
 
     Unlike [Name_occurrences] this module does not segregate names according
     to where they occur (e.g. in terms or in types). *)
 
-[@@@ocaml.warning "+a-4-30-40-41-42"]
+[@@@ocaml.warning "+a-30-40-41-42"]
 
 type t
 
@@ -27,15 +28,16 @@ val empty : t
 
 val print : Format.formatter -> t -> unit
 
-val is_empty : t -> bool
+val has_no_action : t -> bool
 
-(** Note that [compose] is not commutative.  The result of
-    [compose ~second ~first] is that permutation acting initially like
-    [first] then subsequently like [second]. *)
+val of_import_map : Ids_for_export.Import_map.t -> t
+
+(** Note that [compose] is not commutative on the permutation component.
+    The permutation in the result of [compose ~second ~first] is that
+    permutation acting initially like [first] then subsequently like [second].
+*)
 val compose : second:t -> first:t -> t
 
-
-(** Variable bindings *)
 val add_variable : t -> Variable.t -> Variable.t -> t
 
 val add_fresh_variable : t -> Variable.t -> guaranteed_fresh:Variable.t -> t
@@ -44,8 +46,6 @@ val apply_variable : t -> Variable.t -> Variable.t
 
 val apply_variable_set : t -> Variable.Set.t -> Variable.Set.t
 
-
-(** Symbol bindings *)
 val add_symbol : t -> Symbol.t -> Symbol.t -> t
 
 val add_fresh_symbol : t -> Symbol.t -> guaranteed_fresh:Symbol.t -> t
@@ -54,12 +54,8 @@ val apply_symbol : t -> Symbol.t -> Symbol.t
 
 val apply_symbol_set : t -> Symbol.Set.t -> Symbol.Set.t
 
-
-(** Application to {Name.t} *)
 val apply_name : t -> Name.t -> Name.t
 
-
-(** Continuation bindings *)
 val add_continuation : t -> Continuation.t -> Continuation.t -> t
 
 val add_fresh_continuation
@@ -70,8 +66,6 @@ val add_fresh_continuation
 
 val apply_continuation : t -> Continuation.t -> Continuation.t
 
-
-(** Code_id bindings *)
 val add_code_id : t -> Code_id.t -> Code_id.t -> t
 
 val add_fresh_code_id
@@ -82,3 +76,7 @@ val add_fresh_code_id
 
 val apply_code_id : t -> Code_id.t -> Code_id.t
 
+val apply_simple : t -> Reg_width_things.Simple.t -> Reg_width_things.Simple.t
+
+(* See note in ids_for_export.ml. *)
+val closure_var_is_used : t -> Var_within_closure.t -> bool

--- a/middle_end/flambda/naming/var_in_binding_pos.ml
+++ b/middle_end/flambda/naming/var_in_binding_pos.ml
@@ -35,8 +35,8 @@ let with_name_mode t name_mode = { t with name_mode; }
 
 let rename t = with_var t (Variable.rename t.var)
 
-let apply_name_permutation t perm =
-  with_var t (Name_permutation.apply_variable perm t.var)
+let apply_renaming t perm =
+  with_var t (Renaming.apply_variable perm t.var)
 
 let free_names t =
   Name_occurrences.singleton_variable t.var t.name_mode

--- a/middle_end/flambda/naming/with_delayed_permutation.ml
+++ b/middle_end/flambda/naming/with_delayed_permutation.ml
@@ -31,39 +31,39 @@ module Make (Descr : sig
 end) = struct
   type t = {
     mutable descr : Descr.t;
-    mutable delayed_permutation : Name_permutation.t;
+    mutable delayed_permutation : Renaming.t;
     mutable free_names : Name_occurrences.t option;
   }
 
   let create descr =
     { descr;
-      delayed_permutation = Name_permutation.empty;
+      delayed_permutation = Renaming.empty;
       free_names = None;
     }
 
   let peek_descr t = t.descr
 
   let descr t =
-    if Name_permutation.is_empty t.delayed_permutation then begin
+    if Renaming.has_no_action t.delayed_permutation then begin
       t.descr
     end else begin
-      let descr = Descr.apply_name_permutation t.descr t.delayed_permutation in
+      let descr = Descr.apply_renaming t.descr t.delayed_permutation in
       t.descr <- descr;
       let free_names =
         match t.free_names with
         | None -> Descr.free_names descr
         | Some free_names ->
-          Name_occurrences.apply_name_permutation free_names
+          Name_occurrences.apply_renaming free_names
             t.delayed_permutation
       in
-      t.delayed_permutation <- Name_permutation.empty;
+      t.delayed_permutation <- Renaming.empty;
       t.free_names <- Some free_names;
       descr
     end
 
-  let apply_name_permutation t perm =
+  let apply_renaming t perm =
     let delayed_permutation =
-      Name_permutation.compose ~second:perm ~first:t.delayed_permutation
+      Renaming.compose ~second:perm ~first:t.delayed_permutation
     in
     { t with
       delayed_permutation;

--- a/middle_end/flambda/terms/apply_cont_expr.ml
+++ b/middle_end/flambda/terms/apply_cont_expr.ml
@@ -231,19 +231,10 @@ let free_names { k; args; trap_action; dbg=_; } =
       k
       ~has_traps:true
 
-let apply_name_permutation ({ k; args; trap_action; dbg; } as t) perm =
-  let k' = Name_permutation.apply_continuation perm k in
-  let args' = Simple.List.apply_name_permutation args perm in
-  let trap_action' =
-    match trap_action with
-    | None -> None
-    | Some trap_action' ->
-      let new_trap_action' =
-        Trap_action.apply_name_permutation trap_action' perm
-      in
-      if new_trap_action' == trap_action' then trap_action
-      else Some new_trap_action'
-  in
+let apply_renaming ({ k; args; trap_action; dbg; } as t) perm =
+  let k' = Renaming.apply_continuation perm k in
+  let args' = Simple.List.apply_renaming args perm in
+  let trap_action' = Trap_action.Option.apply_renaming trap_action perm in
   if k == k' && args == args' && trap_action == trap_action' then t
   else { k = k'; args = args'; trap_action = trap_action'; dbg; }
 
@@ -253,12 +244,6 @@ let all_ids_for_export { k; args; trap_action; dbg = _; } =
       (Trap_action.Option.all_ids_for_export trap_action)
       k)
     args
-
-let import import_map { k; args; trap_action; dbg; } =
-  let k = Ids_for_export.Import_map.continuation import_map k in
-  let args = List.map (Ids_for_export.Import_map.simple import_map) args in
-  let trap_action = Trap_action.Option.import import_map trap_action in
-  { k; args; trap_action; dbg; }
 
 let update_continuation t continuation =
   { t with k = continuation; }

--- a/middle_end/flambda/terms/bound_symbols.ml
+++ b/middle_end/flambda/terms/bound_symbols.ml
@@ -36,14 +36,14 @@ module Pattern = struct
     | Block_like symbol ->
       Format.fprintf ppf "@[<hov 1>(Block_like@ %a)@]" Symbol.print symbol
 
-  let apply_name_permutation t perm =
+  let apply_renaming t perm =
     match t with
     | Code code_id ->
-      Code (Name_permutation.apply_code_id perm code_id)
+      Code (Renaming.apply_code_id perm code_id)
     | Set_of_closures map ->
-      Set_of_closures (Closure_id.Lmap.map (Name_permutation.apply_symbol perm) map)
+      Set_of_closures (Closure_id.Lmap.map (Renaming.apply_symbol perm) map)
     | Block_like symbol ->
-      Block_like (Name_permutation.apply_symbol perm symbol)
+      Block_like (Renaming.apply_symbol perm symbol)
 
   let free_names t =
     match t with
@@ -115,17 +115,6 @@ module Pattern = struct
       in
       Ids_for_export.create ~symbols ()
     | Block_like symbol -> Ids_for_export.singleton_symbol symbol
-
-  let import import_map t =
-    let module IM = Ids_for_export.Import_map in
-    match t with
-    | Code code_id -> Code (IM.code_id import_map code_id)
-    | Set_of_closures closure_symbols ->
-      let closure_symbols =
-        Closure_id.Lmap.map (IM.symbol import_map) closure_symbols
-      in
-      Set_of_closures closure_symbols
-    | Block_like symbol -> Block_like (IM.symbol import_map symbol)
 end
 
 type t = Pattern.t list
@@ -179,8 +168,8 @@ let for_all_everything_being_defined t ~f =
     t
     f
 
-let apply_name_permutation t perm =
-  List.map (fun pattern -> Pattern.apply_name_permutation pattern perm) t
+let apply_renaming t perm =
+  List.map (fun pattern -> Pattern.apply_renaming pattern perm) t
 
 let free_names t =
   List.map Pattern.free_names t
@@ -189,8 +178,5 @@ let free_names t =
 let all_ids_for_export t =
   List.map Pattern.all_ids_for_export t
   |> Ids_for_export.union_list
-
-let import import_map t =
-  List.map (Pattern.import import_map) t
 
 let concat t1 t2 = t1 @ t2

--- a/middle_end/flambda/terms/call_kind.ml
+++ b/middle_end/flambda/terms/call_kind.ml
@@ -165,17 +165,17 @@ let free_names t =
         Name_occurrences.singleton_name obj Name_mode.normal)
       ~const:(fun _ -> Name_occurrences.empty)
 
-let apply_name_permutation t perm =
+let apply_renaming t perm =
   match t with
   | Function (Direct { code_id; closure_id; return_arity; }) ->
-    let code_id' = Name_permutation.apply_code_id perm code_id in
+    let code_id' = Renaming.apply_code_id perm code_id in
     if code_id == code_id' then t
     else Function (Direct { code_id = code_id'; closure_id; return_arity; })
   | Function Indirect_unknown_arity
   | Function (Indirect_known_arity { param_arity = _; return_arity = _; })
   | C_call { alloc = _; param_arity = _; return_arity = _; } -> t
   | Method { kind; obj; } ->
-    let obj' = Simple.apply_name_permutation obj perm in
+    let obj' = Simple.apply_renaming obj perm in
     if obj == obj' then t
     else
       Method {
@@ -193,14 +193,3 @@ let all_ids_for_export t =
     Ids_for_export.empty
   | Method { kind = _; obj; } ->
     Ids_for_export.from_simple obj
-
-let import import_map t = match t with
-  | Function (Direct { code_id; closure_id; return_arity; }) ->
-    let code_id = Ids_for_export.Import_map.code_id import_map code_id in
-    Function (Direct { code_id; closure_id; return_arity; })
-  | Function Indirect_unknown_arity
-  | Function (Indirect_known_arity { param_arity = _; return_arity = _; })
-  | C_call { alloc = _; param_arity = _; return_arity = _; } -> t
-  | Method { kind; obj; } ->
-    let obj = Ids_for_export.Import_map.simple import_map obj in
-    Method { kind; obj; }

--- a/middle_end/flambda/terms/code.rec.mli
+++ b/middle_end/flambda/terms/code.rec.mli
@@ -85,8 +85,6 @@ val print : Format.formatter -> t -> unit
 
 val all_ids_for_export : t -> Ids_for_export.t
 
-val import : Ids_for_export.Import_map.t -> t -> t
-
 val compare : t -> t -> int
 
 (* CR mshinwell: Somewhere there should be an invariant check that

--- a/middle_end/flambda/terms/continuation_handlers.rec.ml
+++ b/middle_end/flambda/terms/continuation_handlers.rec.ml
@@ -35,11 +35,11 @@ let free_names t =
     t
     (Name_occurrences.empty)
 
-let apply_name_permutation t perm =
+let apply_renaming t perm =
   Continuation.Map.fold (fun k handler result ->
-      let k = Name_permutation.apply_continuation perm k in
+      let k = Renaming.apply_continuation perm k in
       let handler =
-        Continuation_handler.apply_name_permutation handler perm
+        Continuation_handler.apply_renaming handler perm
       in
       Continuation.Map.add k handler result)
     t
@@ -53,14 +53,6 @@ let all_ids_for_export t =
           k))
     t
     Ids_for_export.empty
-
-let import import_map t =
-  Continuation.Map.fold (fun k handler t ->
-      let k = Ids_for_export.Import_map.continuation import_map k in
-      let handler = Continuation_handler.import import_map handler in
-      Continuation.Map.add k handler t)
-    t 
-    Continuation.Map.empty
 
 let domain t = Continuation.Map.keys t
 

--- a/middle_end/flambda/terms/flambda.mli
+++ b/middle_end/flambda/terms/flambda.mli
@@ -667,11 +667,9 @@ end and Code : sig
 
   val print : Format.formatter -> t -> unit
 
-  val free_names : t -> Name_occurrences.t
+  include Contains_names.S with type t := t
 
   val all_ids_for_export : t -> Ids_for_export.t
-
-  val import : Ids_for_export.Import_map.t -> t -> t
 
   val make_deleted : t -> t
 

--- a/middle_end/flambda/terms/flambda_primitive.ml
+++ b/middle_end/flambda/terms/flambda_primitive.ml
@@ -1573,16 +1573,16 @@ let free_names t =
     ]
   | Variadic (_prim, xs) -> Simple.List.free_names xs
 
-let apply_name_permutation t perm =
+let apply_renaming t perm =
   (* CR mshinwell: add phys-equal checks *)
-  let apply simple = Simple.apply_name_permutation simple perm in
+  let apply simple = Simple.apply_renaming simple perm in
   match t with
   | Nullary _ -> t
   | Unary (prim, x0) -> Unary (prim, apply x0)
   | Binary (prim, x0, x1) -> Binary (prim, apply x0, apply x1)
   | Ternary (prim, x0, x1, x2) -> Ternary (prim, apply x0, apply x1, apply x2)
   | Variadic (prim, xs) ->
-    Variadic (prim, Simple.List.apply_name_permutation xs perm)
+    Variadic (prim, Simple.List.apply_renaming xs perm)
 
 let all_ids_for_export t =
   match t with
@@ -1596,27 +1596,6 @@ let all_ids_for_export t =
       x2
   | Variadic (_prim, xs) ->
     List.fold_left Ids_for_export.add_simple Ids_for_export.empty xs
-
-let import import_map t =
-  match t with
-  | Nullary _ -> t
-  | Unary (prim, x0) ->
-    let x0 = Ids_for_export.Import_map.simple import_map x0 in
-    Unary (prim, x0)
-  | Binary (prim, x0, x1) ->
-    let x0 = Ids_for_export.Import_map.simple import_map x0 in
-    let x1 = Ids_for_export.Import_map.simple import_map x1 in
-    Binary (prim, x0, x1)
-  | Ternary (prim, x0, x1, x2) ->
-    let x0 = Ids_for_export.Import_map.simple import_map x0 in
-    let x1 = Ids_for_export.Import_map.simple import_map x1 in
-    let x2 = Ids_for_export.Import_map.simple import_map x2 in
-    Ternary (prim, x0, x1, x2)
-  | Variadic (prim, xs) ->
-    let xs =
-      List.map (Ids_for_export.Import_map.simple import_map) xs
-    in
-    Variadic (prim, xs)
 
 let args t =
   match t with
@@ -1836,7 +1815,7 @@ module Eligible_for_cse = struct
       else None
 
   let free_names = free_names
-  let apply_name_permutation = apply_name_permutation
+  let apply_renaming = apply_renaming
 
   include Identifiable.Make (struct
     type nonrec t = t

--- a/middle_end/flambda/terms/flambda_unit.ml
+++ b/middle_end/flambda/terms/flambda_unit.ml
@@ -60,12 +60,12 @@ let print ppf
 
 let invariant _t = ()
 
-let apply_name_permutation { return_continuation; exn_continuation;
+let apply_renaming { return_continuation; exn_continuation;
                              body; module_symbol; used_closure_vars; } perm =
-  let body = Expr.apply_name_permutation body perm in
-  let module_symbol = Name_permutation.apply_symbol perm module_symbol in
-  let return_continuation = Name_permutation.apply_continuation perm return_continuation in
-  let exn_continuation = Name_permutation.apply_continuation perm exn_continuation in
+  let body = Expr.apply_renaming body perm in
+  let module_symbol = Renaming.apply_symbol perm module_symbol in
+  let return_continuation = Renaming.apply_continuation perm return_continuation in
+  let exn_continuation = Renaming.apply_continuation perm exn_continuation in
   create ~return_continuation ~exn_continuation ~body ~module_symbol ~used_closure_vars
 
 let permute_everything t =
@@ -73,12 +73,12 @@ let permute_everything t =
      that are not the module symbol can be safely permuted *)
   let current_comp_unit = Compilation_unit.get_current_exn () in
   let ids = Expr.all_ids_for_export t.body in
-  let perm = Name_permutation.empty in
+  let perm = Renaming.empty in
   let perm = Symbol.Set.fold (fun symbol perm ->
     if Symbol.in_compilation_unit symbol current_comp_unit
        && not (Symbol.equal t.module_symbol symbol) then begin
       let guaranteed_fresh = Symbol.rename symbol in
-      Name_permutation.add_fresh_symbol perm symbol ~guaranteed_fresh
+      Renaming.add_fresh_symbol perm symbol ~guaranteed_fresh
     end else
       perm
   ) ids.symbols perm
@@ -86,22 +86,22 @@ let permute_everything t =
   let perm = Code_id.Set.fold (fun code_id perm ->
     if Code_id.in_compilation_unit code_id current_comp_unit then begin
       let guaranteed_fresh = Code_id.rename code_id in
-      Name_permutation.add_fresh_code_id perm code_id ~guaranteed_fresh
+      Renaming.add_fresh_code_id perm code_id ~guaranteed_fresh
     end else
       perm
   ) ids.code_ids perm
   in
   let perm = Variable.Set.fold (fun variable perm ->
     let guaranteed_fresh = Variable.rename variable in
-    Name_permutation.add_fresh_variable perm variable ~guaranteed_fresh
+    Renaming.add_fresh_variable perm variable ~guaranteed_fresh
   ) ids.variables perm
   in
   let perm = Continuation.Set.fold (fun k perm ->
     let guaranteed_fresh = Continuation.rename k in
-    Name_permutation.add_fresh_continuation perm k ~guaranteed_fresh
+    Renaming.add_fresh_continuation perm k ~guaranteed_fresh
   ) ids.continuations perm
   in
-  apply_name_permutation t perm
+  apply_renaming t perm
 
 (* Iter on all sets of closures of a given program. *)
 (* CR mshinwell: These functions should be pushed directly into [Flambda] *)

--- a/middle_end/flambda/terms/function_declaration.ml
+++ b/middle_end/flambda/terms/function_declaration.ml
@@ -62,8 +62,8 @@ let free_names
       } =
   Name_occurrences.add_code_id Name_occurrences.empty code_id Name_mode.normal
 
-let apply_name_permutation ({ code_id; dbg = _; is_tupled = _; } as t) perm =
-  let code_id' = Name_permutation.apply_code_id perm code_id in
+let apply_renaming ({ code_id; dbg = _; is_tupled = _; } as t) perm =
+  let code_id' = Renaming.apply_code_id perm code_id in
   if code_id == code_id' then t
   else { t with code_id = code_id'; }
 
@@ -73,18 +73,6 @@ let all_ids_for_export
         is_tupled = _;
       } =
   Ids_for_export.add_code_id Ids_for_export.empty code_id
-
-let import import_map
-      { code_id;
-        dbg;
-        is_tupled;
-      } =
-  let code_id = Ids_for_export.Import_map.code_id import_map code_id in
-  { code_id;
-    dbg;
-    is_tupled;
-  }
-
 
 let update_code_id t code_id = { t with code_id; }
 

--- a/middle_end/flambda/terms/function_declarations.ml
+++ b/middle_end/flambda/terms/function_declarations.ml
@@ -59,12 +59,12 @@ let free_names { funs; _ } =
 
 (* Note: the call to {create} at the end already takes into account the
    permutation applied to the function_declarations in {in_order}, so
-   there is no need to apply_name_permutation the func_decls in the {funs}
+   there is no need to apply_renaming the func_decls in the {funs}
    field. *)
-let apply_name_permutation ({ in_order; _ } as t) perm =
+let apply_renaming ({ in_order; _ } as t) perm =
   let in_order' =
     Closure_id.Lmap.map_sharing (fun func_decl ->
-        Function_declaration.apply_name_permutation func_decl perm)
+        Function_declaration.apply_renaming func_decl perm)
       in_order
   in
   if in_order == in_order' then t
@@ -77,12 +77,6 @@ let all_ids_for_export { funs; _ } =
         (Function_declaration.all_ids_for_export func_decl))
     funs
     Ids_for_export.empty
-
-let import import_map { in_order; _ } =
-  let in_order =
-    Closure_id.Lmap.map (Function_declaration.import import_map) in_order
-  in
-  create in_order
 
 let compare { funs = funs1; _ } { funs = funs2; _ } =
   Closure_id.Map.compare Function_declaration.compare funs1 funs2

--- a/middle_end/flambda/terms/function_params_and_body.rec.ml
+++ b/middle_end/flambda/terms/function_params_and_body.rec.ml
@@ -97,9 +97,9 @@ let print ppf t =
 
 let params_arity t = t.params_arity
 
-let apply_name_permutation
+let apply_renaming
       ({ abst; dbg; params_arity; is_my_closure_used; } as t) perm =
-  let abst' = A.apply_name_permutation abst perm in
+  let abst' = A.apply_renaming abst perm in
   if abst == abst' then t
   else { abst = abst'; dbg; params_arity; is_my_closure_used; }
 
@@ -111,7 +111,3 @@ let debuginfo { dbg; _ } = dbg
 let all_ids_for_export
       { abst; params_arity = _; dbg = _; is_my_closure_used = _; } =
   A.all_ids_for_export abst
-
-let import import_map { abst; params_arity; dbg; is_my_closure_used; } =
-  let abst = A.import import_map abst in
-  { abst; params_arity; dbg; is_my_closure_used; }

--- a/middle_end/flambda/terms/let_cont_expr.rec.ml
+++ b/middle_end/flambda/terms/let_cont_expr.rec.ml
@@ -126,19 +126,19 @@ let free_names t =
   | Recursive handlers ->
     Recursive_let_cont_handlers.free_names handlers
 
-let apply_name_permutation t perm =
+let apply_renaming t perm =
   match t with
   | Non_recursive { handler; num_free_occurrences;
                     is_applied_with_traps; } ->
     let handler' =
-      Non_recursive_let_cont_handler.apply_name_permutation handler perm
+      Non_recursive_let_cont_handler.apply_renaming handler perm
     in
     if handler == handler' then t
     else Non_recursive { handler = handler'; num_free_occurrences;
                          is_applied_with_traps; }
   | Recursive handlers ->
     let handlers' =
-      Recursive_let_cont_handlers.apply_name_permutation handlers perm
+      Recursive_let_cont_handlers.apply_renaming handlers perm
     in
     if handlers == handlers' then t
     else Recursive handlers'
@@ -150,15 +150,3 @@ let all_ids_for_export t =
     Non_recursive_let_cont_handler.all_ids_for_export handler
   | Recursive handlers ->
     Recursive_let_cont_handlers.all_ids_for_export handlers
-
-let import import_map t =
-  match t with
-  | Non_recursive { handler; num_free_occurrences;
-                    is_applied_with_traps; } ->
-    let handler =
-      Non_recursive_let_cont_handler.import import_map handler
-    in
-    Non_recursive { handler; num_free_occurrences; is_applied_with_traps; }
-  | Recursive handlers ->
-    Recursive (Recursive_let_cont_handlers.import import_map handlers)
-

--- a/middle_end/flambda/terms/let_expr.rec.ml
+++ b/middle_end/flambda/terms/let_expr.rec.ml
@@ -37,13 +37,13 @@ module T0 = struct
   let free_names { body; num_normal_occurrences_of_bound_vars = _; } =
     Expr.free_names body
 
-  let apply_name_permutation
+  let apply_renaming
         ({ body; num_normal_occurrences_of_bound_vars; } as t) perm =
-    let body' = Expr.apply_name_permutation body perm in
+    let body' = Expr.apply_renaming body perm in
     let changed = ref (body != body') in
     let num_normal_occurrences_of_bound_vars =
       Variable.Map.fold (fun var num result ->
-          let var' = Name_permutation.apply_variable perm var in
+          let var' = Renaming.apply_variable perm var in
           changed := !changed || (var != var');
           Variable.Map.add var' num result)
         num_normal_occurrences_of_bound_vars
@@ -54,10 +54,6 @@ module T0 = struct
 
   let all_ids_for_export { body; num_normal_occurrences_of_bound_vars = _; } =
     Expr.all_ids_for_export body
-
-  let import import_map { body; num_normal_occurrences_of_bound_vars; } =
-    let body = Expr.import import_map body in
-    { body; num_normal_occurrences_of_bound_vars; }
 end
 
 module A = Name_abstraction.Make (Bindable_let_bound) (T0)
@@ -432,9 +428,9 @@ let free_names
       (Name_occurrences.union from_defining_expr from_body)
       from_bindable)
 
-let apply_name_permutation ({ name_abstraction; defining_expr; } as t) perm =
-  let name_abstraction' = A.apply_name_permutation name_abstraction perm in
-  let defining_expr' = Named.apply_name_permutation defining_expr perm in
+let apply_renaming ({ name_abstraction; defining_expr; } as t) perm =
+  let name_abstraction' = A.apply_renaming name_abstraction perm in
+  let defining_expr' = Named.apply_renaming defining_expr perm in
   if name_abstraction == name_abstraction' && defining_expr == defining_expr'
   then t
   else
@@ -446,8 +442,3 @@ let all_ids_for_export { name_abstraction; defining_expr; } =
   let defining_expr_ids = Named.all_ids_for_export defining_expr in
   let name_abstraction_ids = A.all_ids_for_export name_abstraction in
   Ids_for_export.union defining_expr_ids name_abstraction_ids
-
-let import import_map { name_abstraction; defining_expr; } =
-  let defining_expr = Named.import import_map defining_expr in
-  let name_abstraction = A.import import_map name_abstraction in
-  { name_abstraction; defining_expr; }

--- a/middle_end/flambda/terms/named.rec.ml
+++ b/middle_end/flambda/terms/named.rec.ml
@@ -75,22 +75,22 @@ let free_names t =
   | Set_of_closures set -> Set_of_closures.free_names set
   | Static_consts consts -> Static_const.Group.free_names consts
 
-let apply_name_permutation t perm =
+let apply_renaming t perm =
   match t with
   | Simple simple ->
-    let simple' = Simple.apply_name_permutation simple perm in
+    let simple' = Simple.apply_renaming simple perm in
     if simple == simple' then t
     else Simple simple'
   | Prim (prim, dbg) ->
-    let prim' = Flambda_primitive.apply_name_permutation prim perm in
+    let prim' = Flambda_primitive.apply_renaming prim perm in
     if prim == prim' then t
     else Prim (prim', dbg)
   | Set_of_closures set ->
-    let set' = Set_of_closures.apply_name_permutation set perm in
+    let set' = Set_of_closures.apply_renaming set perm in
     if set == set' then t
     else Set_of_closures set'
   | Static_consts consts ->
-    let consts' = Static_const.Group.apply_name_permutation consts perm in
+    let consts' = Static_const.Group.apply_renaming consts perm in
     if consts == consts' then t
     else Static_consts consts'
 
@@ -100,21 +100,6 @@ let all_ids_for_export t =
   | Prim (prim, _dbg) -> Flambda_primitive.all_ids_for_export prim
   | Set_of_closures set -> Set_of_closures.all_ids_for_export set
   | Static_consts consts -> Static_const.Group.all_ids_for_export consts
-
-let import import_map t =
-  match t with
-  | Simple simple ->
-    let simple = Ids_for_export.Import_map.simple import_map simple in
-    Simple simple
-  | Prim (prim, dbg) ->
-    let prim = Flambda_primitive.import import_map prim in
-    Prim (prim, dbg)
-  | Set_of_closures set ->
-    let set = Set_of_closures.import import_map set in
-    Set_of_closures set
-  | Static_consts consts ->
-    let consts = Static_const.Group.import import_map consts in
-    Static_consts consts
 
 let box_value name (kind : Flambda_kind.t) dbg : t * Flambda_kind.t =
   let simple = Simple.name name in

--- a/middle_end/flambda/terms/non_recursive_let_cont_handler.rec.ml
+++ b/middle_end/flambda/terms/non_recursive_let_cont_handler.rec.ml
@@ -55,12 +55,12 @@ let free_names { continuation_and_body; handler; } =
     (Continuation_and_body.free_names continuation_and_body)
     (Continuation_handler.free_names handler)
 
-let apply_name_permutation { continuation_and_body; handler; } perm =
+let apply_renaming { continuation_and_body; handler; } perm =
   let continuation_and_body' =
-    Continuation_and_body.apply_name_permutation continuation_and_body perm
+    Continuation_and_body.apply_renaming continuation_and_body perm
   in
   let handler' =
-    Continuation_handler.apply_name_permutation handler perm
+    Continuation_handler.apply_renaming handler perm
   in
   { handler = handler';
     continuation_and_body = continuation_and_body';
@@ -72,10 +72,3 @@ let all_ids_for_export { continuation_and_body; handler; } =
     Continuation_and_body.all_ids_for_export continuation_and_body
   in
   Ids_for_export.union handler_ids continuation_and_body_ids
-
-let import import_map { continuation_and_body; handler; } =
-  let handler = Continuation_handler.import import_map handler in
-  let continuation_and_body =
-    Continuation_and_body.import import_map continuation_and_body
-  in
-  { handler; continuation_and_body; }

--- a/middle_end/flambda/terms/recursive_let_cont_handlers.rec.ml
+++ b/middle_end/flambda/terms/recursive_let_cont_handlers.rec.ml
@@ -39,12 +39,12 @@ module T0 = struct
     Name_occurrences.union (Continuation_handlers.free_names handlers)
       (Expr.free_names body)
 
-  let apply_name_permutation { handlers; body; } perm =
+  let apply_renaming { handlers; body; } perm =
     let handlers' =
-      Continuation_handlers.apply_name_permutation handlers perm
+      Continuation_handlers.apply_renaming handlers perm
     in
     let body' =
-      Expr.apply_name_permutation body perm
+      Expr.apply_renaming body perm
     in
     { handlers = handlers';
       body = body';
@@ -54,11 +54,6 @@ module T0 = struct
     let body_ids = Expr.all_ids_for_export body in
     let handlers_ids = Continuation_handlers.all_ids_for_export handlers in
     Ids_for_export.union body_ids handlers_ids
-
-  let import import_map { handlers; body; } =
-    let body = Expr.import import_map body in
-    let handlers = Continuation_handlers.import import_map handlers in
-    { handlers; body; }
 end
 
 include Name_abstraction.Make_list (Bindable_continuation) (T0)

--- a/middle_end/flambda/terms/switch_expr.ml
+++ b/middle_end/flambda/terms/switch_expr.ml
@@ -131,11 +131,11 @@ let free_names { scrutinee; arms; } =
   in
   Name_occurrences.union (Simple.free_names scrutinee) free_names_in_arms
 
-let apply_name_permutation ({ scrutinee; arms; } as t) perm =
-  let scrutinee' = Simple.apply_name_permutation scrutinee perm in
+let apply_renaming ({ scrutinee; arms; } as t) perm =
+  let scrutinee' = Simple.apply_renaming scrutinee perm in
   let arms' =
     Target_imm.Map.map_sharing (fun action ->
-        Apply_cont_expr.apply_name_permutation action perm)
+        Apply_cont_expr.apply_renaming action perm)
       arms
   in
   if scrutinee == scrutinee' && arms == arms' then t
@@ -147,10 +147,3 @@ let all_ids_for_export { scrutinee; arms; } =
       Ids_for_export.union ids (Apply_cont_expr.all_ids_for_export action))
     arms
     scrutinee_ids
-
-let import import_map { scrutinee; arms; } =
-  let scrutinee = Ids_for_export.Import_map.simple import_map scrutinee in
-  let arms =
-    Target_imm.Map.map (Apply_cont_expr.import import_map) arms
-  in
-  { scrutinee; arms; }

--- a/middle_end/flambda/terms/symbol_projection.ml
+++ b/middle_end/flambda/terms/symbol_projection.ml
@@ -92,8 +92,8 @@ let equal t1 t2 =
 let hash { symbol; projection; } =
   Hashtbl.hash (Symbol.hash symbol, Projection.hash projection)
 
-let apply_name_permutation ({ symbol; projection = _; } as t) perm =
-  let symbol' = Name_permutation.apply_symbol perm symbol in
+let apply_renaming ({ symbol; projection = _; } as t) renaming =
+  let symbol' = Renaming.apply_symbol renaming symbol in
   if symbol == symbol' then t
   else { t with symbol = symbol'; }
 
@@ -102,9 +102,3 @@ let free_names { symbol; projection = _; } =
 
 let all_ids_for_export { symbol; projection = _; } =
   Ids_for_export.singleton_symbol symbol
-
-let import import_map { symbol; projection; } =
-  let symbol = Ids_for_export.Import_map.symbol import_map symbol in
-  { symbol;
-    projection;
-  }

--- a/middle_end/flambda/types/basic/closure_id_set.ml
+++ b/middle_end/flambda/types/basic/closure_id_set.ml
@@ -24,6 +24,6 @@ include Identifiable.Make (struct
 end)
 
 let free_names _t = Name_occurrences.empty
-let apply_name_permutation t _perm = t
+let apply_renaming t _perm = t
 
 let subset t1 t2 = Closure_id.Set.subset t1 t2

--- a/middle_end/flambda/types/basic/or_unknown.ml
+++ b/middle_end/flambda/types/basic/or_unknown.ml
@@ -69,9 +69,9 @@ let all_ids_for_export all_ids_for_export_contents t =
   | Known contents -> all_ids_for_export_contents contents
   | Unknown -> Ids_for_export.empty
 
-let import import_contents import_map t =
+let apply_renaming t renaming rename_contents =
   match t with
-  | Known contents -> Known (import_contents import_map contents)
+  | Known contents -> Known (rename_contents contents renaming)
   | Unknown -> Unknown
 
 module Lift (I : Identifiable.S) = struct

--- a/middle_end/flambda/types/basic/or_unknown.mli
+++ b/middle_end/flambda/types/basic/or_unknown.mli
@@ -38,9 +38,11 @@ val free_names : ('a -> Name_occurrences.t) -> 'a t -> Name_occurrences.t
 
 val all_ids_for_export : ('a -> Ids_for_export.t) -> 'a t -> Ids_for_export.t
 
-val import
-   : (Ids_for_export.Import_map.t -> 'a -> 'a)
-  -> Ids_for_export.Import_map.t -> 'a t -> 'a t
+val apply_renaming
+   : 'a t
+  -> Renaming.t
+  -> ('a -> Renaming.t -> 'a)
+  -> 'a t
 
 module Lift (I : Identifiable.S) : sig
   type nonrec t = I.t t

--- a/middle_end/flambda/types/basic/unit.ml
+++ b/middle_end/flambda/types/basic/unit.ml
@@ -28,6 +28,6 @@ include Identifiable.Make (struct
 end)
 
 let free_names _ = Name_occurrences.empty
-let apply_name_permutation () _ = ()
+let apply_renaming () _ = ()
 
 let subset () () = true

--- a/middle_end/flambda/types/env/aliases.ml
+++ b/middle_end/flambda/types/env/aliases.ml
@@ -38,7 +38,7 @@ module Aliases_of_canonical_element : sig
   val union : t -> t -> t
   val inter : t -> t -> t
 
-  val import : (Simple.t -> Simple.t) -> t -> t
+  val rename : (Simple.t -> Simple.t) -> t -> t
 
   val merge : t -> t -> t
 
@@ -135,12 +135,12 @@ end = struct
     invariant t;
     t
 
-  let import import_simple { aliases; all } =
+  let rename rename_simple { aliases; all } =
     let aliases =
-      Name_mode.Map.map (fun elts -> Simple.Set.map import_simple elts)
+      Name_mode.Map.map (fun elts -> Simple.Set.map rename_simple elts)
         aliases
     in
-    let all = Simple.Set.map import_simple all in
+    let all = Simple.Set.map rename_simple all in
     { aliases; all }
 
   let merge t1 t2 =
@@ -536,27 +536,29 @@ let all_ids_for_export { canonical_elements = _;
     binding_times_and_modes
     Ids_for_export.empty
 
-let import import_map { canonical_elements;
-                        aliases_of_canonical_elements;
-                        binding_times_and_modes; } =
-  let import_simple = Ids_for_export.Import_map.simple import_map in
+let apply_renaming
+      { canonical_elements;
+        aliases_of_canonical_elements;
+        binding_times_and_modes; }
+      renaming =
+  let rename_simple = Renaming.apply_simple renaming in
   let canonical_elements =
     Simple.Map.fold (fun elt canonical acc ->
-        Simple.Map.add (import_simple elt) (import_simple canonical) acc)
+        Simple.Map.add (rename_simple elt) (rename_simple canonical) acc)
       canonical_elements
       Simple.Map.empty
   in
   let aliases_of_canonical_elements =
     Simple.Map.fold (fun canonical aliases acc ->
-        Simple.Map.add (import_simple canonical)
-          (Aliases_of_canonical_element.import import_simple aliases)
+        Simple.Map.add (rename_simple canonical)
+          (Aliases_of_canonical_element.rename rename_simple aliases)
           acc)
       aliases_of_canonical_elements
       Simple.Map.empty
   in
   let binding_times_and_modes =
     Simple.Map.fold (fun simple binding_time_and_mode acc ->
-        Simple.Map.add (import_simple simple) binding_time_and_mode acc)
+        Simple.Map.add (rename_simple simple) binding_time_and_mode acc)
       binding_times_and_modes
       Simple.Map.empty
   in

--- a/middle_end/flambda/types/env/aliases.mli
+++ b/middle_end/flambda/types/env/aliases.mli
@@ -61,3 +61,5 @@ val get_canonical_ignoring_name_mode : t -> Name.t -> Simple.t
 val merge : t -> t -> t
 
 val clean_for_export : t -> t
+
+val apply_renaming : t -> Renaming.t -> t

--- a/middle_end/flambda/types/env/typing_env.rec.mli
+++ b/middle_end/flambda/types/env/typing_env.rec.mli
@@ -160,7 +160,7 @@ module Serializable : sig
 
   val all_ids_for_export : t -> Ids_for_export.t
 
-  val import : Ids_for_export.Import_map.t -> t -> t
+  val apply_renaming : t -> Renaming.t -> t
 
   val merge : t -> t -> t
 end

--- a/middle_end/flambda/types/env/typing_env_level.rec.ml
+++ b/middle_end/flambda/types/env/typing_env_level.rec.ml
@@ -89,14 +89,14 @@ let fold_on_defined_vars f t init =
     t.binding_times
     init
 
-let apply_name_permutation
+let apply_renaming
       ({ defined_vars; binding_times; equations; symbol_projections; }
         as t)
       perm =
   let defined_vars_changed = ref false in
   let defined_vars' =
     Variable.Map.fold (fun var kind defined_vars ->
-        let var' = Name_permutation.apply_variable perm var in
+        let var' = Renaming.apply_variable perm var in
         if not (var == var') then begin
           defined_vars_changed := true
         end;
@@ -109,7 +109,7 @@ let apply_name_permutation
       Binding_time.Map.fold (fun binding_time vars binding_times ->
           let vars' =
             Variable.Set.map (fun var ->
-              Name_permutation.apply_variable perm var)
+              Renaming.apply_variable perm var)
               vars
           in
           Binding_time.Map.add binding_time vars' binding_times)
@@ -121,8 +121,8 @@ let apply_name_permutation
   let equations_changed = ref false in
   let equations' =
     Name.Map.fold (fun name typ equations ->
-        let name' = Name_permutation.apply_name perm name in
-        let typ' = Type_grammar.apply_name_permutation typ perm in
+        let name' = Renaming.apply_name perm name in
+        let typ' = Type_grammar.apply_renaming typ perm in
         if not (name == name' && typ == typ') then begin
           equations_changed := true
         end;
@@ -133,9 +133,9 @@ let apply_name_permutation
   let symbol_projections_changed = ref false in
   let symbol_projections' =
     Variable.Map.fold (fun var projection symbol_projections ->
-        let var' = Name_permutation.apply_variable perm var in
+        let var' = Renaming.apply_variable perm var in
         let projection' =
-          Symbol_projection.apply_name_permutation projection perm
+          Symbol_projection.apply_renaming projection perm
         in
         if not (var == var') ||
            not (projection == projection') then begin
@@ -599,6 +599,3 @@ let all_ids_for_export t =
     Ids_for_export.add_variable ids var
   in
   Variable.Map.fold symbol_projection t.symbol_projections ids
-
-let import _import_map _t =
-  Misc.fatal_error "Import not implemented on Typing_env_level"

--- a/middle_end/flambda/types/flambda_type.mli
+++ b/middle_end/flambda/types/flambda_type.mli
@@ -198,7 +198,7 @@ module Typing_env : sig
 
     val all_ids_for_export : t -> Ids_for_export.t
 
-    val import : Ids_for_export.Import_map.t -> t -> t
+    val apply_renaming : t -> Renaming.t -> t
 
     val merge : t -> t -> t
   end

--- a/middle_end/flambda/types/structures/closures_entry.rec.ml
+++ b/middle_end/flambda/types/structures/closures_entry.rec.ml
@@ -137,14 +137,14 @@ let join env
     closure_var_types;
   }
 
-let apply_name_permutation
+let apply_renaming
       { function_decls; closure_types; closure_var_types; } perm =
   { function_decls =
       Closure_id.Map.map_sharing (fun function_decl ->
-          FDT.apply_name_permutation function_decl perm)
+          FDT.apply_renaming function_decl perm)
         function_decls;
-    closure_types = PC.apply_name_permutation closure_types perm;
-    closure_var_types = PV.apply_name_permutation closure_var_types perm;
+    closure_types = PC.apply_renaming closure_types perm;
+    closure_var_types = PV.apply_renaming closure_var_types perm;
   }
 
 let free_names { function_decls; closure_types; closure_var_types; } =
@@ -168,20 +168,6 @@ let all_ids_for_export { function_decls; closure_types; closure_var_types; } =
   Ids_for_export.union function_decls_ids
     (Ids_for_export.union (PC.all_ids_for_export closure_types)
       (PV.all_ids_for_export closure_var_types))
-
-let import import_map { function_decls; closure_types; closure_var_types; } =
-  let function_decls =
-    Closure_id.Map.map (fun function_decl ->
-        FDT.import import_map function_decl)
-      function_decls
-  in
-  let closure_types =
-    PC.import import_map closure_types
-  in
-  let closure_var_types =
-    PV.import import_map closure_var_types
-  in
-  { function_decls; closure_types; closure_var_types; }
 
 let function_decl_types t = t.function_decls
 let closure_types t = PC.to_map t.closure_types

--- a/middle_end/flambda/types/structures/code_age_relation.ml
+++ b/middle_end/flambda/types/structures/code_age_relation.ml
@@ -139,9 +139,9 @@ let all_code_ids_for_export t =
     t
     Code_id.Set.empty
 
-let import import_map t =
-  let import_code_id = Ids_for_export.Import_map.code_id import_map in
+let apply_renaming t renaming =
+  let rename_code_id = Renaming.apply_code_id renaming in
   Code_id.Map.fold (fun key v acc ->
-      Code_id.Map.add (import_code_id key) (import_code_id v) acc)
+      Code_id.Map.add (rename_code_id key) (rename_code_id v) acc)
     t
     Code_id.Map.empty

--- a/middle_end/flambda/types/structures/code_age_relation.mli
+++ b/middle_end/flambda/types/structures/code_age_relation.mli
@@ -73,4 +73,4 @@ val union : t -> t -> t
 
 val all_code_ids_for_export : t -> Code_id.Set.t
 
-val import : Ids_for_export.Import_map.t -> t -> t
+val apply_renaming : t -> Renaming.t -> t

--- a/middle_end/flambda/types/structures/product_intf.ml
+++ b/middle_end/flambda/types/structures/product_intf.ml
@@ -57,5 +57,5 @@ end
 module type Index = sig
   include Identifiable.S
 
-  val remove_on_import : t -> Ids_for_export.Import_map.t -> bool
+  val remove_on_import : t -> Renaming.t -> bool
 end

--- a/middle_end/flambda/types/structures/set_of_closures_contents.ml
+++ b/middle_end/flambda/types/structures/set_of_closures_contents.ml
@@ -75,10 +75,10 @@ let inter
   let closure_vars = Var_within_closure.Set.inter closure_vars1 closure_vars2 in
   { closures; closure_vars }
 
-let import import_map { closures; closure_vars; } =
+let apply_renaming { closures; closure_vars; } renaming =
   let closure_vars =
     Var_within_closure.Set.filter (fun var ->
-        Ids_for_export.Import_map.closure_var_is_used import_map var)
+        Renaming.closure_var_is_used renaming var)
       closure_vars
   in
   { closures; closure_vars; }

--- a/middle_end/flambda/types/structures/set_of_closures_contents.mli
+++ b/middle_end/flambda/types/structures/set_of_closures_contents.mli
@@ -35,7 +35,7 @@ val union : t -> t -> t
 val closures : t -> Closure_id.Set.t
 val closure_vars : t -> Var_within_closure.Set.t
 
-val import : Ids_for_export.Import_map.t -> t -> t
+val apply_renaming : t -> Renaming.t -> t
 
 module With_closure_id : sig
   type nonrec t = Closure_id.t * t

--- a/middle_end/flambda/types/type_descr.rec.ml
+++ b/middle_end/flambda/types/type_descr.rec.ml
@@ -58,17 +58,17 @@ module Make (Head : Type_head_intf.S
     let print ppf t =
       print_with_cache ~cache:(Printing_cache.create ()) ppf t
 
-    let apply_name_permutation t perm =
-      if Name_permutation.is_empty perm then t
+    let apply_renaming t renaming =
+      if Renaming.has_no_action renaming then t
       else
         match t with
         | No_alias Bottom | No_alias Unknown -> t
         | No_alias (Ok head) ->
-          let head' = Head.apply_name_permutation head perm in
+          let head' = Head.apply_renaming head renaming in
           if head == head' then t
           else No_alias (Ok head')
         | Equals simple ->
-          let simple' = Simple.apply_name_permutation simple perm in
+          let simple' = Simple.apply_renaming simple renaming in
           if simple == simple' then t
           else Equals simple'
 
@@ -89,16 +89,6 @@ module Make (Head : Type_head_intf.S
     | No_alias Bottom | No_alias Unknown -> Ids_for_export.empty
     | No_alias (Ok head) -> Head.all_ids_for_export head
     | Equals simple -> Ids_for_export.from_simple simple
-
-  let import import_map t =
-    let descr : Descr.t =
-      match descr t with
-      | (No_alias Unknown | No_alias Bottom) as descr -> descr
-      | No_alias (Ok head) -> No_alias (Ok (Head.import import_map head))
-      | Equals simple ->
-        Equals (Ids_for_export.Import_map.simple import_map simple)
-    in
-    create descr
 
   let print_with_cache ~cache ppf t =
     Descr.print_with_cache ~cache ppf (descr t)

--- a/middle_end/flambda/types/type_grammar.rec.ml
+++ b/middle_end/flambda/types/type_grammar.rec.ml
@@ -113,30 +113,30 @@ let force_to_kind_naked_nativeint t =
       "Type has wrong kind (expected [Naked_number Nativeint]):@ %a"
       print t
 
-let apply_name_permutation t perm =
+let apply_renaming t renaming =
   match t with
   | Value ty ->
-    let ty' = T_V.apply_name_permutation ty perm in
+    let ty' = T_V.apply_renaming ty renaming in
     if ty == ty' then t
     else Value ty'
   | Naked_immediate ty ->
-    let ty' = T_NI.apply_name_permutation ty perm in
+    let ty' = T_NI.apply_renaming ty renaming in
     if ty == ty' then t
     else Naked_immediate ty'
   | Naked_float ty ->
-    let ty' = T_Nf.apply_name_permutation ty perm in
+    let ty' = T_Nf.apply_renaming ty renaming in
     if ty == ty' then t
     else Naked_float ty'
   | Naked_int32 ty ->
-    let ty' = T_N32.apply_name_permutation ty perm in
+    let ty' = T_N32.apply_renaming ty renaming in
     if ty == ty' then t
     else Naked_int32 ty'
   | Naked_int64 ty ->
-    let ty' = T_N64.apply_name_permutation ty perm in
+    let ty' = T_N64.apply_renaming ty renaming in
     if ty == ty' then t
     else Naked_int64 ty'
   | Naked_nativeint ty ->
-    let ty' = T_NN.apply_name_permutation ty perm in
+    let ty' = T_NN.apply_renaming ty renaming in
     if ty == ty' then t
     else Naked_nativeint ty'
 
@@ -157,15 +157,6 @@ let all_ids_for_export t =
   | Naked_int32 ty -> T_N32.all_ids_for_export ty
   | Naked_int64 ty -> T_N64.all_ids_for_export ty
   | Naked_nativeint ty -> T_NN.all_ids_for_export ty
-
-let import import_map t =
-  match t with
-  | Value ty -> Value (T_V.import import_map ty)
-  | Naked_immediate ty -> Naked_immediate (T_NI.import import_map ty)
-  | Naked_float ty -> Naked_float (T_Nf.import import_map ty)
-  | Naked_int32 ty -> Naked_int32 (T_N32.import import_map ty)
-  | Naked_int64 ty -> Naked_int64 (T_N64.import import_map ty)
-  | Naked_nativeint ty -> Naked_nativeint (T_NN.import import_map ty)
 
 let apply_rec_info t rec_info : _ Or_bottom.t =
   match t with
@@ -813,13 +804,13 @@ let rec make_suitable_for_environment0_core t env ~depth ~suitable_for level =
     if Name_occurrences.is_empty to_erase then level, t
     else if depth > 1 then level, unknown (kind t)
     else
-      let level, perm =
+      let level, renaming =
         (* To avoid writing an erasure operation, we define irrelevant fresh
            variables in the returned [Typing_env_level], and swap them with
            the variables that we wish to erase throughout the type. *)
         Name_occurrences.fold_names to_erase
-          ~init:(level, Name_permutation.empty)
-          ~f:(fun ((level, perm) as acc) to_erase_name ->
+          ~init:(level, Renaming.empty)
+          ~f:(fun ((level, renaming) as acc) to_erase_name ->
             Name.pattern_match to_erase_name
               ~symbol:(fun _ -> acc)
               ~var:(fun to_erase ->
@@ -845,12 +836,12 @@ let rec make_suitable_for_environment0_core t env ~depth ~suitable_for level =
                   in
                   TEEV.add_definition level fresh_var kind ty
                 in
-                let perm =
-                  Name_permutation.add_variable perm to_erase fresh_var
+                let renaming =
+                  Renaming.add_variable renaming to_erase fresh_var
                 in
-                level, perm))
+                level, renaming))
       in
-      level, apply_name_permutation t perm
+      level, apply_renaming t renaming
 
 let make_suitable_for_environment0 t env ~suitable_for level =
   make_suitable_for_environment0_core t env ~depth:0 ~suitable_for level

--- a/middle_end/flambda/types/type_of_kind/type_of_kind_naked_float0.rec.ml
+++ b/middle_end/flambda/types/type_of_kind/type_of_kind_naked_float0.rec.ml
@@ -26,13 +26,11 @@ let print ppf t =
 
 let print_with_cache ~cache:_ ppf t = print ppf t
 
-let apply_name_permutation t _perm = t
+let apply_renaming t _perm = t
 
 let free_names _t = Name_occurrences.empty
 
 let all_ids_for_export _t = Ids_for_export.empty
-
-let import _import_map t = t
 
 let apply_rec_info t rec_info : _ Or_bottom.t =
   if Rec_info.is_initial rec_info then Ok t

--- a/middle_end/flambda/types/type_of_kind/type_of_kind_naked_immediate0.rec.ml
+++ b/middle_end/flambda/types/type_of_kind/type_of_kind_naked_immediate0.rec.ml
@@ -39,15 +39,15 @@ let print_with_cache ~cache ppf t =
 
 let print ppf t = print_with_cache ~cache:(Printing_cache.create ()) ppf t
 
-let apply_name_permutation t perm =
+let apply_renaming t renaming =
   match t with
   | Naked_immediates _ -> t
   | Is_int ty ->
-    let ty' = T.apply_name_permutation ty perm in
+    let ty' = T.apply_renaming ty renaming in
     if ty == ty' then t
     else Is_int ty'
   | Get_tag ty ->
-    let ty' = T.apply_name_permutation ty perm in
+    let ty' = T.apply_renaming ty renaming in
     if ty == ty' then t
     else Get_tag ty'
 
@@ -60,12 +60,6 @@ let all_ids_for_export t =
   match t with
   | Naked_immediates _ -> Ids_for_export.empty
   | Is_int ty | Get_tag ty -> T.all_ids_for_export ty
-
-let import import_map t =
-  match t with
-  | Naked_immediates _ -> t
-  | Is_int ty -> Is_int (T.import import_map ty)
-  | Get_tag ty -> Get_tag (T.import import_map ty)
 
 let apply_rec_info t rec_info : _ Or_bottom.t =
   if Rec_info.is_initial rec_info then Ok t

--- a/middle_end/flambda/types/type_of_kind/type_of_kind_naked_int32_0.rec.ml
+++ b/middle_end/flambda/types/type_of_kind/type_of_kind_naked_int32_0.rec.ml
@@ -26,13 +26,11 @@ let print ppf t =
 
 let print_with_cache ~cache:_ ppf t = print ppf t
 
-let apply_name_permutation t _perm = t
+let apply_renaming t _renaming = t
 
 let free_names _t = Name_occurrences.empty
 
 let all_ids_for_export _t = Ids_for_export.empty
-
-let import _import_map t = t
 
 let apply_rec_info t rec_info : _ Or_bottom.t =
   if Rec_info.is_initial rec_info then Ok t

--- a/middle_end/flambda/types/type_of_kind/type_of_kind_naked_int64_0.rec.ml
+++ b/middle_end/flambda/types/type_of_kind/type_of_kind_naked_int64_0.rec.ml
@@ -26,13 +26,11 @@ let print ppf t =
 
 let print_with_cache ~cache:_ ppf t = print ppf t
 
-let apply_name_permutation t _perm = t
+let apply_renaming t _renaming = t
 
 let free_names _t = Name_occurrences.empty
 
 let all_ids_for_export _t = Ids_for_export.empty
-
-let import _import_map t = t
 
 let apply_rec_info t rec_info : _ Or_bottom.t =
   if Rec_info.is_initial rec_info then Ok t

--- a/middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.ml
+++ b/middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.ml
@@ -25,13 +25,11 @@ let print ppf t =
 
 let print_with_cache ~cache:_ ppf t = print ppf t
 
-let apply_name_permutation t _perm = t
+let apply_renaming t _renaming = t
 
 let free_names _t = Name_occurrences.empty
 
 let all_ids_for_export _t = Ids_for_export.empty
-
-let import _import_map t = t
 
 let apply_rec_info t rec_info : _ Or_bottom.t =
   if Rec_info.is_initial rec_info then Ok t


### PR DESCRIPTION
Next attempt at speeding up the loading of `.cmx` files.

I tried using only permutations as previously discussed, but there is some complicated problem relating to a clash on the hash of a constant (it seems like it's the usual sort of thing that happens when you try to use permutations for non-fresh substitutions, where if the non-fresh variable already occurs in the term then the stale one reappears).  It's also difficult to understand the logic around `Simple`s which, at present, need to be hashed because of the possible presence of `Rec_info`.  (It is possible that once the coercion work lands, we might be able to use normal sets and maps for `Simple` rather than the `Patricia_tree` versions, which would mean an unboxed representation of a normal variant type would suffice for `Simple`.  I have half an implementation for such using `Obj`.)

Anyway, I thought I would try something else, which is to apply the `Import_map` lazily during `apply_name_permutation` if there is one (and delete the `import` functions).  Given that there is more than permutations going on here now, I've renamed `Name_permutation` to `Renaming` (which is maybe a better name anyway).  There are some residual uses of `perm` as a variable name still around, but they can be cleaned up later.  It is possible, that if we sort out `Simple` in the way just described, that we could go back to these values just being permutations and remove the import map entirely -- with the wart of the "used closure vars" field though...

@lthls What do you think?  This seems overall to be an improvement to me, with 300 fewer lines of code to boot.  The renamings should be delayed on types as well as terms, so we shouldn't be exploring and reallocating either of those during import now.