### PR TITLE
Various reductions in allocation

### DIFF
--- a/.depend
+++ b/.depend
@@ -9248,14 +9248,18 @@ middle_end/flambda/types/env/aliases.cmi : \
     middle_end/flambda/cmx/contains_ids.cmo \
     middle_end/flambda/types/env/binding_time.cmi
 middle_end/flambda/types/env/binding_time.cmo : \
+    middle_end/flambda/compilenv_deps/patricia_tree.cmi \
     utils/numbers.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     utils/misc.cmi \
+    utils/identifiable.cmi \
     middle_end/flambda/types/env/binding_time.cmi
 middle_end/flambda/types/env/binding_time.cmx : \
+    middle_end/flambda/compilenv_deps/patricia_tree.cmx \
     utils/numbers.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     utils/misc.cmx \
+    utils/identifiable.cmx \
     middle_end/flambda/types/env/binding_time.cmi
 middle_end/flambda/types/env/binding_time.cmi : \
     middle_end/flambda/naming/name_mode.cmi \

--- a/Makefile.common.in
+++ b/Makefile.common.in
@@ -66,6 +66,8 @@ else
   ocamlopt_cmd = $(FLEXLINK_ENV) $(ocamlopt)
 endif
 
+# CR mshinwell: We should be able to remove this inlining depth setting
+# once the new inliner has been merged.
 OPTCOMPFLAGS=-flambda-expert-max-inlining-depth 3
 ifeq "$(FUNCTION_SECTIONS)" "true"
 OPTCOMPFLAGS += -function-sections

--- a/Makefile.common.in
+++ b/Makefile.common.in
@@ -66,7 +66,7 @@ else
   ocamlopt_cmd = $(FLEXLINK_ENV) $(ocamlopt)
 endif
 
-OPTCOMPFLAGS=
+OPTCOMPFLAGS=-flambda-expert-max-inlining-depth 3
 ifeq "$(FUNCTION_SECTIONS)" "true"
 OPTCOMPFLAGS += -function-sections
 endif

--- a/middle_end/flambda/compilenv_deps/reg_width_things.ml
+++ b/middle_end/flambda/compilenv_deps/reg_width_things.ml
@@ -530,15 +530,15 @@ module Simple = struct
 
   let [@inline always] pattern_match t ~name ~const =
     let flags = Id.flags t in
-    if flags = var_flags then name (Name.var t)
-    else if flags = symbol_flags then name (Name.symbol t)
-    else if flags = const_flags then const t
+    if flags = var_flags then (name [@inlined hint]) (Name.var t)
+    else if flags = symbol_flags then (name [@inlined hint]) (Name.symbol t)
+    else if flags = const_flags then (const [@inlined hint]) t
     else if flags = simple_flags then
       let t = (find_data t).simple in
       let flags = Id.flags t in
-      if flags = var_flags then name (Name.var t)
-      else if flags = symbol_flags then name (Name.symbol t)
-      else if flags = const_flags then const t
+      if flags = var_flags then (name [@inlined hint]) (Name.var t)
+      else if flags = symbol_flags then (name [@inlined hint]) (Name.symbol t)
+      else if flags = const_flags then (const [@inlined hint]) t
       else assert false
     else assert false
 

--- a/middle_end/flambda/compilenv_deps/reg_width_things.ml
+++ b/middle_end/flambda/compilenv_deps/reg_width_things.ml
@@ -155,10 +155,13 @@ module Variable_data = struct
 
   let hash { compilation_unit; previous_compilation_units;
              name = _; name_stamp; user_visible = _; } =
-    (* The [name_stamp] uniquely determines [name] and [user_visible]. *)
-    Hashtbl.hash (List.map Compilation_unit.hash
-                    (compilation_unit :: previous_compilation_units),
-                  name_stamp)
+    let compilation_unit_hashes =
+      List.fold_left (fun hash compilation_unit ->
+          Misc.hash2 hash (Compilation_unit.hash compilation_unit))
+        (Compilation_unit.hash compilation_unit)
+        previous_compilation_units
+    in
+    Misc.hash2 compilation_unit_hashes (Hashtbl.hash name_stamp)
 
   let equal t1 t2 =
     if t1 == t2 then true

--- a/middle_end/flambda/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion.ml
@@ -845,6 +845,10 @@ and close_one_function t ~external_env ~by_closure_id decl
   in
   let my_closure' = Simple.var my_closure in
   let body =
