### PR TITLE
Improve Simplify_simple, canonical lookup etc.

### DIFF
--- a/middle_end/flambda/simplify/common_subexpression_elimination.ml
+++ b/middle_end/flambda/simplify/common_subexpression_elimination.ml
@@ -153,6 +153,7 @@ let cse_with_eligible_lhs ~typing_env_at_fork ~cse_at_each_use ~params prev_cse
             match
               TE.get_canonical_simple_exn env_at_use arg
                 ~min_name_mode:NM.normal
+                ~name_mode_of_existing_simple:NM.normal
             with
             | exception Not_found -> None
             | arg ->
@@ -173,6 +174,7 @@ let cse_with_eligible_lhs ~typing_env_at_fork ~cse_at_each_use ~params prev_cse
           match
             TE.get_canonical_simple_exn env_at_use bound_to
               ~min_name_mode:NM.normal
+              ~name_mode_of_existing_simple:NM.normal
           with
           | exception Not_found -> eligible
           | bound_to ->

--- a/middle_end/flambda/simplify/simplify_apply_cont_expr.ml
+++ b/middle_end/flambda/simplify/simplify_apply_cont_expr.ml
@@ -140,17 +140,17 @@ let rebuild_apply_cont apply_cont ~args ~rewrite_id uacc ~after_rebuild =
       Apply_cont.free_names apply_cont)
 
 let simplify_apply_cont dacc apply_cont ~down_to_up =
-  let min_name_mode = Name_mode.normal in
-  match S.simplify_simples dacc (AC.args apply_cont) ~min_name_mode with
-  | _, Bottom ->
+  let { S. seen_bottom; simples = args; simple_tys = arg_types; } =
+    S.simplify_simples dacc (AC.args apply_cont)
+  in
+  if seen_bottom then
     down_to_up dacc ~rebuild:(fun uacc ~after_rebuild ->
       let uacc =
         UA.notify_removed ~operation:Removed_operations.branch uacc
       in
       EB.rebuild_invalid uacc ~after_rebuild
     )
-  | _changed, Ok args_with_types ->
-    let args, arg_types = List.split args_with_types in
+  else
     let use_kind : Continuation_use_kind.t =
       (* CR mshinwell: Is [Continuation.sort] reliable enough to detect
          the toplevel continuation?  Probably not -- we should store it in

--- a/middle_end/flambda/simplify/simplify_apply_cont_expr.ml
+++ b/middle_end/flambda/simplify/simplify_apply_cont_expr.ml
@@ -140,34 +140,26 @@ let rebuild_apply_cont apply_cont ~args ~rewrite_id uacc ~after_rebuild =
       Apply_cont.free_names apply_cont)
 
 let simplify_apply_cont dacc apply_cont ~down_to_up =
-  let { S. seen_bottom; simples = args; simple_tys = arg_types; } =
+  let { S. simples = args; simple_tys = arg_types; } =
     S.simplify_simples dacc (AC.args apply_cont)
   in
