### PR TITLE
Inlining cost uses the accumulated cost_metrics

### DIFF
--- a/.depend
+++ b/.depend
@@ -4842,6 +4842,7 @@ middle_end/flambda/from_lambda/closure_conversion.cmo : \
     middle_end/flambda/basic/continuation.cmi \
     utils/config.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
+    middle_end/flambda/inlining/metrics/code_size.cmi \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/basic/closure_id.cmi \
     middle_end/flambda/from_lambda/closure_conversion_aux.cmi \
@@ -4894,6 +4895,7 @@ middle_end/flambda/from_lambda/closure_conversion.cmx : \
     middle_end/flambda/basic/continuation.cmx \
     utils/config.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
+    middle_end/flambda/inlining/metrics/code_size.cmx \
     middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/basic/closure_id.cmx \
     middle_end/flambda/from_lambda/closure_conversion_aux.cmx \
@@ -4925,6 +4927,7 @@ middle_end/flambda/from_lambda/closure_conversion_aux.cmo : \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
+    middle_end/flambda/inlining/metrics/code_size.cmi \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/basic/closure_id.cmi \
     middle_end/flambda/from_lambda/closure_conversion_aux.cmi
@@ -4945,6 +4948,7 @@ middle_end/flambda/from_lambda/closure_conversion_aux.cmx : \
     middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/basic/continuation.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
+    middle_end/flambda/inlining/metrics/code_size.cmx \
     middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/basic/closure_id.cmx \
     middle_end/flambda/from_lambda/closure_conversion_aux.cmi
@@ -5210,30 +5214,19 @@ middle_end/flambda/from_lambda/prepare_lambda.cmx : \
 middle_end/flambda/from_lambda/prepare_lambda.cmi : \
     utils/numbers.cmi \
     lambda/lambda.cmi
-middle_end/flambda/from_lambda/wrapper.cmo : \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/basic/code_id.cmi \
-    middle_end/flambda/from_lambda/closure_conversion_aux.cmi
-middle_end/flambda/from_lambda/wrapper.cmx : \
-    middle_end/flambda/terms/flambda.cmx \
-    middle_end/flambda/basic/code_id.cmx \
-    middle_end/flambda/from_lambda/closure_conversion_aux.cmx
 middle_end/flambda/inlining/inlining_cost.cmo : \
     middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/simplify/env/downwards_env.cmi \
     middle_end/flambda/inlining/metrics/code_size.cmi \
     utils/clflags.cmi \
     middle_end/flambda/inlining/inlining_cost.cmi
 middle_end/flambda/inlining/inlining_cost.cmx : \
     middle_end/flambda/terms/flambda.cmx \
-    middle_end/flambda/simplify/env/downwards_env.cmx \
     middle_end/flambda/inlining/metrics/code_size.cmx \
     utils/clflags.cmx \
     middle_end/flambda/inlining/inlining_cost.cmi
 middle_end/flambda/inlining/inlining_cost.cmi : \
     middle_end/flambda/terms/flambda_primitive.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/simplify/env/downwards_env.cmi
+    middle_end/flambda/terms/flambda.cmi
 middle_end/flambda/inlining/inlining_decision.cmo : \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
     utils/numbers.cmi \
@@ -5836,6 +5829,7 @@ middle_end/flambda/parser/fexpr_to_flambda.cmo : \
     lambda/debuginfo.cmi \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
+    middle_end/flambda/inlining/metrics/code_size.cmi \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/basic/closure_id.cmi \
     middle_end/flambda/terms/call_kind.cmi \
@@ -5878,6 +5872,7 @@ middle_end/flambda/parser/fexpr_to_flambda.cmx : \
     lambda/debuginfo.cmx \
     middle_end/flambda/basic/continuation.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
+    middle_end/flambda/inlining/metrics/code_size.cmx \
     middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/basic/closure_id.cmx \
     middle_end/flambda/terms/call_kind.cmx \
@@ -5949,6 +5944,7 @@ middle_end/flambda/parser/flambda_to_fexpr.cmo : \
     middle_end/flambda/parser/fexpr.cmo \
     middle_end/flambda/basic/exn_continuation.cmi \
     middle_end/flambda/basic/continuation.cmi \
+    middle_end/flambda/inlining/metrics/code_size.cmi \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/basic/closure_id.cmi \
     middle_end/flambda/terms/bound_symbols.cmi \
@@ -5985,6 +5981,7 @@ middle_end/flambda/parser/flambda_to_fexpr.cmx : \
     middle_end/flambda/parser/fexpr.cmx \
     middle_end/flambda/basic/exn_continuation.cmx \
     middle_end/flambda/basic/continuation.cmx \
+    middle_end/flambda/inlining/metrics/code_size.cmx \
     middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/basic/closure_id.cmx \
     middle_end/flambda/terms/bound_symbols.cmx \
@@ -6503,24 +6500,6 @@ middle_end/flambda/simplify/simplify_expr.cmx : \
 middle_end/flambda/simplify/simplify_expr.cmi : \
     middle_end/flambda/simplify/simplify_common.cmi \
     middle_end/flambda/terms/flambda.cmi