+    (* CR mshinwell: These Select_closure operations should maybe be inserted
+       at the point of use rather than at the top of the function.  We should
+       also check the behaviour of the backend w.r.t. CSE of projections from
+       closures. *)
     Variable.Map.fold (fun var closure_id body ->
         let move : Flambda_primitive.unary_primitive =
           Select_closure {

--- a/middle_end/flambda/simplify/env/downwards_acc.ml
+++ b/middle_end/flambda/simplify/env/downwards_acc.ml
@@ -111,9 +111,6 @@ let typing_env t = DE.typing_env (denv t)
 let add_variable t var ty =
   with_denv t (DE.add_variable (denv t) var ty)
 
-let extend_typing_environment t env_extension =
-  with_denv t (DE.extend_typing_environment (denv t) env_extension)
-
 let get_typing_env_no_more_than_one_use t k =
   CUE.get_typing_env_no_more_than_one_use t.continuation_uses_env k
 

--- a/middle_end/flambda/simplify/env/downwards_acc.mli
+++ b/middle_end/flambda/simplify/env/downwards_acc.mli
@@ -56,8 +56,6 @@ val typing_env : t -> Flambda_type.Typing_env.t
 
 val add_variable : t -> Var_in_binding_pos.t -> Flambda_type.t -> t
 
-val extend_typing_environment : t -> Flambda_type.Typing_env_extension.t -> t
-
 val no_lifted_constants : t -> bool
 
 val add_lifted_constant

--- a/middle_end/flambda/simplify/env/downwards_env.mli
+++ b/middle_end/flambda/simplify/env/downwards_env.mli
@@ -141,7 +141,12 @@ val add_parameters_with_unknown_types'
 
 val mark_parameters_as_toplevel : t -> Kinded_parameter.t list -> t
 
-val extend_typing_environment : t -> Flambda_type.Typing_env_extension.t -> t
+val add_variable_and_extend_typing_environment
+   : t
+  -> Var_in_binding_pos.t
+  -> Flambda_type.t
+  -> Flambda_type.Typing_env_extension.t
+  -> t
 
 val with_typing_env : t -> Flambda_type.Typing_env.t -> t
 

--- a/middle_end/flambda/simplify/simplify_named.ml
+++ b/middle_end/flambda/simplify/simplify_named.ml
@@ -179,8 +179,9 @@ let simplify_named0 dacc (bindable_let_bound : Bindable_let_bound.t)
       (* CR mshinwell: It's a bit weird that the env_extension is added to
          the typing env here; couldn't it just have been returned already
          added to [dacc]? *)
-      let dacc = DA.add_variable dacc bound_var (T.unknown kind) in
-      DA.extend_typing_environment dacc env_extension
+      DA.map_denv dacc ~f:(fun denv ->
+        DE.add_variable_and_extend_typing_environment denv
+          bound_var (T.unknown kind) env_extension)
     in
     (* CR mshinwell: Add check along the lines of: types are unknown
        whenever [not (P.With_fixed_value.eligible prim)] holds. *)

--- a/middle_end/flambda/types/env/binding_time.ml
+++ b/middle_end/flambda/types/env/binding_time.ml
@@ -14,8 +14,21 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
-include Numbers.Int
+module T = struct
+  include Int
+
+  let print = Numbers.Int.print
+  let output = Numbers.Int.output
+  let hash = Hashtbl.hash
+end
+
+include T
+
 type binding_time = t
+
+module Set = Patricia_tree.Make_set (T)
+module Map = Patricia_tree.Make_map (T) (Set)
+module Tbl = Identifiable.Make_tbl (T) (Map)
 
 let strictly_earlier (t : t) ~than =
   t < than

--- a/middle_end/flambda/types/type_descr.rec.ml
+++ b/middle_end/flambda/types/type_descr.rec.ml
@@ -82,6 +82,8 @@ module Make (Head : Type_head_intf.S
           Name_mode.in_types
   end
 
+  (* CR mshinwell: Flambda 2 compilation is causing calls to e.g. [descr]
+     to be indirect. *)
   include With_delayed_permutation.Make (Descr)
 
   let all_ids_for_export t =

--- a/middle_end/flambda/types/type_grammar.rec.ml
+++ b/middle_end/flambda/types/type_grammar.rec.ml
@@ -795,11 +795,10 @@ let rec make_suitable_for_environment0_core t env ~depth ~suitable_for level =
   else if missing_kind env free_names then level, unknown (kind t)
   else
     let to_erase =
+      let var free_var = not (TE.mem suitable_for (Name.var free_var)) in
       Name_occurrences.filter_names free_names
         ~f:(fun free_name ->
-          Name.pattern_match free_name
-            ~var:(fun _ -> not (TE.mem suitable_for free_name))
-            ~symbol:(fun _ -> true))
+          Name.pattern_match free_name ~var ~symbol:(fun _ -> true))
     in
     if Name_occurrences.is_empty to_erase then level, t
     else if depth > 1 then level, unknown (kind t)

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -531,6 +531,16 @@ let create_hashtable size init =
   List.iter (fun (key, data) -> Hashtbl.add tbl key data) init;
   tbl
 
+let hash_seed =
+  let seed = Random.bits () in
+  if seed mod 2 = 0 then seed + 1 else seed
+
+let hash2 a b =
+  let a = Hashtbl.hash a in
+  let b = Hashtbl.hash b in
+  let r = a * hash_seed + b in
+  r lxor (r lsr 17)
+
 (* File copy *)
 
 let copy_file ic oc =

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -535,6 +535,8 @@ let hash_seed =
   let seed = Random.bits () in
   if seed mod 2 = 0 then seed + 1 else seed
 
+(* Fast integer hashing algorithm for sdolan.  With the stdlib Hashtbl
+   implementation it's ok that this returns > 30 bits. *)
 let hash2 a b =
   let a = Hashtbl.hash a in
   let b = Hashtbl.hash b in

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -238,6 +238,9 @@ val create_hashtable: int -> ('a * 'b) list -> ('a, 'b) Hashtbl.t
         (* Create a hashtable of the given size and fills it with the
            given bindings. *)
 
+(* Hashing of two things without allocating a pair. *)
+val hash2 : 'a -> 'b -> int
+
 val copy_file: in_channel -> out_channel -> unit
         (* [copy_file ic oc] reads the contents of file [ic] and copies
            them to [oc]. It stops when encountering EOF on [ic]. *)


### PR DESCRIPTION
This assortment of fixes reduces the allocation done by Flambda 2 when compiling `typecore.ml` by nearly 10%.  A further increase is gained by #334.  A couple of random CRs have also been added.