-  if seen_bottom then
-    down_to_up dacc ~rebuild:(fun uacc ~after_rebuild ->
-      let uacc =
-        UA.notify_removed ~operation:Removed_operations.branch uacc
-      in
-      EB.rebuild_invalid uacc ~after_rebuild
-    )
-  else
-    let use_kind : Continuation_use_kind.t =
-      (* CR mshinwell: Is [Continuation.sort] reliable enough to detect
-         the toplevel continuation?  Probably not -- we should store it in
-         the environment. *)
-      match Continuation.sort (AC.continuation apply_cont) with
-      | Normal ->
-        (* Until such time as we can manually add to the backtrace buffer,
-           never substitute a "raise" for the body of an exception handler. *)
-        if Option.is_none (Apply_cont.trap_action apply_cont) then Inlinable
-        else Non_inlinable
-      | Return | Toplevel_return | Exn -> Non_inlinable
-      | Define_root_symbol ->
-        assert (Option.is_none (Apply_cont.trap_action apply_cont));
-        Inlinable
-    in
-    let dacc, rewrite_id =
-      DA.record_continuation_use dacc (AC.continuation apply_cont)
-        use_kind ~env_at_use:(DA.denv dacc) ~arg_types
-    in
-    down_to_up dacc ~rebuild:(rebuild_apply_cont apply_cont ~args ~rewrite_id)
+  let use_kind : Continuation_use_kind.t =
+    (* CR mshinwell: Is [Continuation.sort] reliable enough to detect
+       the toplevel continuation?  Probably not -- we should store it in
+       the environment. *)
+    match Continuation.sort (AC.continuation apply_cont) with
+    | Normal ->
+      (* Until such time as we can manually add to the backtrace buffer,
+         never substitute a "raise" for the body of an exception handler. *)
+      if Option.is_none (Apply_cont.trap_action apply_cont) then Inlinable
+      else Non_inlinable
+    | Return | Toplevel_return | Exn -> Non_inlinable
+    | Define_root_symbol ->
+      assert (Option.is_none (Apply_cont.trap_action apply_cont));
+      Inlinable
+  in
+  let dacc, rewrite_id =
+    DA.record_continuation_use dacc (AC.continuation apply_cont)
+      use_kind ~env_at_use:(DA.denv dacc) ~arg_types
+  in
+  down_to_up dacc ~rebuild:(rebuild_apply_cont apply_cont ~args ~rewrite_id)

--- a/middle_end/flambda/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda/simplify/simplify_apply_expr.ml
@@ -701,28 +701,24 @@ let simplify_apply_shared dacc apply : _ Or_bottom.t =
   let callee_ty =
     S.simplify_simple dacc (Apply.callee apply) ~min_name_mode:NM.normal
   in