-middle_end/flambda/simplify/simplify_expr.rec.cmo : \
-    middle_end/flambda/simplify/simplify_switch_expr.cmi \
-    middle_end/flambda/simplify/simplify_let_expr.cmi \
-    middle_end/flambda/simplify/simplify_let_cont_expr.cmi \
-    middle_end/flambda/simplify/simplify_import.cmi \
-    middle_end/flambda/simplify/simplify_common.cmi \
-    middle_end/flambda/simplify/simplify_apply_expr.cmi \
-    middle_end/flambda/simplify/simplify_apply_cont_expr.cmi \
-    utils/misc.cmi
-middle_end/flambda/simplify/simplify_expr.rec.cmx : \
-    middle_end/flambda/simplify/simplify_switch_expr.cmx \
-    middle_end/flambda/simplify/simplify_let_expr.cmx \
-    middle_end/flambda/simplify/simplify_let_cont_expr.cmx \
-    middle_end/flambda/simplify/simplify_import.cmx \
-    middle_end/flambda/simplify/simplify_common.cmx \
-    middle_end/flambda/simplify/simplify_apply_expr.cmx \
-    middle_end/flambda/simplify/simplify_apply_cont_expr.cmx \
-    utils/misc.cmx
 middle_end/flambda/simplify/simplify_import.cmo : \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
     middle_end/flambda/simplify/env/upwards_env.cmi \
@@ -7775,14 +7754,11 @@ middle_end/flambda/terms/cost_metrics.rec.cmo : \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/terms/set_of_closures.cmi \
     middle_end/flambda/inlining/metrics/removed_operations.cmi \
-    middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/naming/name_mode.cmi \
-    utils/misc.cmi \
     middle_end/flambda/terms/function_declarations.cmi \
     middle_end/flambda/terms/function_declaration.cmi \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/inlining/metrics/code_size.cmi \
-    middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/basic/closure_id.cmi \
     middle_end/flambda/naming/bindable_let_bound.cmi \
     middle_end/flambda/terms/cost_metrics.rec.cmi
@@ -7791,21 +7767,17 @@ middle_end/flambda/terms/cost_metrics.rec.cmx : \
     middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/terms/set_of_closures.cmx \
     middle_end/flambda/inlining/metrics/removed_operations.cmx \
-    middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/naming/name_mode.cmx \
-    utils/misc.cmx \
     middle_end/flambda/terms/function_declarations.cmx \
     middle_end/flambda/terms/function_declaration.cmx \
     middle_end/flambda/basic/continuation.cmx \
     middle_end/flambda/inlining/metrics/code_size.cmx \
-    middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/basic/closure_id.cmx \
     middle_end/flambda/naming/bindable_let_bound.cmx \
     middle_end/flambda/terms/cost_metrics.rec.cmi
 middle_end/flambda/terms/cost_metrics.rec.cmi : \
     middle_end/flambda/terms/set_of_closures.cmi \
     middle_end/flambda/inlining/metrics/removed_operations.cmi \
-    middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/inlining/metrics/code_size.cmi \
     middle_end/flambda/basic/code_id.cmi
 middle_end/flambda/terms/expr.rec.cmo : \

--- a/middle_end/flambda/inlining/inlining_cost.mli
+++ b/middle_end/flambda/inlining/inlining_cost.mli
@@ -52,8 +52,7 @@ type inline_res =
    cost so as to fit under the given [inlining_threshold].  The [bonus] is
    added to the threshold before evaluation. *)
 val can_inline
-   : Downwards_env.t
-  -> Expr.t
+  : metrics:Cost_metrics.t
   -> Threshold.t
   -> bonus:int
   -> inline_res
@@ -81,11 +80,6 @@ module Benefit : sig
   val remove_branch : t -> t
   val direct_call_of_indirect_unknown_arity : t -> t
   val direct_call_of_indirect_known_arity : t -> t
-  val requested_inline
-     : Downwards_env.t
-    -> t
-    -> cost_metrics_of:Expr.t
-    -> t
 
   val print : Format.formatter -> t -> unit
 end

--- a/middle_end/flambda/inlining/inlining_decision.ml
+++ b/middle_end/flambda/inlining/inlining_decision.ml
@@ -82,7 +82,9 @@ module Function_declaration_decision = struct
 
 end
 
-let make_decision_for_function_declaration denv ?cost_metrics function_decl
+type cost_metrics_source = From_denv | Metrics of Cost_metrics.t
+
+let make_decision_for_function_declaration denv ~cost_metrics_source function_decl
   : Function_declaration_decision.t =
   (* At present, we follow Closure, taking inlining decisions without
      first examining call sites. *)
@@ -107,9 +109,9 @@ let make_decision_for_function_declaration denv ?cost_metrics function_decl
               (float_of_int Inlining_cost.scale_inline_threshold_by)))
       in
       let metrics =
