### PR TITLE
Allow Set_of_closures bindings to be phantomised

### DIFF
--- a/middle_end/flambda/naming/bindable_let_bound.ml
+++ b/middle_end/flambda/naming/bindable_let_bound.ml
@@ -215,6 +215,14 @@ let name_mode t =
   | Set_of_closures { name_mode; _ } -> name_mode
   | Symbols _ -> Name_mode.normal
 
+let with_name_mode t name_mode =
+  match t with
+  | Singleton var ->
+    Singleton (Var_in_binding_pos.with_name_mode var name_mode)
+  | Set_of_closures { name_mode = _; closure_vars; } ->
+    Set_of_closures { name_mode; closure_vars; }
+  | Symbols _ -> t
+
 let must_be_singleton t =
   match t with
   | Singleton var -> var
@@ -237,6 +245,19 @@ let must_be_symbols t =
   | Symbols symbols -> symbols
   | Singleton _ | Set_of_closures _ ->
     Misc.fatal_errorf "Bound name is not a [Set_of_closures]:@ %a" print t
+
+let exists_all_bound_vars t ~f =
+  match t with
+  | Singleton var -> f var
+  | Set_of_closures { closure_vars; _ } -> ListLabels.exists closure_vars ~f
+  | Symbols _ -> false
+
+let fold_all_bound_vars t ~init ~f =
+  match t with
+  | Singleton var -> f init var
+  | Set_of_closures { closure_vars; _ } ->
+    ListLabels.fold_left closure_vars ~init ~f
+  | Symbols _ -> init
 
 let all_bound_vars t =
   match t with

--- a/middle_end/flambda/naming/bindable_let_bound.mli
+++ b/middle_end/flambda/naming/bindable_let_bound.mli
@@ -55,6 +55,19 @@ val must_be_symbols : t -> symbols
 
 val name_mode : t -> Name_mode.t
 
+val with_name_mode : t -> Name_mode.t -> t
+
+val exists_all_bound_vars
+   : t
+  -> f:(Var_in_binding_pos.t -> bool)
+  -> bool
+
+val fold_all_bound_vars
+   : t
+  -> init:'a
+  -> f:('a -> Var_in_binding_pos.t -> 'a)
+  -> 'a
+
 val all_bound_vars : t -> Var_in_binding_pos.Set.t
 
 val all_bound_vars' : t -> Variable.Set.t

--- a/middle_end/flambda/naming/name_mode.ml
+++ b/middle_end/flambda/naming/name_mode.ml
@@ -29,6 +29,13 @@ type t =
     In_types   Phantom
 *)
 
+let max_in_terms t1 t2 =
+  match t1, t2 with
+  | Normal, Normal | Phantom, Phantom -> t1
+  | Normal, Phantom | Phantom, Normal -> Normal
+  | In_types, _ | _, In_types ->
+    Misc.fatal_error "Cannot use [max_in_terms] with [In_types] mode"
+
 type kind = t
 
 let normal = Normal

--- a/middle_end/flambda/naming/name_mode.mli
+++ b/middle_end/flambda/naming/name_mode.mli
@@ -42,6 +42,8 @@ val top : t
 
 val can_be_in_terms : t -> bool
 
+val max_in_terms : t -> t -> t
+
 include Identifiable.S with type t := t
 
 val compare_total_order : t -> t -> int


### PR DESCRIPTION
This patch allows non-lifted `Set_of_closures` bindings to be phantomised in the same way as `Singleton` bindings.  This stops closure allocations from being kept alive by phantom lets.