-  if T.is_obviously_bottom callee_ty then Bottom
-  else
-    let { S. seen_bottom; simples = args; simple_tys = arg_types; } =
-      S.simplify_simples dacc (Apply.args apply)
-    in
-    if seen_bottom then Bottom
-    else
-      let inlining_state =
-        Inlining_state.merge (DE.get_inlining_state (DA.denv dacc))
-          (Apply.inlining_state apply)
-      in
-      let apply =
-        Apply.create ~callee:(T.get_alias_exn callee_ty)
-          ~continuation:(Apply.continuation apply)
-          (Apply.exn_continuation apply)
-          ~args
-          ~call_kind:(Apply.call_kind apply)
-          (DE.add_inlined_debuginfo' (DA.denv dacc) (Apply.dbg apply))
-          ~inline:(Apply.inline apply)
-          ~inlining_state
-      in
-      Ok (callee_ty, apply, arg_types)
+  let { S. simples = args; simple_tys = arg_types; } =
+    S.simplify_simples dacc (Apply.args apply)
+  in
+  let inlining_state =
+    Inlining_state.merge (DE.get_inlining_state (DA.denv dacc))
+      (Apply.inlining_state apply)
+  in
+  let apply =
+    Apply.create ~callee:(T.get_alias_exn callee_ty)
+      ~continuation:(Apply.continuation apply)
+      (Apply.exn_continuation apply)
+      ~args
+      ~call_kind:(Apply.call_kind apply)
+      (DE.add_inlined_debuginfo' (DA.denv dacc) (Apply.dbg apply))
+      ~inline:(Apply.inline apply)
+      ~inlining_state
+  in
+  Ok (callee_ty, apply, arg_types)
 
 let rebuild_method_call apply ~use_id ~exn_cont_use_id uacc ~after_rebuild =
   let apply =

--- a/middle_end/flambda/simplify/simplify_named.ml
+++ b/middle_end/flambda/simplify/simplify_named.ml
@@ -150,20 +150,14 @@ let simplify_named0 dacc (bindable_let_bound : Bindable_let_bound.t)
     let bound_var = Bindable_let_bound.must_be_singleton bindable_let_bound in
     let min_name_mode = Var_in_binding_pos.name_mode bound_var in
     let ty = S.simplify_simple dacc simple ~min_name_mode in
-    if T.is_obviously_bottom ty then
-      let dacc = DA.add_variable dacc bound_var (T.bottom (T.kind ty)) in
-      let defining_expr = Simplified_named.invalid () in
-      Simplify_named_result.have_simplified_to_single_term dacc
-        bindable_let_bound defining_expr ~original_defining_expr:named
-    else
-      let new_simple = T.get_alias_exn ty in
-      let dacc = DA.add_variable dacc bound_var ty in
-      let defining_expr =
-        if simple == new_simple then Simplified_named.reachable named
-        else Simplified_named.reachable (Named.create_simple simple)
-      in
-      Simplify_named_result.have_simplified_to_single_term dacc
-        bindable_let_bound defining_expr ~original_defining_expr:named
+    let new_simple = T.get_alias_exn ty in
+    let dacc = DA.add_variable dacc bound_var ty in
+    let defining_expr =
+      if simple == new_simple then Simplified_named.reachable named
+      else Simplified_named.reachable (Named.create_simple simple)
+    in
+    Simplify_named_result.have_simplified_to_single_term dacc
+      bindable_let_bound defining_expr ~original_defining_expr:named
   | Prim (prim, dbg) ->
     let bound_var = Bindable_let_bound.must_be_singleton bindable_let_bound in
     let term, env_extension, simplified_args, dacc =

--- a/middle_end/flambda/simplify/simplify_named.ml
+++ b/middle_end/flambda/simplify/simplify_named.ml
@@ -149,13 +149,14 @@ let simplify_named0 dacc (bindable_let_bound : Bindable_let_bound.t)
   | Simple simple ->
     let bound_var = Bindable_let_bound.must_be_singleton bindable_let_bound in
     let min_name_mode = Var_in_binding_pos.name_mode bound_var in
-    begin match S.simplify_simple dacc simple ~min_name_mode with
-    | Bottom, ty ->
+    let ty = S.simplify_simple dacc simple ~min_name_mode in
+    if T.is_obviously_bottom ty then
       let dacc = DA.add_variable dacc bound_var (T.bottom (T.kind ty)) in
       let defining_expr = Simplified_named.invalid () in
       Simplify_named_result.have_simplified_to_single_term dacc
         bindable_let_bound defining_expr ~original_defining_expr:named
-    | Ok new_simple, ty ->
+    else
+      let new_simple = T.get_alias_exn ty in
       let dacc = DA.add_variable dacc bound_var ty in
       let defining_expr =
         if simple == new_simple then Simplified_named.reachable named
@@ -163,7 +164,6 @@ let simplify_named0 dacc (bindable_let_bound : Bindable_let_bound.t)
       in
       Simplify_named_result.have_simplified_to_single_term dacc
         bindable_let_bound defining_expr ~original_defining_expr:named
-    end
   | Prim (prim, dbg) ->
     let bound_var = Bindable_let_bound.must_be_singleton bindable_let_bound in
     let term, env_extension, simplified_args, dacc =

--- a/middle_end/flambda/simplify/simplify_primitive.ml
+++ b/middle_end/flambda/simplify/simplify_primitive.ml
@@ -29,8 +29,12 @@ let apply_cse dacc ~original_prim =
     match DE.find_cse (DA.denv dacc) with_fixed_value with
     | None -> None
     | Some simple ->
-      (* CR mshinwell: Is this missing a [min_name_mode] constraint? *)
-      match TE.get_canonical_simple_exn (DA.typing_env dacc) simple with
+      let canonical =
+        TE.get_canonical_simple_exn (DA.typing_env dacc) simple
+          ~min_name_mode:NM.normal
+          ~name_mode_of_existing_simple:NM.normal
+      in
+      match canonical with
       | exception Not_found -> None
       | simple -> Some simple
 
@@ -77,9 +81,12 @@ let simplify_primitive dacc (prim : P.t) dbg ~result_var =
     ListLabels.fold_left (P.args prim)
       ~init:([], false)
       ~f:(fun (args_rev, found_invalid) arg ->
-        match S.simplify_simple dacc arg ~min_name_mode with
-        | Bottom, arg_ty -> (arg, arg_ty) :: args_rev, true
-        | Ok arg, arg_ty -> (arg, arg_ty) :: args_rev, found_invalid)
+        let arg_ty = S.simplify_simple dacc arg ~min_name_mode in
+        if T.is_obviously_bottom arg_ty then
+          (arg, arg_ty) :: args_rev, true
+        else
+          let arg = T.get_alias_exn arg_ty in
+          (arg, arg_ty) :: args_rev, found_invalid)
   in
   let args = List.rev args_rev in
   if found_invalid then

--- a/middle_end/flambda/simplify/simplify_primitive.ml
+++ b/middle_end/flambda/simplify/simplify_primitive.ml
@@ -82,11 +82,8 @@ let simplify_primitive dacc (prim : P.t) dbg ~result_var =
       ~init:([], false)
       ~f:(fun (args_rev, found_invalid) arg ->
         let arg_ty = S.simplify_simple dacc arg ~min_name_mode in
-        if T.is_obviously_bottom arg_ty then
-          (arg, arg_ty) :: args_rev, true
-        else
-          let arg = T.get_alias_exn arg_ty in
-          (arg, arg_ty) :: args_rev, found_invalid)
+        let arg = T.get_alias_exn arg_ty in
+        (arg, arg_ty) :: args_rev, found_invalid)
   in
   let args = List.rev args_rev in
   if found_invalid then