-        match cost_metrics  with
-        | Some metrics -> metrics
-        | None -> Code.cost_metrics code
+        match cost_metrics_source with
+        | Metrics metrics -> metrics
+        | From_denv -> Code.cost_metrics code
       in
       match Inlining_cost.can_inline ~metrics inlining_threshold ~bonus:0
       with

--- a/middle_end/flambda/inlining/inlining_decision.ml
+++ b/middle_end/flambda/inlining/inlining_decision.ml
@@ -102,7 +102,7 @@ let make_decision_for_function_declaration denv ?params_and_body function_decl
         | Some params_and_body -> params_and_body
       in
       Function_params_and_body.pattern_match params_and_body
-        ~f:(fun ~return_continuation:_ _exn_continuation _params ~body
+        ~f:(fun ~return_continuation:_ _exn_continuation _params ~body:_
                 ~my_closure:_ ~is_my_closure_used:_
                 : Function_declaration_decision.t ->
           let inlining_threshold : Inlining_cost.Threshold.t =
@@ -117,7 +117,11 @@ let make_decision_for_function_declaration denv ?params_and_body function_decl
                 (unscaled *.
                   (float_of_int Inlining_cost.scale_inline_threshold_by)))
           in
-          match Inlining_cost.can_inline denv body inlining_threshold ~bonus:0 with
+          match Inlining_cost.can_inline
+                  ~metrics:(Code.cost_metrics code)
+                  inlining_threshold
+                  ~bonus:0
+          with
           | Can_inline size -> Inline (Some (size, inlining_threshold))
           | Cannot_inline -> Function_body_too_large inlining_threshold)
 

--- a/middle_end/flambda/inlining/inlining_decision.mli
+++ b/middle_end/flambda/inlining/inlining_decision.mli
@@ -32,9 +32,12 @@ module Function_declaration_decision : sig
   val can_inline : t -> bool
 end
 
+(* If a cost_metrics is passed it will be used as the cost metrics for
+   the function declaration instead of grabbing the cost metrics from the
+   one stored on the code located in the env. *)
 val make_decision_for_function_declaration
    : Downwards_env.t
-  -> ?params_and_body:Function_params_and_body.t
+  -> ?cost_metrics:Cost_metrics.t
   -> Function_declaration.t
   -> Function_declaration_decision.t
 

--- a/middle_end/flambda/inlining/inlining_decision.mli
+++ b/middle_end/flambda/inlining/inlining_decision.mli
@@ -32,12 +32,15 @@ module Function_declaration_decision : sig
   val can_inline : t -> bool
 end
 
+
+type cost_metrics_source = From_denv | Metrics of Cost_metrics.t
+
 (* If a cost_metrics is passed it will be used as the cost metrics for
    the function declaration instead of grabbing the cost metrics from the
    one stored on the code located in the env. *)
 val make_decision_for_function_declaration
    : Downwards_env.t
-  -> ?cost_metrics:Cost_metrics.t
+  -> cost_metrics_source:cost_metrics_source
   -> Function_declaration.t
   -> Function_declaration_decision.t
 

--- a/middle_end/flambda/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda/simplify/simplify_set_of_closures.ml
@@ -26,11 +26,11 @@ open! Simplify_import
    file tail recursive, although it probably isn't necessary, as
    excessive levels of nesting of functions seems unlikely. *)
 
-let function_decl_type ~pass denv function_decl ?code_id ?cost_metrics
+let function_decl_type ~pass ~cost_metrics_source denv function_decl ?code_id
       rec_info =
   let decision =
     Inlining_decision.make_decision_for_function_declaration
-      denv ?cost_metrics function_decl
+      denv ~cost_metrics_source function_decl
   in
   let code_id = Option.value code_id ~default:(FD.code_id function_decl) in
   Inlining_report.record_decision (
@@ -161,6 +161,7 @@ end = struct
                   ~pass:Inlining_report.Before_simplify
                   denv function_decl
                   ~code_id:new_code_id
+                  ~cost_metrics_source:From_denv
                   (Rec_info.create ~depth:1 ~unroll_to:None))
               (Function_declarations.funs function_decls)
           in
@@ -468,14 +469,11 @@ let simplify_function context ~used_closure_vars ~shareable_constants
     in
     let function_decl = FD.update_code_id function_decl new_code_id in
     let function_type =
-      (* We need to use [dacc_after_body] to ensure that all [code_ids] in
-         [params_and_body] are available for the inlining decision code.
-         We also provide the latest [cost_metrics] manually as the one present
-         in the denv is the one before simplification.
-      *)
+      (* We need to manually specify the cost metrics to use to ensure that
+         they are the one of the body after simplification. *)
       function_decl_type
         ~pass:Inlining_report.After_simplify
-        ~cost_metrics
+        ~cost_metrics_source:(Metrics cost_metrics)
         (DA.denv dacc_after_body) function_decl
         Rec_info.initial
     in


### PR DESCRIPTION
This allow to avoid having to call [expr_size] which goes through the term each time we want to inline a function.