--- a/middle_end/flambda/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda/simplify/simplify_set_of_closures.ml
@@ -795,27 +795,22 @@ let type_closure_elements_and_make_lifting_decision_for_one_set dacc
            (closure_elements, closure_element_types, symbol_projections) ->
         let env_entry, ty, symbol_projections =
           let ty = S.simplify_simple dacc env_entry ~min_name_mode in
-          if T.is_obviously_bottom ty then begin
-            assert (K.equal (T.kind ty) K.value);
-            env_entry, ty, symbol_projections
-          end else begin
-            let simple = T.get_alias_exn ty in
-            (* Note down separately if [simple] remains a variable and is known
-               to be equal to a projection from a symbol. *)
-            let symbol_projections =
-              Simple.pattern_match' simple
-                ~const:(fun _ -> symbol_projections)
-                ~symbol:(fun _ -> symbol_projections)
-                ~var:(fun var ->
-                  (* [var] will already be canonical, as we require for the
-                     symbol projections map. *)
-                  match DE.find_symbol_projection (DA.denv dacc) var with
-                  | None -> symbol_projections
-                  | Some proj ->
-                    Variable.Map.add var proj symbol_projections)
-            in
-            simple, ty, symbol_projections
-          end
+          let simple = T.get_alias_exn ty in
+          (* Note down separately if [simple] remains a variable and is known
+             to be equal to a projection from a symbol. *)
+          let symbol_projections =
+            Simple.pattern_match' simple
+              ~const:(fun _ -> symbol_projections)
+              ~symbol:(fun _ -> symbol_projections)
+              ~var:(fun var ->
+                (* [var] will already be canonical, as we require for the
+                   symbol projections map. *)
+                match DE.find_symbol_projection (DA.denv dacc) var with
+                | None -> symbol_projections
+                | Some proj ->
+                  Variable.Map.add var proj symbol_projections)
+          in
+          simple, ty, symbol_projections
         in
         let closure_elements =
           Var_within_closure.Map.add closure_var env_entry closure_elements

--- a/middle_end/flambda/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda/simplify/simplify_set_of_closures.ml
@@ -794,11 +794,12 @@ let type_closure_elements_and_make_lifting_decision_for_one_set dacc
       (fun closure_var env_entry
            (closure_elements, closure_element_types, symbol_projections) ->
         let env_entry, ty, symbol_projections =
-          match S.simplify_simple dacc env_entry ~min_name_mode with
-          | Bottom, ty ->
+          let ty = S.simplify_simple dacc env_entry ~min_name_mode in
+          if T.is_obviously_bottom ty then begin
             assert (K.equal (T.kind ty) K.value);
             env_entry, ty, symbol_projections
-          | Ok simple, ty ->
+          end else begin
+            let simple = T.get_alias_exn ty in
             (* Note down separately if [simple] remains a variable and is known
                to be equal to a projection from a symbol. *)
             let symbol_projections =
@@ -814,6 +815,7 @@ let type_closure_elements_and_make_lifting_decision_for_one_set dacc
                     Variable.Map.add var proj symbol_projections)
             in
             simple, ty, symbol_projections
+          end
         in
         let closure_elements =
           Var_within_closure.Map.add closure_var env_entry closure_elements

--- a/middle_end/flambda/simplify/simplify_simple.ml
+++ b/middle_end/flambda/simplify/simplify_simple.ml
@@ -32,14 +32,12 @@ let simplify_simple dacc simple ~min_name_mode =
   | ty -> ty
 
 type simplify_simples_result = {
-  seen_bottom : bool;
   simples : Simple.t list;
   simple_tys : Flambda_type.t list;
 }
 
 let simplify_simples dacc simples =
   let typing_env = DA.typing_env dacc in
-  let seen_bottom = ref false in
   let simple_tys =
     ListLabels.map simples ~f:(fun simple ->
       match
@@ -49,9 +47,6 @@ let simplify_simples dacc simples =
       | ty ->
         (* [ty] will always be an alias type; see the implementation of
            [TE.get_canonical_simple_in_term_exn]. *)
-        if T.is_obviously_bottom ty then begin
-          seen_bottom := true
-        end;
         ty
       | exception Not_found ->
         Misc.fatal_errorf "No canonical [Simple] for %a exists at the@ \
@@ -60,7 +55,6 @@ let simplify_simples dacc simples =
           Simple.print simple
           DA.print dacc)
   in
-  { seen_bottom = !seen_bottom;
-    simples = ListLabels.map simple_tys ~f:T.get_alias_exn;
+  { simples = ListLabels.map simple_tys ~f:T.get_alias_exn;
     simple_tys;
   }

--- a/middle_end/flambda/simplify/simplify_simple.ml
+++ b/middle_end/flambda/simplify/simplify_simple.ml
@@ -20,87 +20,47 @@ module DA = Downwards_acc
 module T = Flambda_type
 module TE = T.Typing_env
 
-(* CR mshinwell: Is the best place for this?  Are there other places where
-   this may be required? *)
-(* CR mshinwell: avoid having two functions *)
-let type_for_simple simple kind : _ Or_bottom.t =
-  let ty = T.alias_type_of kind simple in
-  match Simple.rec_info simple with
-  | None -> Ok (simple, ty)
-  | Some rec_info ->
-    match T.apply_rec_info ty rec_info with
-    | Bottom -> Bottom
-    | Ok ty -> Ok (simple, ty)
-
-let type_for_simple' simple kind : _ Or_bottom.t * _ =
-  let ty = T.alias_type_of kind simple in
-  match Simple.rec_info simple with
-  | None -> Ok simple, ty
-  | Some rec_info ->
-    match T.apply_rec_info ty rec_info with
-    | Bottom -> Bottom, T.bottom (T.kind ty)
-    | Ok ty -> Ok simple, ty
-
-let simplify_simple dacc simple ~min_name_mode : _ Or_bottom.t * _ =
+let simplify_simple dacc simple ~min_name_mode =
   let typing_env = DA.typing_env dacc in
-  match
-    TE.get_canonical_simple_with_kind_exn typing_env simple ~min_name_mode
-  with
+  match TE.type_simple_in_term_exn typing_env simple ~min_name_mode with
   | exception Not_found ->
     Misc.fatal_errorf "No canonical [Simple] for %a exists at the@ \
         requested name mode (%a) or one greater.@ Downwards accumulator:@ %a"
       Simple.print simple
       Name_mode.print min_name_mode
       DA.print dacc
-  | simple, kind -> type_for_simple' simple kind
+  | ty -> ty
 
-type changed =
-  | Unchanged
-  | Changed
+type simplify_simples_result = {
+  seen_bottom : bool;
+  simples : Simple.t list;
+  simple_tys : Flambda_type.t list;
+}
 
-let simplify_simples dacc simples ~min_name_mode =
+let simplify_simples dacc simples =
   let typing_env = DA.typing_env dacc in
-  let changed = ref Unchanged in
-  let result =
-    Or_bottom.all (List.map (fun simple : _ Or_bottom.t ->
-        match
-          TE.get_canonical_simple_with_kind_exn typing_env simple
-            ~min_name_mode
-        with
-        | new_simple, kind ->
-          if new_simple != simple then begin
-            changed := Changed;
-          end;
-          type_for_simple new_simple kind
-        | exception Not_found ->
-          Misc.fatal_errorf "No canonical [Simple] for %a exists at the@ \
-              requested name mode (%a) or one greater.@ \
-              Downwards accumulator:@ %a"
-            Simple.print simple
-            Name_mode.print min_name_mode
-            DA.print dacc)
-      simples)
+  let seen_bottom = ref false in
+  let simple_tys =
+    ListLabels.map simples ~f:(fun simple ->
+      match
+        TE.type_simple_in_term_exn typing_env simple
+          ~min_name_mode:Name_mode.normal
+      with
+      | ty ->
+        (* [ty] will always be an alias type; see the implementation of
+           [TE.get_canonical_simple_in_term_exn]. *)
+        if T.is_obviously_bottom ty then begin
+          seen_bottom := true
+        end;
+        ty
+      | exception Not_found ->
+        Misc.fatal_errorf "No canonical [Simple] for %a exists at the@ \
+            requested name mode (Normal) or one greater.@ \
+            Downwards accumulator:@ %a"
+          Simple.print simple
+          DA.print dacc)
   in
-  !changed, result
-
-let simplify_simples' dacc simples ~min_name_mode =
-  let typing_env = DA.typing_env dacc in
-  let changed = ref Unchanged in
-  let result =
-    Or_bottom.all (List.map (fun simple : _ Or_bottom.t ->
-        match TE.get_canonical_simple_exn typing_env simple ~min_name_mode with
-        | new_simple ->
-          if new_simple != simple then begin
-            changed := Changed;
-          end;
-          Ok new_simple
-        | exception Not_found ->
-          Misc.fatal_errorf "No canonical [Simple] for %a exists at the@ \
-              requested name mode (%a) or one greater.@ \
-              Downwards accumulator:@ %a"
-            Simple.print simple
-            Name_mode.print min_name_mode
-            DA.print dacc)
-      simples)
-  in
-  !changed, result
+  { seen_bottom = !seen_bottom;
+    simples = ListLabels.map simple_tys ~f:T.get_alias_exn;
+    simple_tys;
+  }

--- a/middle_end/flambda/simplify/simplify_simple.mli
+++ b/middle_end/flambda/simplify/simplify_simple.mli
@@ -26,7 +26,6 @@ val simplify_simple
   -> Flambda_type.t
 
 type simplify_simples_result = private {
-  seen_bottom : bool;
   simples : Simple.t list;
   simple_tys : Flambda_type.t list;
 }

--- a/middle_end/flambda/simplify/simplify_simple.mli
+++ b/middle_end/flambda/simplify/simplify_simple.mli
@@ -18,24 +18,20 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
+(** This function is guaranteed to return an alias type. *)
 val simplify_simple
    : Downwards_acc.t
   -> Simple.t
   -> min_name_mode:Name_mode.t
-  -> Simple.t Or_bottom.t * Flambda_type.t
+  -> Flambda_type.t
 
-type changed =
-  | Unchanged
-  | Changed
+type simplify_simples_result = private {
+  seen_bottom : bool;
+  simples : Simple.t list;
+  simple_tys : Flambda_type.t list;
+}
 
 val simplify_simples
    : Downwards_acc.t
   -> Simple.t list
-  -> min_name_mode:Name_mode.t
-  -> changed * ((Simple.t * Flambda_type.t) list Or_bottom.t)
-
-val simplify_simples'
-   : Downwards_acc.t
-  -> Simple.t list
-  -> min_name_mode:Name_mode.t
-  -> changed * (Simple.t list Or_bottom.t)
+  -> simplify_simples_result

--- a/middle_end/flambda/simplify/simplify_static_const.ml
+++ b/middle_end/flambda/simplify/simplify_static_const.ml
@@ -29,25 +29,19 @@ let simplify_field_of_block dacc (field : Field_of_block.t) =
   | Dynamically_computed var ->
     let min_name_mode = Name_mode.normal in
     let ty = S.simplify_simple dacc (Simple.var var) ~min_name_mode in
-    if T.is_obviously_bottom ty then begin
-      assert (K.equal (T.kind ty) K.value);
-      (* CR mshinwell: This should be "invalid" and propagate up *)
-      field, T.bottom K.value
-    end else begin
-      let simple = T.get_alias_exn ty in
-      Simple.pattern_match simple
-        ~name:(fun name ->
-          Name.pattern_match name
-            ~var:(fun var -> Field_of_block.Dynamically_computed var, ty)
-            ~symbol:(fun sym -> Field_of_block.Symbol sym, ty))
-        ~const:(fun const ->
-          match Reg_width_const.descr const with
-          | Tagged_immediate imm -> Field_of_block.Tagged_immediate imm, ty
-          | Naked_immediate _ | Naked_float _ | Naked_int32 _
-              | Naked_int64 _ | Naked_nativeint _ ->
-            (* CR mshinwell: This should be "invalid" and propagate up *)
-            field, ty)
-    end
+    let simple = T.get_alias_exn ty in
+    Simple.pattern_match simple
+      ~name:(fun name ->
+        Name.pattern_match name
+          ~var:(fun var -> Field_of_block.Dynamically_computed var, ty)
+          ~symbol:(fun sym -> Field_of_block.Symbol sym, ty))
+      ~const:(fun const ->
+        match Reg_width_const.descr const with
+        | Tagged_immediate imm -> Field_of_block.Tagged_immediate imm, ty
+        | Naked_immediate _ | Naked_float _ | Naked_int32 _
+            | Naked_int64 _ | Naked_nativeint _ ->
+          (* CR mshinwell: This should be "invalid" and propagate up *)
+          field, ty)
 
 let simplify_or_variable dacc type_for_const
       (or_variable : _ Or_variable.t) =

--- a/middle_end/flambda/types/env/typing_env.rec.mli
+++ b/middle_end/flambda/types/env/typing_env.rec.mli
@@ -98,21 +98,25 @@ val add_env_extension_with_extra_variables
   -> Typing_env_extension.With_extra_variables.t
   -> t
 
+val type_simple_in_term_exn
+   : t
+  -> ?min_name_mode:Name_mode.t
+  -> Simple.t
+  -> Type_grammar.t
+
+(** [name_mode_of_existing_simple] can be provided to improve performance
+    of this function. *)
 val get_canonical_simple_exn
    : t
   -> ?min_name_mode:Name_mode.t
+  -> ?name_mode_of_existing_simple:Name_mode.t
   -> Simple.t
   -> Simple.t
-
-val get_canonical_simple_with_kind_exn
-   : t
-  -> ?min_name_mode:Name_mode.t
-  -> Simple.t
-  -> Simple.t * Flambda_kind.t
 
 val get_alias_then_canonical_simple_exn
    : t
   -> ?min_name_mode:Name_mode.t
+  -> ?name_mode_of_existing_simple:Name_mode.t
   -> Type_grammar.t
   -> Simple.t
 

--- a/middle_end/flambda/types/flambda_type.mli
+++ b/middle_end/flambda/types/flambda_type.mli
@@ -140,19 +140,22 @@ module Typing_env : sig
     -> Typing_env_extension.With_extra_variables.t
     -> t
 
-  (** Raises [Not_found] if no canonical [Simple] was found. *)
+  (** Raises [Not_found] if no canonical [Simple] was found.
+      [name_mode_of_existing_simple] can be provided to improve performance
+      of this function. *)
   val get_canonical_simple_exn
      : t
     -> ?min_name_mode:Name_mode.t
+    -> ?name_mode_of_existing_simple:Name_mode.t
     -> Simple.t
     -> Simple.t
 
   (** Raises [Not_found] if no canonical [Simple] was found. *)
-  val get_canonical_simple_with_kind_exn
+  val type_simple_in_term_exn
      : t
     -> ?min_name_mode:Name_mode.t
     -> Simple.t
-    -> Simple.t * Flambda_kind.t
+    -> flambda_type
 
   val add_to_code_age_relation : t -> newer:Code_id.t -> older:Code_id.t -> t
 
@@ -454,6 +457,8 @@ val bottom_types_from_arity : Flambda_arity.t -> t list
 (** Whether the given type says that a term of that type can never be
     constructed (in other words, it is [Invalid]). *)
 val is_bottom : (t -> bool) type_accessor
+
+val is_obviously_bottom : t -> bool
 
 val type_for_const : Reg_width_const.t -> t
 val kind_for_const : Reg_width_const.t -> Flambda_kind.t

--- a/middle_end/flambda/unboxing/unbox_continuation_params.ml
+++ b/middle_end/flambda/unboxing/unbox_continuation_params.ml
@@ -128,9 +128,9 @@ module Make (U : Unboxing_spec) = struct
             | exception Not_found -> None
             | block ->
               match
-                TE.get_canonical_simple_exn typing_env_at_use
+                TE.get_canonical_simple_exn typing_env_at_use block
                   ~min_name_mode:Name_mode.normal
-                  block
+                  ~name_mode_of_existing_simple:NM.normal
               with
               | exception Not_found -> None
               | block -> Some block
@@ -225,9 +225,9 @@ module Make (U : Unboxing_spec) = struct
                 Continue (extra_args, field_types_by_id)
               in
               match
-                TE.get_canonical_simple_exn typing_env_at_use
-                  ~min_name_mode:Name_mode.normal
-                  field
+                TE.get_canonical_simple_exn typing_env_at_use field
+                  ~min_name_mode:NM.normal
+                  ~name_mode_of_existing_simple:NM.normal
               with
               | exception Not_found ->
                 begin match untag with
@@ -241,8 +241,9 @@ module Make (U : Unboxing_spec) = struct
                   let untagged_field = Simple.var untagged_field_var in
                   match
                     TE.get_canonical_simple_exn typing_env_at_use
-                      ~min_name_mode:Name_mode.normal
-                    untagged_field
+                      untagged_field
+                      ~min_name_mode:NM.normal
+                      ~name_mode_of_existing_simple:NM.normal
                   with
                   | exception Not_found -> fail ()
                   | untagged_simple ->


### PR DESCRIPTION
This should reduce the number of lookups in the names-to-types map.  It also aims to improve the interface to `Simplify_simple` and reduce allocation.

I need to look over this again as there is currently a build failure on top of my other recent patches, complaining about a variable from another unit not being found in the corresponding `.cmx` file.