### PR TITLE
Add support for not rebuilding terms during simplification

### DIFF
--- a/.depend
+++ b/.depend
@@ -4842,7 +4842,6 @@ middle_end/flambda/from_lambda/closure_conversion.cmo : \
     middle_end/flambda/basic/continuation.cmi \
     utils/config.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    middle_end/flambda/inlining/metrics/code_size.cmi \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/basic/closure_id.cmi \
     middle_end/flambda/from_lambda/closure_conversion_aux.cmi \
@@ -4895,7 +4894,6 @@ middle_end/flambda/from_lambda/closure_conversion.cmx : \
     middle_end/flambda/basic/continuation.cmx \
     utils/config.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
-    middle_end/flambda/inlining/metrics/code_size.cmx \
     middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/basic/closure_id.cmx \
     middle_end/flambda/from_lambda/closure_conversion_aux.cmx \
@@ -5367,7 +5365,6 @@ middle_end/flambda/lifting/lifted_constant.cmo : \
     middle_end/flambda/naming/name_mode.cmi \
     utils/misc.cmi \
     middle_end/flambda/types/flambda_type.cmi \
-    middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/simplify/env/downwards_env.cmi \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/basic/closure_id.cmi \
@@ -5383,7 +5380,6 @@ middle_end/flambda/lifting/lifted_constant.cmx : \
     middle_end/flambda/naming/name_mode.cmx \
     utils/misc.cmx \
     middle_end/flambda/types/flambda_type.cmx \
-    middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/simplify/env/downwards_env.cmx \
     middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/basic/closure_id.cmx \
@@ -6099,6 +6095,7 @@ middle_end/flambda/simplify/expr_builder.cmo : \
     middle_end/flambda/terms/set_of_closures.cmi \
     middle_end/flambda/inlining/metrics/removed_operations.cmi \
     middle_end/flambda/simplify/rebuilt_static_const.cmi \
+    middle_end/flambda/simplify/rebuilt_expr.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     utils/misc.cmi \
@@ -6116,9 +6113,9 @@ middle_end/flambda/simplify/expr_builder.cmo : \
     middle_end/flambda/basic/code_id_or_symbol.cmi \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/types/structures/code_age_relation.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/terms/bound_symbols.cmi \
     middle_end/flambda/naming/bindable_let_bound.cmi \
+    middle_end/flambda/simplify/env/are_rebuilding_terms.cmi \
     middle_end/flambda/simplify/basic/apply_cont_rewrite.cmi \
     middle_end/flambda/terms/apply_cont_expr.cmi \
     middle_end/flambda/simplify/expr_builder.cmi
@@ -6139,6 +6136,7 @@ middle_end/flambda/simplify/expr_builder.cmx : \
     middle_end/flambda/terms/set_of_closures.cmx \
     middle_end/flambda/inlining/metrics/removed_operations.cmx \
     middle_end/flambda/simplify/rebuilt_static_const.cmx \
+    middle_end/flambda/simplify/rebuilt_expr.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     utils/misc.cmx \
@@ -6156,9 +6154,9 @@ middle_end/flambda/simplify/expr_builder.cmx : \
     middle_end/flambda/basic/code_id_or_symbol.cmx \
     middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/types/structures/code_age_relation.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/terms/bound_symbols.cmx \
     middle_end/flambda/naming/bindable_let_bound.cmx \
+    middle_end/flambda/simplify/env/are_rebuilding_terms.cmx \
     middle_end/flambda/simplify/basic/apply_cont_rewrite.cmx \
     middle_end/flambda/terms/apply_cont_expr.cmx \
     middle_end/flambda/simplify/expr_builder.cmi
@@ -6168,6 +6166,7 @@ middle_end/flambda/simplify/expr_builder.cmi : \
     middle_end/flambda/basic/symbol_scoping_rule.cmi \
     middle_end/flambda/simplify/basic/simplify_named_result.cmi \
     middle_end/flambda/basic/simple.cmi \
+    middle_end/flambda/simplify/rebuilt_expr.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/lifting/lifted_constant_state.cmi \
     middle_end/flambda/lifting/lifted_constant.cmi \
@@ -6176,10 +6175,8 @@ middle_end/flambda/simplify/expr_builder.cmi : \
     middle_end/flambda/basic/exn_continuation.cmi \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/types/structures/code_age_relation.cmi \
-    middle_end/flambda/terms/apply_expr.cmi \
     middle_end/flambda/basic/apply_cont_rewrite_id.cmi \
-    middle_end/flambda/simplify/basic/apply_cont_rewrite.cmi \
-    middle_end/flambda/terms/apply_cont_expr.cmi
+    middle_end/flambda/simplify/basic/apply_cont_rewrite.cmi
 middle_end/flambda/simplify/non_constructed_code.cmo : \
     middle_end/flambda/types/basic/unit.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
@@ -6195,34 +6192,95 @@ middle_end/flambda/simplify/non_constructed_code.cmx : \
 middle_end/flambda/simplify/non_constructed_code.cmi : \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/terms/code_intf.cmo
+middle_end/flambda/simplify/rebuilt_expr.cmo : \
+    middle_end/flambda/naming/var_in_binding_pos.cmi \
+    middle_end/flambda/naming/name_occurrences.cmi \
+    middle_end/flambda/naming/name_mode.cmi \
+    utils/misc.cmi \
+    middle_end/flambda/terms/flambda.cmi \
+    middle_end/flambda/naming/bindable_let_bound.cmi \
+    middle_end/flambda/simplify/env/are_rebuilding_terms.cmi \
+    middle_end/flambda/simplify/rebuilt_expr.cmi
+middle_end/flambda/simplify/rebuilt_expr.cmx : \
+    middle_end/flambda/naming/var_in_binding_pos.cmx \
+    middle_end/flambda/naming/name_occurrences.cmx \
+    middle_end/flambda/naming/name_mode.cmx \
+    utils/misc.cmx \
+    middle_end/flambda/terms/flambda.cmx \
+    middle_end/flambda/naming/bindable_let_bound.cmx \
+    middle_end/flambda/simplify/env/are_rebuilding_terms.cmx \
+    middle_end/flambda/simplify/rebuilt_expr.cmi
+middle_end/flambda/simplify/rebuilt_expr.cmi : \
+    middle_end/flambda/compilenv_deps/variable.cmi \
+    middle_end/flambda/naming/var_in_binding_pos.cmi \
+    middle_end/flambda/terms/switch_expr.cmi \
+    middle_end/flambda/naming/num_occurrences.cmi \
+    middle_end/flambda/naming/name_occurrences.cmi \
+    middle_end/flambda/basic/kinded_parameter.cmi \
+    middle_end/flambda/terms/flambda.cmi \
+    middle_end/flambda/basic/exn_continuation.cmi \
+    lambda/debuginfo.cmi \
+    middle_end/flambda/basic/continuation.cmi \
+    middle_end/flambda/inlining/metrics/code_size.cmi \
+    middle_end/flambda/naming/bindable_let_bound.cmi \
+    middle_end/flambda/simplify/env/are_rebuilding_terms.cmi
 middle_end/flambda/simplify/rebuilt_static_const.cmo : \
+    middle_end/flambda/compilenv_deps/variable.cmi \
+    middle_end/flambda/terms/set_of_closures.cmi \
+    middle_end/flambda/simplify/rebuilt_expr.cmi \
+    middle_end/flambda/basic/or_variable.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
+    middle_end/flambda/basic/or_deleted.cmi \
+    middle_end/flambda/simplify/non_constructed_code.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     utils/misc.cmi \
     middle_end/flambda/terms/flambda.cmi \
+    middle_end/flambda/basic/exn_continuation.cmi \
+    lambda/debuginfo.cmi \
+    middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/basic/code_id.cmi \
+    middle_end/flambda/simplify/env/are_rebuilding_terms.cmi \
     middle_end/flambda/simplify/rebuilt_static_const.cmi
 middle_end/flambda/simplify/rebuilt_static_const.cmx : \
+    middle_end/flambda/compilenv_deps/variable.cmx \
+    middle_end/flambda/terms/set_of_closures.cmx \
+    middle_end/flambda/simplify/rebuilt_expr.cmx \
+    middle_end/flambda/basic/or_variable.cmx \
     middle_end/flambda/types/basic/or_unknown.cmx \
+    middle_end/flambda/basic/or_deleted.cmx \
+    middle_end/flambda/simplify/non_constructed_code.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     utils/misc.cmx \
     middle_end/flambda/terms/flambda.cmx \
+    middle_end/flambda/basic/exn_continuation.cmx \
+    lambda/debuginfo.cmx \
+    middle_end/flambda/basic/continuation.cmx \
     middle_end/flambda/basic/code_id.cmx \
+    middle_end/flambda/simplify/env/are_rebuilding_terms.cmx \
     middle_end/flambda/simplify/rebuilt_static_const.cmi
 middle_end/flambda/simplify/rebuilt_static_const.cmi : \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
+    utils/targetint.cmi \
+    lambda/tag.cmi \
     middle_end/flambda/terms/set_of_closures.cmi \
+    middle_end/flambda/basic/recursive.cmi \
+    middle_end/flambda/simplify/rebuilt_expr.cmi \
+    middle_end/flambda/basic/or_variable.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
+    middle_end/flambda/basic/or_deleted.cmi \
+    utils/numbers.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
+    middle_end/flambda/basic/mutability.cmi \
+    middle_end/flambda/basic/inline_attribute.cmi \
+    middle_end/flambda/types/kinds/flambda_arity.cmi \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/basic/code_id.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    middle_end/flambda/terms/bound_symbols.cmi
+    middle_end/flambda/simplify/env/are_rebuilding_terms.cmi
 middle_end/flambda/simplify/simplify.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/simplify/simplify_import.cmi \
     middle_end/flambda/simplify/simplify_expr.cmi \
+    middle_end/flambda/simplify/rebuilt_expr.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_in_binding_pos.cmi \
     middle_end/flambda/basic/name.cmi \
@@ -6242,6 +6300,7 @@ middle_end/flambda/simplify/simplify.cmx : \
     middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/simplify/simplify_import.cmx \
     middle_end/flambda/simplify/simplify_expr.cmx \
+    middle_end/flambda/simplify/rebuilt_expr.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_in_binding_pos.cmx \
     middle_end/flambda/basic/name.cmx \
@@ -6265,13 +6324,11 @@ middle_end/flambda/simplify/simplify_apply_cont_expr.cmo : \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
     middle_end/flambda/simplify/basic/simplify_named_result.cmi \
     middle_end/flambda/simplify/simplify_import.cmi \
-    middle_end/flambda/simplify/simplify_common.cmi \
     middle_end/flambda/simplify/basic/simplified_named.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/inlining/metrics/removed_operations.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     utils/misc.cmi \
-    middle_end/flambda/simplify/expr_builder.cmi \
     middle_end/flambda/simplify/env/continuation_use_kind.cmi \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/inlining/metrics/code_size.cmi \
@@ -6281,13 +6338,11 @@ middle_end/flambda/simplify/simplify_apply_cont_expr.cmx : \
     middle_end/flambda/naming/var_in_binding_pos.cmx \
     middle_end/flambda/simplify/basic/simplify_named_result.cmx \
     middle_end/flambda/simplify/simplify_import.cmx \
-    middle_end/flambda/simplify/simplify_common.cmx \
     middle_end/flambda/simplify/basic/simplified_named.cmx \
     middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/inlining/metrics/removed_operations.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     utils/misc.cmx \
-    middle_end/flambda/simplify/expr_builder.cmx \
     middle_end/flambda/simplify/env/continuation_use_kind.cmx \
     middle_end/flambda/basic/continuation.cmx \
     middle_end/flambda/inlining/metrics/code_size.cmx \
@@ -6419,16 +6474,23 @@ middle_end/flambda/simplify/simplify_binary_primitive.cmi : \
     lambda/debuginfo.cmi
 middle_end/flambda/simplify/simplify_common.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
+    middle_end/flambda/simplify/env/upwards_env.cmi \
     middle_end/flambda/simplify/env/upwards_acc.cmi \
     utils/targetint.cmi \
     lambda/tag.cmi \
-    middle_end/flambda/simplify/simplify_import.cmi \
     middle_end/flambda/simplify/basic/simplified_named.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/basic/scope.cmi \
+    middle_end/flambda/simplify/rebuilt_expr.cmi \
     middle_end/flambda/basic/mutability.cmi \
     utils/misc.cmi \
+    middle_end/flambda/basic/kinded_parameter.cmi \
+    middle_end/flambda/types/flambda_type.cmi \
+    middle_end/flambda/terms/flambda_primitive.cmi \
+    middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/types/kinds/flambda_arity.cmi \
+    middle_end/flambda/terms/flambda.cmi \
+    middle_end/flambda/simplify/expr_builder.cmi \
     middle_end/flambda/basic/exn_continuation.cmi \
     middle_end/flambda/simplify/env/downwards_acc.cmi \
     middle_end/flambda/basic/continuation.cmi \
@@ -6436,16 +6498,23 @@ middle_end/flambda/simplify/simplify_common.cmo : \
     middle_end/flambda/simplify/simplify_common.cmi
 middle_end/flambda/simplify/simplify_common.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
+    middle_end/flambda/simplify/env/upwards_env.cmx \
     middle_end/flambda/simplify/env/upwards_acc.cmx \
     utils/targetint.cmx \
     lambda/tag.cmx \
-    middle_end/flambda/simplify/simplify_import.cmx \
     middle_end/flambda/simplify/basic/simplified_named.cmx \
     middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/basic/scope.cmx \
+    middle_end/flambda/simplify/rebuilt_expr.cmx \
     middle_end/flambda/basic/mutability.cmx \
     utils/misc.cmx \
+    middle_end/flambda/basic/kinded_parameter.cmx \
+    middle_end/flambda/types/flambda_type.cmx \
+    middle_end/flambda/terms/flambda_primitive.cmx \
+    middle_end/flambda/types/kinds/flambda_kind.cmx \
     middle_end/flambda/types/kinds/flambda_arity.cmx \
+    middle_end/flambda/terms/flambda.cmx \
+    middle_end/flambda/simplify/expr_builder.cmx \
     middle_end/flambda/basic/exn_continuation.cmx \
     middle_end/flambda/simplify/env/downwards_acc.cmx \
     middle_end/flambda/basic/continuation.cmx \
@@ -6457,6 +6526,7 @@ middle_end/flambda/simplify/simplify_common.cmi : \
     middle_end/flambda/simplify/basic/simplified_named.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/basic/scope.cmi \
+    middle_end/flambda/simplify/rebuilt_expr.cmi \
     middle_end/flambda/types/flambda_type.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/types/kinds/flambda_arity.cmi \
@@ -6472,30 +6542,24 @@ middle_end/flambda/simplify/simplify_expr.cmo : \
     middle_end/flambda/simplify/simplify_let_expr.cmi \
     middle_end/flambda/simplify/simplify_let_cont_expr.cmi \
     middle_end/flambda/simplify/simplify_import.cmi \
-    middle_end/flambda/simplify/simplify_common.cmi \
     middle_end/flambda/simplify/simplify_apply_expr.cmi \
     middle_end/flambda/simplify/simplify_apply_cont_expr.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     utils/misc.cmi \
     middle_end/flambda/basic/exn_continuation.cmi \
-    middle_end/flambda/simplify/env/downwards_env.cmi \
     middle_end/flambda/basic/continuation.cmi \
-    middle_end/flambda/inlining/metrics/code_size.cmi \
     middle_end/flambda/simplify/simplify_expr.cmi
 middle_end/flambda/simplify/simplify_expr.cmx : \
     middle_end/flambda/simplify/simplify_switch_expr.cmx \
     middle_end/flambda/simplify/simplify_let_expr.cmx \
     middle_end/flambda/simplify/simplify_let_cont_expr.cmx \
     middle_end/flambda/simplify/simplify_import.cmx \
-    middle_end/flambda/simplify/simplify_common.cmx \
     middle_end/flambda/simplify/simplify_apply_expr.cmx \
     middle_end/flambda/simplify/simplify_apply_cont_expr.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     utils/misc.cmx \
     middle_end/flambda/basic/exn_continuation.cmx \
-    middle_end/flambda/simplify/env/downwards_env.cmx \
     middle_end/flambda/basic/continuation.cmx \
-    middle_end/flambda/inlining/metrics/code_size.cmx \
     middle_end/flambda/simplify/simplify_expr.cmi
 middle_end/flambda/simplify/simplify_expr.cmi : \
     middle_end/flambda/simplify/simplify_common.cmi \
@@ -6505,6 +6569,7 @@ middle_end/flambda/simplify/simplify_import.cmo : \
     middle_end/flambda/simplify/env/upwards_env.cmi \
     middle_end/flambda/simplify/env/upwards_acc.cmi \
     middle_end/flambda/simplify/simplify_simple.cmi \
+    middle_end/flambda/simplify/rebuilt_expr.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/lifting/lifted_constant_state.cmi \
     middle_end/flambda/lifting/lifted_constant.cmi \
@@ -6527,6 +6592,7 @@ middle_end/flambda/simplify/simplify_import.cmx : \
     middle_end/flambda/simplify/env/upwards_env.cmx \
     middle_end/flambda/simplify/env/upwards_acc.cmx \
     middle_end/flambda/simplify/simplify_simple.cmx \
+    middle_end/flambda/simplify/rebuilt_expr.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/lifting/lifted_constant_state.cmx \
     middle_end/flambda/lifting/lifted_constant.cmx \
@@ -6549,6 +6615,7 @@ middle_end/flambda/simplify/simplify_import.cmi : \
     middle_end/flambda/simplify/env/upwards_env.cmi \
     middle_end/flambda/simplify/env/upwards_acc.cmi \
     middle_end/flambda/simplify/simplify_simple.cmi \
+    middle_end/flambda/simplify/rebuilt_expr.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/lifting/lifted_constant_state.cmi \
     middle_end/flambda/lifting/lifted_constant.cmi \
@@ -6578,8 +6645,6 @@ middle_end/flambda/simplify/simplify_let_cont_expr.cmo : \
     middle_end/flambda/naming/name_mode.cmi \
     utils/misc.cmi \
     middle_end/flambda/terms/flambda_primitive.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/simplify/expr_builder.cmi \
     lambda/debuginfo.cmi \
     middle_end/flambda/basic/continuation_extra_params_and_args.cmi \
     middle_end/flambda/simplify/env/continuation_env_and_param_types.cmi \
@@ -6600,8 +6665,6 @@ middle_end/flambda/simplify/simplify_let_cont_expr.cmx : \
     middle_end/flambda/naming/name_mode.cmx \
     utils/misc.cmx \
     middle_end/flambda/terms/flambda_primitive.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    middle_end/flambda/simplify/expr_builder.cmx \
     lambda/debuginfo.cmx \
     middle_end/flambda/basic/continuation_extra_params_and_args.cmx \
     middle_end/flambda/simplify/env/continuation_env_and_param_types.cmx \
@@ -6774,6 +6837,7 @@ middle_end/flambda/simplify/simplify_set_of_closures.cmo : \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
     middle_end/flambda/simplify/rebuilt_static_const.cmi \
     utils/profile.cmi \
+    middle_end/flambda/types/basic/or_unknown_or_bottom.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/naming/name_in_binding_pos.cmi \
@@ -6798,6 +6862,7 @@ middle_end/flambda/simplify/simplify_set_of_closures.cmo : \
     utils/clflags.cmi \
     middle_end/flambda/terms/bound_symbols.cmi \
     middle_end/flambda/naming/bindable_let_bound.cmi \
+    middle_end/flambda/simplify/env/are_rebuilding_terms.cmi \
     middle_end/flambda/simplify/simplify_set_of_closures.cmi
 middle_end/flambda/simplify/simplify_set_of_closures.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
@@ -6815,6 +6880,7 @@ middle_end/flambda/simplify/simplify_set_of_closures.cmx : \
     middle_end/flambda/compilenv_deps/rec_info.cmx \
     middle_end/flambda/simplify/rebuilt_static_const.cmx \
     utils/profile.cmx \
+    middle_end/flambda/types/basic/or_unknown_or_bottom.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/naming/name_in_binding_pos.cmx \
@@ -6839,6 +6905,7 @@ middle_end/flambda/simplify/simplify_set_of_closures.cmx : \
     utils/clflags.cmx \
     middle_end/flambda/terms/bound_symbols.cmx \
     middle_end/flambda/naming/bindable_let_bound.cmx \
+    middle_end/flambda/simplify/env/are_rebuilding_terms.cmx \
     middle_end/flambda/simplify/simplify_set_of_closures.cmi
 middle_end/flambda/simplify/simplify_set_of_closures.cmi : \
     middle_end/flambda/compilenv_deps/symbol.cmi \
@@ -6916,10 +6983,10 @@ middle_end/flambda/simplify/simplify_switch_expr.cmo : \
     middle_end/flambda/compilenv_deps/target_imm.cmi \
     lambda/switch.cmi \
     middle_end/flambda/simplify/simplify_import.cmi \
-    middle_end/flambda/simplify/simplify_common.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/inlining/metrics/removed_operations.cmi \
     middle_end/flambda/basic/reg_width_const.cmi \
+    middle_end/flambda/simplify/rebuilt_expr.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     utils/misc.cmi \
@@ -6935,10 +7002,10 @@ middle_end/flambda/simplify/simplify_switch_expr.cmx : \
     middle_end/flambda/compilenv_deps/target_imm.cmx \
     lambda/switch.cmx \
     middle_end/flambda/simplify/simplify_import.cmx \
-    middle_end/flambda/simplify/simplify_common.cmx \
     middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/inlining/metrics/removed_operations.cmx \
     middle_end/flambda/basic/reg_width_const.cmx \
+    middle_end/flambda/simplify/rebuilt_expr.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     utils/misc.cmx \
@@ -7057,6 +7124,7 @@ middle_end/flambda/simplify/basic/apply_cont_rewrite.cmi : \
     middle_end/flambda/basic/continuation_extra_params_and_args.cmi \
     middle_end/flambda/basic/apply_cont_rewrite_id.cmi
 middle_end/flambda/simplify/basic/continuation_in_env.cmo : \
+    middle_end/flambda/simplify/rebuilt_expr.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
@@ -7064,6 +7132,7 @@ middle_end/flambda/simplify/basic/continuation_in_env.cmo : \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/simplify/basic/continuation_in_env.cmi
 middle_end/flambda/simplify/basic/continuation_in_env.cmx : \
+    middle_end/flambda/simplify/rebuilt_expr.cmx \
     middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/basic/kinded_parameter.cmx \
@@ -7071,6 +7140,7 @@ middle_end/flambda/simplify/basic/continuation_in_env.cmx : \
     middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/simplify/basic/continuation_in_env.cmi
 middle_end/flambda/simplify/basic/continuation_in_env.cmi : \
+    middle_end/flambda/simplify/rebuilt_expr.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
@@ -7315,8 +7385,11 @@ middle_end/flambda/simplify/env/upwards_acc.cmo : \
     middle_end/flambda/types/flambda_type.cmi \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/cmx/exported_code.cmi \
+    middle_end/flambda/simplify/env/downwards_env.cmi \
     middle_end/flambda/simplify/env/downwards_acc.cmi \
     middle_end/flambda/types/structures/code_age_relation.cmi \
+    utils/clflags.cmi \
+    middle_end/flambda/simplify/env/are_rebuilding_terms.cmi \
     middle_end/flambda/simplify/env/upwards_acc.cmi
 middle_end/flambda/simplify/env/upwards_acc.cmx : \
     middle_end/flambda/simplify/env/upwards_env.cmx \
@@ -7326,8 +7399,11 @@ middle_end/flambda/simplify/env/upwards_acc.cmx : \
     middle_end/flambda/types/flambda_type.cmx \
     middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/cmx/exported_code.cmx \
+    middle_end/flambda/simplify/env/downwards_env.cmx \
     middle_end/flambda/simplify/env/downwards_acc.cmx \
     middle_end/flambda/types/structures/code_age_relation.cmx \
+    utils/clflags.cmx \
+    middle_end/flambda/simplify/env/are_rebuilding_terms.cmx \
     middle_end/flambda/simplify/env/upwards_acc.cmi
 middle_end/flambda/simplify/env/upwards_acc.cmi : \
     middle_end/flambda/simplify/env/upwards_env.cmi \
@@ -7341,7 +7417,8 @@ middle_end/flambda/simplify/env/upwards_acc.cmi : \
     middle_end/flambda/simplify/env/downwards_acc.cmi \
     middle_end/flambda/inlining/metrics/code_size.cmi \
     middle_end/flambda/basic/code_id.cmi \
-    middle_end/flambda/types/structures/code_age_relation.cmi
+    middle_end/flambda/types/structures/code_age_relation.cmi \
+    middle_end/flambda/simplify/env/are_rebuilding_terms.cmi
 middle_end/flambda/simplify/env/upwards_env.cmo : \
     middle_end/flambda/basic/scope.cmi \
     utils/misc.cmi \
@@ -7364,6 +7441,7 @@ middle_end/flambda/simplify/env/upwards_env.cmx : \
     middle_end/flambda/simplify/env/upwards_env.cmi
 middle_end/flambda/simplify/env/upwards_env.cmi : \
     middle_end/flambda/basic/scope.cmi \
+    middle_end/flambda/simplify/rebuilt_expr.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
@@ -7811,16 +7889,13 @@ middle_end/flambda/terms/expr.rec.cmx : \
     middle_end/flambda/naming/bindable_let_bound.cmx \
     middle_end/flambda/terms/expr.rec.cmi
 middle_end/flambda/terms/expr.rec.cmi : \
-    middle_end/flambda/naming/var_in_binding_pos.cmi \
     middle_end/flambda/terms/switch_expr.cmi \
     lambda/switch.cmi \
     middle_end/flambda/basic/simple.cmi \
-    middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/basic/invalid_term_semantics.cmi \
     middle_end/flambda/basic/expr_std.cmo \
-    middle_end/flambda/cmx/contains_ids.cmo \
-    middle_end/flambda/inlining/metrics/code_size.cmi
+    middle_end/flambda/cmx/contains_ids.cmo
 middle_end/flambda/terms/flambda.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
@@ -7937,7 +8012,6 @@ middle_end/flambda/terms/flambda.cmx : \
     middle_end/flambda/terms/flambda.cmi
 middle_end/flambda/terms/flambda.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/naming/var_in_binding_pos.cmi \
     utils/targetint.cmi \
     middle_end/flambda/compilenv_deps/target_imm.cmi \
     lambda/tag.cmi \

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -304,11 +304,12 @@ MIDDLE_END_FLAMBDA_SIMPLIFY=\
   middle_end/flambda/simplify/env/continuation_env_and_param_types.cmo \
   middle_end/flambda/simplify/basic/continuation_in_env.cmo \
   middle_end/flambda/simplify/basic/simplified_named.cmo \
-  middle_end/flambda/simplify/non_constructed_code.cmo \
-  middle_end/flambda/simplify/rebuilt_static_const.cmo \
   middle_end/flambda/simplify/common_subexpression_elimination.cmo \
   middle_end/flambda/simplify/env/downwards_env.cmo \
   middle_end/flambda/simplify/env/are_rebuilding_terms.cmo \
+  middle_end/flambda/simplify/rebuilt_expr.cmo \
+  middle_end/flambda/simplify/non_constructed_code.cmo \
+  middle_end/flambda/simplify/rebuilt_static_const.cmo \
   middle_end/flambda/simplify/env/upwards_env.cmo \
   middle_end/flambda/lifting/lifted_constant.cmo \
   middle_end/flambda/lifting/lifted_constant_state.cmo \

--- a/middle_end/flambda/lifting/lifted_constant.ml
+++ b/middle_end/flambda/lifting/lifted_constant.ml
@@ -16,8 +16,6 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
-open! Flambda.Import
-
 module DE = Downwards_env
 module T = Flambda_type
 
@@ -95,19 +93,9 @@ module Definition = struct
     | Block_like { symbol_projections; _ } -> symbol_projections
 
   let code code_id defining_expr =
-    match Rebuilt_static_const.const defining_expr with
-    | Code code ->
-      if Code_id.equal code_id (Code.code_id code) then
-        { descr = Code code_id;
-          defining_expr;
-        }
-      else
-        Misc.fatal_errorf "Mismatched code ids: %a vs.@ %a"
-          Code_id.print code_id
-          Code_id.print (Code.code_id code)
-    | _ ->
-      Misc.fatal_errorf "Not a code definition: %a"
-        Rebuilt_static_const.print defining_expr
+    { descr = Code code_id;
+      defining_expr;
+    }
 
   let set_of_closures denv ~closure_symbols_with_types
         ~symbol_projections defining_expr =

--- a/middle_end/flambda/lifting/lifted_constant_state.ml
+++ b/middle_end/flambda/lifting/lifted_constant_state.ml
@@ -155,7 +155,7 @@ let add_to_denv ?maybe_already_defined denv lifted =
     ~f:(fun denv lifted_constant ->
       let pieces_of_code =
         LC.defining_exprs lifted_constant
-        |> Rebuilt_static_const.Group.pieces_of_code
+        |> Rebuilt_static_const.Group.pieces_of_code_including_those_not_rebuilt
       in
       Code_id.Map.fold (fun code_id code denv ->
           match Code.params_and_body code with

--- a/middle_end/flambda/simplify/basic/continuation_in_env.ml
+++ b/middle_end/flambda/simplify/basic/continuation_in_env.ml
@@ -19,12 +19,12 @@
 type t =
   | Linearly_used_and_inlinable of {
       params : Kinded_parameter.t list;
-      handler : Flambda.Expr.t;
+      handler : Rebuilt_expr.t;
       free_names_of_handler : Name_occurrences.t;
       cost_metrics_of_handler : Flambda.Cost_metrics.t;
     }
   | Non_inlinable_zero_arity of {
-      handler : Flambda.Expr.t Or_unknown.t;
+      handler : Rebuilt_expr.t Or_unknown.t;
     }
   | Non_inlinable_non_zero_arity of {
       arity : Flambda_arity.With_subkinds.t;

--- a/middle_end/flambda/simplify/basic/continuation_in_env.mli
+++ b/middle_end/flambda/simplify/basic/continuation_in_env.mli
@@ -26,14 +26,14 @@ type t =
           bindings of the [params].  There is no requirement for binders to
           use fresh names when name abstractions are being constructed; they
           just have to match the ones in the terms being closed over. *)
-      handler : Flambda.Expr.t;
+      handler : Rebuilt_expr.t;
       (** [free_names_of_handler] includes entries for any occurrences of the
           [params] in the [handler]. *)
       free_names_of_handler : Name_occurrences.t;
       cost_metrics_of_handler : Flambda.Cost_metrics.t;
     }
   | Non_inlinable_zero_arity of {
-      handler : Flambda.Expr.t Or_unknown.t;
+      handler : Rebuilt_expr.t Or_unknown.t;
       (** The handler, if available, is stored for [Simplify_switch_expr]. *)
     }
   | Non_inlinable_non_zero_arity of {

--- a/middle_end/flambda/simplify/env/upwards_acc.ml
+++ b/middle_end/flambda/simplify/env/upwards_acc.ml
@@ -17,6 +17,7 @@
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
 module DA = Downwards_acc
+module DE = Downwards_env
 module LCS = Lifted_constant_state
 module TE = Flambda_type.Typing_env
 module UE = Upwards_env
@@ -32,21 +33,26 @@ type t = {
   name_occurrences : Name_occurrences.t;
   used_closure_vars : Name_occurrences.t;
   shareable_constants : Symbol.t Static_const.Map.t;
-  cost_metrics: Flambda.Cost_metrics.t;
+  cost_metrics : Flambda.Cost_metrics.t;
+  are_rebuilding_terms : Are_rebuilding_terms.t;
+  generate_phantom_lets : bool;
 }
 
 let print ppf
       { uenv; creation_dacc = _; code_age_relation; lifted_constants;
         name_occurrences; used_closure_vars; all_code = _;
-        shareable_constants; cost_metrics; } =
+        shareable_constants; cost_metrics; are_rebuilding_terms;
+        generate_phantom_lets; } =
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(uenv@ %a)@]@ \
       @[<hov 1>(code_age_relation@ %a)@]@ \
       @[<hov 1>(lifted_constants@ %a)@]@ \
       @[<hov 1>(name_occurrences@ %a)@]@ \
       @[<hov 1>(used_closure_vars@ %a)@]@ \
-      @[<hov 1>(shareable_constants@ %a)@]\
-      @[<hov 1>(cost_metrics %a)@]\
+      @[<hov 1>(shareable_constants@ %a)@]@ \
+      @[<hov 1>(cost_metrics@ %a)@]@ \
+      @[<hov 1>(are_rebuilding_terms@ %a)@]@ \
+      @[<hov 1>(generate_phantom_lets@ %b)@]\
       )@]"
     UE.print uenv
     Code_age_relation.print code_age_relation
@@ -55,8 +61,17 @@ let print ppf
     Name_occurrences.print used_closure_vars
     (Static_const.Map.print Symbol.print) shareable_constants
     Flambda.Cost_metrics.print cost_metrics
+    Are_rebuilding_terms.print are_rebuilding_terms
+    generate_phantom_lets
 
 let create uenv dacc =
+  let are_rebuilding_terms = DE.are_rebuilding_terms (DA.denv dacc) in
+  let generate_phantom_lets =
+    !Clflags.debug && !Clflags.Flambda.Expert.phantom_lets
+      (* It would be a waste of time generating phantom lets when not
+         rebuilding terms, since they have no effect on cost metrics. *)
+      && not (Are_rebuilding_terms.do_not_rebuild_terms are_rebuilding_terms)
+  in
   { uenv;
     creation_dacc = dacc;
     code_age_relation = TE.code_age_relation (DA.typing_env dacc);
@@ -70,6 +85,8 @@ let create uenv dacc =
     used_closure_vars = DA.used_closure_vars dacc;
     shareable_constants = DA.shareable_constants dacc;
     cost_metrics = Flambda.Cost_metrics.zero;
+    are_rebuilding_terms;
+    generate_phantom_lets;
   }
 
 let creation_dacc t = t.creation_dacc
@@ -77,8 +94,9 @@ let uenv t = t.uenv
 let code_age_relation t = t.code_age_relation
 let lifted_constants t = t.lifted_constants
 let cost_metrics t = t.cost_metrics
+let are_rebuilding_terms t = t.are_rebuilding_terms
 
-(* Don't add empty LCS to the list *)
+(* CR mshinwell: (?) Don't add empty LCS to the list *)
 
 let add_outermost_lifted_constant t const =
   { t with
@@ -103,8 +121,10 @@ let with_uenv t uenv =
   }
 
 let remember_code_for_cmx t code =
-  let all_code = Exported_code.add_code code t.all_code in
-  { t with all_code; }
+  if Are_rebuilding_terms.do_not_rebuild_terms t.are_rebuilding_terms then t
+  else
+    let all_code = Exported_code.add_code code t.all_code in
+    { t with all_code; }
 
 let all_code t = t.all_code
 
@@ -145,3 +165,7 @@ let notify_removed ~operation t =
 
 let add_cost_metrics cost_metrics t =
   { t with cost_metrics = Flambda.Cost_metrics.(+) t.cost_metrics cost_metrics }
+let cost_metrics_add ~added t =
+  { t with cost_metrics = Flambda.Cost_metrics.(+) added t.cost_metrics }
+
+let generate_phantom_lets t = t.generate_phantom_lets

--- a/middle_end/flambda/simplify/env/upwards_acc.ml
+++ b/middle_end/flambda/simplify/env/upwards_acc.ml
@@ -16,6 +16,7 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
+module ART = Are_rebuilding_terms
 module DA = Downwards_acc
 module DE = Downwards_env
 module LCS = Lifted_constant_state
@@ -34,7 +35,7 @@ type t = {
   used_closure_vars : Name_occurrences.t;
   shareable_constants : Symbol.t Static_const.Map.t;
   cost_metrics : Flambda.Cost_metrics.t;
-  are_rebuilding_terms : Are_rebuilding_terms.t;
+  are_rebuilding_terms : ART.t;
   generate_phantom_lets : bool;
 }
 
@@ -61,7 +62,7 @@ let print ppf
     Name_occurrences.print used_closure_vars
     (Static_const.Map.print Symbol.print) shareable_constants
     Flambda.Cost_metrics.print cost_metrics
-    Are_rebuilding_terms.print are_rebuilding_terms
+    ART.print are_rebuilding_terms
     generate_phantom_lets
 
 let create uenv dacc =
@@ -70,7 +71,7 @@ let create uenv dacc =
     !Clflags.debug && !Clflags.Flambda.Expert.phantom_lets
       (* It would be a waste of time generating phantom lets when not
          rebuilding terms, since they have no effect on cost metrics. *)
-      && not (Are_rebuilding_terms.do_not_rebuild_terms are_rebuilding_terms)
+      && not (ART.do_not_rebuild_terms are_rebuilding_terms)
   in
   { uenv;
     creation_dacc = dacc;
@@ -121,7 +122,7 @@ let with_uenv t uenv =
   }
 
 let remember_code_for_cmx t code =
-  if Are_rebuilding_terms.do_not_rebuild_terms t.are_rebuilding_terms then t
+  if ART.do_not_rebuild_terms t.are_rebuilding_terms then t
   else
     let all_code = Exported_code.add_code code t.all_code in
     { t with all_code; }

--- a/middle_end/flambda/simplify/env/upwards_acc.ml
+++ b/middle_end/flambda/simplify/env/upwards_acc.ml
@@ -165,7 +165,5 @@ let notify_removed ~operation t =
 
 let add_cost_metrics cost_metrics t =
   { t with cost_metrics = Flambda.Cost_metrics.(+) t.cost_metrics cost_metrics }
-let cost_metrics_add ~added t =
-  { t with cost_metrics = Flambda.Cost_metrics.(+) added t.cost_metrics }
 
 let generate_phantom_lets t = t.generate_phantom_lets

--- a/middle_end/flambda/simplify/env/upwards_acc.mli
+++ b/middle_end/flambda/simplify/env/upwards_acc.mli
@@ -45,11 +45,7 @@ val with_lifted_constants : t -> Lifted_constant_state.t -> t
 val no_lifted_constants : t -> bool
 
 (** Map the environment component of the given upwards accumulator. *)
-val map_uenv
-   : t
-  -> f:(Upwards_env.t
-    -> Upwards_env.t)
-  -> t
+val map_uenv : t -> f:(Upwards_env.t -> Upwards_env.t) -> t
 
 (** Replace the environment component of the given upwards accumulator. *)
 val with_uenv : t -> Upwards_env.t -> t
@@ -62,7 +58,10 @@ val shareable_constants : t -> Symbol.t Flambda.Static_const.Map.t
 
 val name_occurrences : t -> Name_occurrences.t
 
-val with_name_occurrences : t -> name_occurrences:Name_occurrences.t -> t
+val with_name_occurrences
+   : t
+  -> name_occurrences:Name_occurrences.t
+  -> t
 
 val clear_name_occurrences : t -> t
 
@@ -70,7 +69,10 @@ val add_free_names : t -> Name_occurrences.t -> t
 
 val used_closure_vars : t -> Name_occurrences.t
 
-val remove_all_occurrences_of_free_names : t -> Name_occurrences.t -> t
+val remove_all_occurrences_of_free_names
+   : t
+  -> Name_occurrences.t
+  -> t
 
 val clear_cost_metrics : t -> t
 
@@ -82,3 +84,8 @@ val notify_added: code_size:Code_size.t -> t -> t
 
 val notify_removed: operation:Removed_operations.t -> t -> t
 
+val cost_metrics_add : added:Flambda.Cost_metrics.t -> t -> t
+
+val generate_phantom_lets : t -> bool
+
+val are_rebuilding_terms : t -> Are_rebuilding_terms.t

--- a/middle_end/flambda/simplify/env/upwards_acc.mli
+++ b/middle_end/flambda/simplify/env/upwards_acc.mli
@@ -45,7 +45,11 @@ val with_lifted_constants : t -> Lifted_constant_state.t -> t
 val no_lifted_constants : t -> bool
 
 (** Map the environment component of the given upwards accumulator. *)
-val map_uenv : t -> f:(Upwards_env.t -> Upwards_env.t) -> t
+val map_uenv
+   : t
+  -> f:(Upwards_env.t
+    -> Upwards_env.t)
+  -> t
 
 (** Replace the environment component of the given upwards accumulator. *)
 val with_uenv : t -> Upwards_env.t -> t
@@ -58,10 +62,7 @@ val shareable_constants : t -> Symbol.t Flambda.Static_const.Map.t
 
 val name_occurrences : t -> Name_occurrences.t
 
-val with_name_occurrences
-   : t
-  -> name_occurrences:Name_occurrences.t
-  -> t
+val with_name_occurrences : t -> name_occurrences:Name_occurrences.t -> t
 
 val clear_name_occurrences : t -> t
 
@@ -69,10 +70,7 @@ val add_free_names : t -> Name_occurrences.t -> t
 
 val used_closure_vars : t -> Name_occurrences.t
 
-val remove_all_occurrences_of_free_names
-   : t
-  -> Name_occurrences.t
-  -> t
+val remove_all_occurrences_of_free_names : t -> Name_occurrences.t -> t
 
 val clear_cost_metrics : t -> t
 
@@ -83,8 +81,6 @@ val add_cost_metrics : Flambda.Cost_metrics.t -> t -> t
 val notify_added: code_size:Code_size.t -> t -> t
 
 val notify_removed: operation:Removed_operations.t -> t -> t
-
-val cost_metrics_add : added:Flambda.Cost_metrics.t -> t -> t
 
 val generate_phantom_lets : t -> bool
 

--- a/middle_end/flambda/simplify/env/upwards_env.mli
+++ b/middle_end/flambda/simplify/env/upwards_env.mli
@@ -14,6 +14,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+(** Upwards environments used during simplification. *)
+
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
 open! Flambda.Import
@@ -31,7 +33,7 @@ val add_non_inlinable_continuation
   -> Continuation.t
   -> Scope.t
   -> params:Kinded_parameter.t list
-  -> handler:Flambda.Expr.t Or_unknown.t
+  -> handler:Rebuilt_expr.t Or_unknown.t
   -> t
 
 val add_unreachable_continuation
@@ -53,7 +55,7 @@ val add_linearly_used_inlinable_continuation
   -> Continuation.t
   -> Scope.t
   -> params:Kinded_parameter.t list
-  -> handler:Flambda.Expr.t
+  -> handler:Rebuilt_expr.t
   -> free_names_of_handler:Name_occurrences.t
   -> cost_metrics_of_handler:Cost_metrics.t
   -> t
@@ -82,26 +84,14 @@ val resolve_exn_continuation_aliases
   -> Exn_continuation.t
   -> Exn_continuation.t
 
-val continuation_arity : t -> Continuation.t -> Flambda_arity.With_subkinds.t
-
 val check_continuation_is_bound : t -> Continuation.t -> unit
 
 val check_exn_continuation_is_bound : t -> Exn_continuation.t -> unit
 
-val add_apply_cont_rewrite
-   : t
-  -> Continuation.t
-  -> Apply_cont_rewrite.t
-  -> t
+val add_apply_cont_rewrite : t -> Continuation.t -> Apply_cont_rewrite.t -> t
 
-val find_apply_cont_rewrite
-   : t
-  -> Continuation.t
-  -> Apply_cont_rewrite.t option
+val find_apply_cont_rewrite : t -> Continuation.t -> Apply_cont_rewrite.t option
 
-val delete_apply_cont_rewrite
-   : t
-  -> Continuation.t
-  -> t
+val delete_apply_cont_rewrite : t -> Continuation.t -> t
 
 val will_inline_continuation : t -> Continuation.t -> bool

--- a/middle_end/flambda/simplify/expr_builder.ml
+++ b/middle_end/flambda/simplify/expr_builder.ml
@@ -23,6 +23,7 @@ module KP = Kinded_parameter
 module LC = Lifted_constant
 module LCS = Lifted_constant_state
 module P = Flambda_primitive
+module RE = Rebuilt_expr
 module UA = Upwards_acc
 module UE = Upwards_env
 module VB = Var_in_binding_pos
@@ -35,9 +36,7 @@ let create_let uacc (bound_vars : BLB.t) defining_expr
       ~free_names_of_defining_expr ~body ~cost_metrics_of_defining_expr =
   (* The name occurrences component of [uacc] is expected to be in the state
      described in the comment at the top of [Simplify_let.rebuild_let]. *)
-  let generate_phantom_lets =
-    !Clflags.debug && !Clflags.Flambda.Expert.phantom_lets
-  in
+  let generate_phantom_lets = UA.generate_phantom_lets uacc in
   let free_names_of_body = UA.name_occurrences uacc in
   let bound_vars, keep_binding, let_creation_result =
     let greatest_name_mode =
@@ -46,7 +45,7 @@ let create_let uacc (bound_vars : BLB.t) defining_expr
         (* We avoid the closure allocation (below) in this case. *)
         Name_occurrences.greatest_name_mode_var free_names_of_body
           (VB.var bound_var)
-      | Set_of_closures _ | Symbols _ ->
+      | Set_of_closures _ ->
         BLB.fold_all_bound_vars bound_vars ~init:Name_mode.Or_absent.absent
           ~f:(fun (greatest_name_mode : Name_mode.Or_absent.t) bound_var ->
             let name_mode =
@@ -60,6 +59,7 @@ let create_let uacc (bound_vars : BLB.t) defining_expr
             | Present name_mode, Present greatest_name_mode ->
               Name_mode.max_in_terms name_mode greatest_name_mode
               |> Name_mode.Or_absent.present)
+      | Symbols _ -> assert false  (* see below *)
     in
     let declared_name_mode = BLB.name_mode bound_vars in
     begin match
@@ -79,7 +79,7 @@ let create_let uacc (bound_vars : BLB.t) defining_expr
           Named.print defining_expr
           Name_mode.Or_absent.print greatest_name_mode
           Name_occurrences.print free_names_of_body
-          Expr.print body
+          (RE.print (UA.are_rebuilding_terms uacc)) body
     end;
     if not (Named.at_most_generative_effects defining_expr) then begin
       if not (Name_mode.is_normal declared_name_mode)
@@ -152,11 +152,10 @@ let create_let uacc (bound_vars : BLB.t) defining_expr
            (Cost_metrics.increase_due_to_let_expr
               ~is_phantom ~cost_metrics_of_defining_expr)
     in
-    let let_expr =
-      Let.create bound_vars defining_expr ~body
-        ~free_names_of_body:(Known free_names_of_body)
-    in
-    Expr.create_let let_expr, uacc, Nothing_deleted
+    RE.create_let (UA.are_rebuilding_terms uacc) bound_vars defining_expr
+      ~body ~free_names_of_body,
+    uacc,
+    Nothing_deleted
 
 let make_new_let_bindings uacc
       ~(bindings_outermost_first : Simplify_named_result.binding_to_place list)
@@ -173,7 +172,7 @@ let make_new_let_bindings uacc
           UA.with_name_occurrences uacc ~name_occurrences:Name_occurrences.empty
           |> UA.notify_added ~code_size:Code_size.invalid
         in
-        Expr.create_invalid (), uacc
+        RE.create_invalid (), uacc
       | Reachable {
           named = defining_expr;
           free_names = free_names_of_defining_expr;
@@ -223,10 +222,6 @@ let create_raw_let_symbol uacc bound_symbols scoping_rule static_consts ~body =
   let free_names_of_static_consts =
     Rebuilt_static_const.Group.free_names static_consts
   in
-  let defining_expr, cost_metrics_of_defining_expr =
-    let static_consts = Rebuilt_static_const.Group.consts static_consts in
-    Named.create_static_consts static_consts, Cost_metrics.zero
-  in
   let free_names_of_body = UA.name_occurrences uacc in
   let free_names_of_let =
     (* Care: these bindings can be recursive (e.g. via a set of closures). *)
@@ -243,13 +238,16 @@ let create_raw_let_symbol uacc bound_symbols scoping_rule static_consts ~body =
     |> UA.add_cost_metrics
          (Cost_metrics.increase_due_to_let_expr
             ~is_phantom:false
-            ~cost_metrics_of_defining_expr)
+            (* Static consts always have zero cost metrics at present. *)
+            ~cost_metrics_of_defining_expr:Cost_metrics.zero)
   in
-  let let_expr =
-    Let.create bindable defining_expr ~body
-      ~free_names_of_body:(Known free_names_of_body)
-  in
-  Expr.create_let let_expr, uacc
+  if Are_rebuilding_terms.do_not_rebuild_terms (UA.are_rebuilding_terms uacc)
+  then
+    RE.term_not_rebuilt (), uacc
+  else
+    let defining_expr = Rebuilt_static_const.Group.to_named static_consts in
+    RE.create_let (UA.are_rebuilding_terms uacc) bindable defining_expr
+      ~body ~free_names_of_body, uacc
 
 let create_let_symbol0 uacc code_age_relation (bound_symbols : Bound_symbols.t)
       (static_consts : Rebuilt_static_const.Group.t) ~body =
@@ -280,8 +278,7 @@ let create_let_symbol0 uacc code_age_relation (bound_symbols : Bound_symbols.t)
         (* CR-someday mshinwell: This could be made more precise, but would
            probably require a proper analysis. *)
         let code_ids_static_consts =
-          ListLabels.fold_left
-            (Rebuilt_static_const.Group.to_list static_consts)
+          Rebuilt_static_const.Group.fold_left static_consts
             ~init:Code_id.Set.empty
             ~f:(fun code_ids static_const ->
               Rebuilt_static_const.free_names static_const
@@ -323,19 +320,8 @@ let create_let_symbol0 uacc code_age_relation (bound_symbols : Bound_symbols.t)
       else
         Rebuilt_static_const.Group.map static_consts
           ~f:(fun static_const ->
-            match
-              Rebuilt_static_const.const static_const
-              |> Static_const.to_code
-            with
-            | Some code
-              when Code_id.Set.mem (Code.code_id code)
-                code_ids_to_make_deleted ->
-              let static_const : Static_const.t =
-                Code (Code.make_deleted code)
-              in
-              Rebuilt_static_const.create static_const
-                ~free_names:Unknown
-            | Some _ | None -> static_const)
+            Rebuilt_static_const.make_code_deleted static_const
+              ~if_code_id_is_member_of:code_ids_to_make_deleted)
     in
     let expr, uacc =
       create_raw_let_symbol uacc bound_symbols Syntactic static_consts ~body
@@ -343,37 +329,23 @@ let create_let_symbol0 uacc code_age_relation (bound_symbols : Bound_symbols.t)
     let uacc =
       if not will_bind_code then uacc
       else
-        Rebuilt_static_const.Group.pieces_of_code static_consts
+        Rebuilt_static_const.Group.pieces_of_code_for_cmx static_consts
         |> UA.remember_code_for_cmx uacc
     in
     expr, uacc
 
 let remove_unused_closure_vars uacc static_const =
-  match Rebuilt_static_const.const static_const with
-  | Set_of_closures set_of_closures ->
-    let name_occurrences = UA.used_closure_vars uacc in
-    let closure_vars = Set_of_closures.closure_elements set_of_closures in
-    let closure_elements =
-      Var_within_closure.Map.filter (fun closure_var _ ->
-          Name_occurrences.mem_closure_var name_occurrences closure_var)
-        closure_vars
-    in
-    let set_of_closures =
+  Rebuilt_static_const.map_set_of_closures static_const
+    ~f:(fun set_of_closures ->
+      let name_occurrences = UA.used_closure_vars uacc in
+      let closure_vars = Set_of_closures.closure_elements set_of_closures in
+      let closure_elements =
+        Var_within_closure.Map.filter (fun closure_var _ ->
+            Name_occurrences.mem_closure_var name_occurrences closure_var)
+          closure_vars
+      in
       Set_of_closures.create (Set_of_closures.function_decls set_of_closures)
-        ~closure_elements
-    in
-    Rebuilt_static_const.create (Set_of_closures set_of_closures)
-      ~free_names:(Known (Set_of_closures.free_names set_of_closures))
-  | Code _
-  | Block _
-  | Boxed_float _
-  | Boxed_int32 _
-  | Boxed_int64 _
-  | Boxed_nativeint _
-  | Immutable_float_block _
-  | Immutable_float_array _
-  | Mutable_string _
-  | Immutable_string _ -> static_const
+        ~closure_elements)
 
 let create_let_symbols uacc (scoping_rule : Symbol_scoping_rule.t)
       code_age_relation lifted_constant ~body =
@@ -394,8 +366,8 @@ let create_let_symbols uacc (scoping_rule : Symbol_scoping_rule.t)
           ~body
       in
       let uacc =
-        (LC.defining_exprs lifted_constant)
-        |> Rebuilt_static_const.Group.pieces_of_code
+        LC.defining_exprs lifted_constant
+        |> Rebuilt_static_const.Group.pieces_of_code_for_cmx
         |> UA.remember_code_for_cmx uacc
       in
       expr, uacc
@@ -451,7 +423,9 @@ let create_let_symbols uacc (scoping_rule : Symbol_scoping_rule.t)
          projection operation, but it's unlikely there will be a
          significant number, and since we're at toplevel we tolerate
          them. *)
-      let defining_expr, code_size_of_defining_expr = apply_projection proj in
+      let defining_expr, code_size_of_defining_expr =
+        apply_projection proj
+      in
       let cost_metrics_of_defining_expr =
         Cost_metrics.from_size code_size_of_defining_expr
       in
@@ -543,7 +517,7 @@ let place_lifted_constants uacc (scoping_rule : Symbol_scoping_rule.t)
 
 let create_switch uacc ~scrutinee ~arms =
   if Target_imm.Map.cardinal arms < 1 then
-    Expr.create_invalid (),
+    RE.create_invalid (),
     UA.notify_added ~code_size:Code_size.invalid uacc
   else
     let change_to_apply_cont action =
@@ -551,7 +525,7 @@ let create_switch uacc ~scrutinee ~arms =
         UA.add_free_names uacc (Apply_cont.free_names action)
         |> UA.notify_added ~code_size:(Code_size.apply_cont action)
       in
-      Expr.create_apply_cont action, uacc
+      RE.create_apply_cont (UA.are_rebuilding_terms uacc) action, uacc
     in
     match Target_imm.Map.get_singleton arms with
     | Some (_discriminant, action) -> change_to_apply_cont action
@@ -569,21 +543,21 @@ let create_switch uacc ~scrutinee ~arms =
           UA.add_free_names uacc (Switch.free_names switch)
           |> UA.notify_added ~code_size:(Code_size.switch switch)
         in
-        Expr.create_switch switch, uacc
+        RE.create_switch (UA.are_rebuilding_terms uacc) switch, uacc
 
 let rebuild_invalid uacc ~after_rebuild =
-  after_rebuild (Expr.create_invalid ()) uacc
+  after_rebuild (RE.create_invalid ()) uacc
 
 type rewrite_use_result =
   | Apply_cont of Apply_cont.t
   | Expr of (
        apply_cont_to_expr:(Apply_cont.t
-         -> (Expr.t * Cost_metrics.t * Name_occurrences.t))
-    -> Expr.t * Cost_metrics.t * Name_occurrences.t)
+         -> (RE.t * Cost_metrics.t * Name_occurrences.t))
+    -> RE.t * Cost_metrics.t * Name_occurrences.t)
 
 let no_rewrite apply_cont = Apply_cont apply_cont
 
-let rewrite_use rewrite id apply_cont : rewrite_use_result =
+let rewrite_use uacc rewrite id apply_cont : rewrite_use_result =
   let args = Apply_cont.args apply_cont in
   let original_params = Apply_cont_rewrite.original_params rewrite in
   if List.compare_lengths args original_params <> 0 then begin
@@ -594,8 +568,8 @@ let rewrite_use rewrite id apply_cont : rewrite_use_result =
       Simple.List.print args
   end;
   let original_params_with_args = List.combine original_params args in
+  let used_params = Apply_cont_rewrite.used_params rewrite in
   let args =
-    let used_params = Apply_cont_rewrite.used_params rewrite in
     List.filter_map (fun (original_param, arg) ->
         if KP.Set.mem original_param used_params then Some arg
         else None)
@@ -631,7 +605,8 @@ let rewrite_use rewrite id apply_cont : rewrite_use_result =
       let body, cost_metrics_of_body, free_names_of_body =
         apply_cont_to_expr apply_cont
       in
-      Expr.bind_no_simplification ~bindings:extra_lets ~body
+      RE.bind_no_simplification (UA.are_rebuilding_terms uacc)
+        ~bindings:extra_lets ~body
         ~cost_metrics_of_body ~free_names_of_body
     in
     Expr build_expr
@@ -656,16 +631,16 @@ let rewrite_exn_continuation rewrite id exn_cont =
     List.combine (List.tl original_params)
       (Exn_continuation.extra_args exn_cont)
   in
+  let used_params = Apply_cont_rewrite.used_params rewrite in
   let extra_args0 =
-    let used_params = Apply_cont_rewrite.used_params rewrite in
     List.filter_map (fun (pre_existing_extra_param, arg) ->
         if KP.Set.mem pre_existing_extra_param used_params then Some arg
         else None)
       pre_existing_extra_params_with_args
   in
+  let used_extra_params = Apply_cont_rewrite.used_extra_params rewrite in
   let extra_args1 =
     let extra_args_list = Apply_cont_rewrite.extra_args rewrite id in
-    let used_extra_params = Apply_cont_rewrite.used_extra_params rewrite in
     assert (List.compare_lengths used_extra_params extra_args_list = 0);
     List.map2
       (fun param (arg : Continuation_extra_params_and_args.Extra_arg.t) ->
@@ -682,7 +657,7 @@ let rewrite_exn_continuation rewrite id exn_cont =
 type add_wrapper_for_fixed_arity_continuation0_result =
   | This_continuation of Continuation.t
   | Apply_cont of Apply_cont.t
-  | New_wrapper of Continuation.t * Continuation_handler.t
+  | New_wrapper of Continuation.t * RE.Continuation_handler.t
       * Name_occurrences.t * Cost_metrics.t
 
 type cont_or_apply_cont =
@@ -717,22 +692,18 @@ let add_wrapper_for_fixed_arity_continuation0 uacc cont_or_apply_cont
     end;
     This_continuation cont
   | Some rewrite ->
-    (* CR-someday mshinwell: This area should be improved and hence
-       simplified.  Allowing [Apply] to take extra arguments is probably the
-       way forward.  Although unboxing of variants requires untagging
-       expressions to be inserted, so wrappers cannot always be avoided. *)
     let params = List.map (fun _kind -> Variable.create "param") arity in
-    let kinded_params = List.map2 KP.create params arity in
+    let params = List.map2 KP.create params arity in
     let new_wrapper expr ~free_names ~cost_metrics =
       let new_cont = Continuation.create () in
       let new_handler =
-        Continuation_handler.create kinded_params ~handler:expr
-          ~free_names_of_handler:(Known free_names)
+        RE.Continuation_handler.create (UA.are_rebuilding_terms uacc) params
+          ~handler:expr ~free_names_of_handler:free_names
           ~is_exn_handler:false
       in
       let free_names =
         ListLabels.fold_left params ~init:free_names ~f:(fun free_names param ->
-          Name_occurrences.remove_var free_names param)
+          Name_occurrences.remove_var free_names (Kinded_parameter.var param))
       in
       New_wrapper (new_cont, new_handler, free_names, cost_metrics)
     in
@@ -740,20 +711,21 @@ let add_wrapper_for_fixed_arity_continuation0 uacc cont_or_apply_cont
     | Continuation cont ->
       (* In this case, any generated [Apply_cont] will sit inside a wrapper
          that binds [kinded_params]. *)
-      let args = List.map KP.simple kinded_params in
+      let args = List.map KP.simple params in
       let apply_cont = Apply_cont.create cont ~args ~dbg:Debuginfo.none in
-      begin match rewrite_use rewrite use_id apply_cont with
+      begin match rewrite_use uacc rewrite use_id apply_cont with
       | Apply_cont apply_cont ->
         let cost_metrics =
           Cost_metrics.from_size (Code_size.apply_cont apply_cont)
         in
-        new_wrapper (Expr.create_apply_cont apply_cont)
+        new_wrapper
+          (RE.create_apply_cont (UA.are_rebuilding_terms uacc) apply_cont)
           ~free_names:(Apply_cont.free_names apply_cont)
           ~cost_metrics
       | Expr build_expr ->
         let expr, cost_metrics, free_names =
           build_expr ~apply_cont_to_expr:(fun apply_cont ->
-            Expr.create_apply_cont apply_cont,
+            RE.create_apply_cont (UA.are_rebuilding_terms uacc) apply_cont,
             Cost_metrics.from_size (Code_size.apply_cont apply_cont),
             Apply_cont.free_names apply_cont)
         in
@@ -761,12 +733,12 @@ let add_wrapper_for_fixed_arity_continuation0 uacc cont_or_apply_cont
       end
     | Apply_cont apply_cont ->
       let apply_cont = Apply_cont.update_continuation apply_cont cont in
-      match rewrite_use rewrite use_id apply_cont with
+      match rewrite_use uacc rewrite use_id apply_cont with
       | Apply_cont apply_cont -> Apply_cont apply_cont
       | Expr build_expr ->
         let expr, cost_metrics, free_names =
           build_expr ~apply_cont_to_expr:(fun apply_cont ->
-            Expr.create_apply_cont apply_cont,
+            RE.create_apply_cont (UA.are_rebuilding_terms uacc) apply_cont,
             Cost_metrics.from_size (Code_size.apply_cont apply_cont),
             Apply_cont.free_names apply_cont)
         in
@@ -774,7 +746,7 @@ let add_wrapper_for_fixed_arity_continuation0 uacc cont_or_apply_cont
 
 type add_wrapper_for_switch_arm_result =
   | Apply_cont of Apply_cont.t
-  | New_wrapper of Continuation.t * Continuation_handler.t
+  | New_wrapper of Continuation.t * RE.Continuation_handler.t
       * Name_occurrences.t * Cost_metrics.t
 
 let add_wrapper_for_switch_arm uacc apply_cont ~use_id arity
@@ -801,8 +773,8 @@ let add_wrapper_for_fixed_arity_continuation uacc cont ~use_id arity ~around =
     let body, uacc = around uacc new_cont in
     let free_names_of_body = UA.name_occurrences uacc in
     let expr =
-      Let_cont.create_non_recursive
-        new_cont new_handler ~body ~free_names_of_body:(Known free_names_of_body)
+      RE.create_non_recursive_let_cont (UA.are_rebuilding_terms uacc)
+        new_cont new_handler ~body ~free_names_of_body
     in
     let free_names =
       Name_occurrences.union free_names_of_handler free_names_of_body
@@ -827,7 +799,7 @@ let add_wrapper_for_fixed_arity_apply uacc ~use_id arity apply =
       UA.add_free_names uacc (Apply.free_names apply)
       |> UA.notify_added ~code_size:(Code_size.apply apply)
     in
-    Expr.create_apply apply, uacc
+    RE.create_apply (UA.are_rebuilding_terms uacc) apply, uacc
   | Return cont ->
     add_wrapper_for_fixed_arity_continuation uacc cont
       ~use_id arity
@@ -843,4 +815,4 @@ let add_wrapper_for_fixed_arity_apply uacc ~use_id arity apply =
           UA.add_free_names uacc (Apply.free_names apply)
           |> UA.notify_added ~code_size:(Code_size.apply apply)
         in
-        Expr.create_apply apply, uacc)
+        RE.create_apply (UA.are_rebuilding_terms uacc) apply, uacc)

--- a/middle_end/flambda/simplify/expr_builder.ml
+++ b/middle_end/flambda/simplify/expr_builder.ml
@@ -423,9 +423,7 @@ let create_let_symbols uacc (scoping_rule : Symbol_scoping_rule.t)
          projection operation, but it's unlikely there will be a
          significant number, and since we're at toplevel we tolerate
          them. *)
-      let defining_expr, code_size_of_defining_expr =
-        apply_projection proj
-      in
+      let defining_expr, code_size_of_defining_expr = apply_projection proj in
       let cost_metrics_of_defining_expr =
         Cost_metrics.from_size code_size_of_defining_expr
       in
@@ -568,8 +566,8 @@ let rewrite_use uacc rewrite id apply_cont : rewrite_use_result =
       Simple.List.print args
   end;
   let original_params_with_args = List.combine original_params args in
-  let used_params = Apply_cont_rewrite.used_params rewrite in
   let args =
+    let used_params = Apply_cont_rewrite.used_params rewrite in
     List.filter_map (fun (original_param, arg) ->
         if KP.Set.mem original_param used_params then Some arg
         else None)
@@ -631,16 +629,16 @@ let rewrite_exn_continuation rewrite id exn_cont =
     List.combine (List.tl original_params)
       (Exn_continuation.extra_args exn_cont)
   in
-  let used_params = Apply_cont_rewrite.used_params rewrite in
   let extra_args0 =
+    let used_params = Apply_cont_rewrite.used_params rewrite in
     List.filter_map (fun (pre_existing_extra_param, arg) ->
         if KP.Set.mem pre_existing_extra_param used_params then Some arg
         else None)
       pre_existing_extra_params_with_args
   in
-  let used_extra_params = Apply_cont_rewrite.used_extra_params rewrite in
   let extra_args1 =
     let extra_args_list = Apply_cont_rewrite.extra_args rewrite id in
+    let used_extra_params = Apply_cont_rewrite.used_extra_params rewrite in
     assert (List.compare_lengths used_extra_params extra_args_list = 0);
     List.map2
       (fun param (arg : Continuation_extra_params_and_args.Extra_arg.t) ->

--- a/middle_end/flambda/simplify/expr_builder.ml
+++ b/middle_end/flambda/simplify/expr_builder.ml
@@ -523,7 +523,7 @@ let create_switch uacc ~scrutinee ~arms =
         UA.add_free_names uacc (Apply_cont.free_names action)
         |> UA.notify_added ~code_size:(Code_size.apply_cont action)
       in
-      RE.create_apply_cont (UA.are_rebuilding_terms uacc) action, uacc
+      RE.create_apply_cont action, uacc
     in
     match Target_imm.Map.get_singleton arms with
     | Some (_discriminant, action) -> change_to_apply_cont action
@@ -717,13 +717,13 @@ let add_wrapper_for_fixed_arity_continuation0 uacc cont_or_apply_cont
           Cost_metrics.from_size (Code_size.apply_cont apply_cont)
         in
         new_wrapper
-          (RE.create_apply_cont (UA.are_rebuilding_terms uacc) apply_cont)
+          (RE.create_apply_cont apply_cont)
           ~free_names:(Apply_cont.free_names apply_cont)
           ~cost_metrics
       | Expr build_expr ->
         let expr, cost_metrics, free_names =
           build_expr ~apply_cont_to_expr:(fun apply_cont ->
-            RE.create_apply_cont (UA.are_rebuilding_terms uacc) apply_cont,
+            RE.create_apply_cont apply_cont,
             Cost_metrics.from_size (Code_size.apply_cont apply_cont),
             Apply_cont.free_names apply_cont)
         in
@@ -736,7 +736,7 @@ let add_wrapper_for_fixed_arity_continuation0 uacc cont_or_apply_cont
       | Expr build_expr ->
         let expr, cost_metrics, free_names =
           build_expr ~apply_cont_to_expr:(fun apply_cont ->
-            RE.create_apply_cont (UA.are_rebuilding_terms uacc) apply_cont,
+            RE.create_apply_cont apply_cont,
             Cost_metrics.from_size (Code_size.apply_cont apply_cont),
             Apply_cont.free_names apply_cont)
         in

--- a/middle_end/flambda/simplify/rebuilt_expr.ml
+++ b/middle_end/flambda/simplify/rebuilt_expr.ml
@@ -33,12 +33,10 @@ let to_expr t are_rebuilding =
   else
     t
 
-let to_apply_cont t are_rebuilding =
-  if ART.do_not_rebuild_terms are_rebuilding then None
-  else
-    match Expr.descr t with
-    | Apply_cont apply_cont -> Some apply_cont
-    | Let _ | Let_cont _ | Apply _ | Switch _ | Invalid _ -> None
+let to_apply_cont t =
+  match Expr.descr t with
+  | Apply_cont apply_cont -> Some apply_cont
+  | Let _ | Let_cont _ | Apply _ | Switch _ | Invalid _ -> None
 
 let is_unreachable t are_rebuilding =
   if ART.do_not_rebuild_terms are_rebuilding then false
@@ -67,9 +65,8 @@ let create_apply are_rebuilding apply =
   if ART.do_not_rebuild_terms are_rebuilding then Lazy.force invalid
   else Expr.create_apply apply
 
-let create_apply_cont are_rebuilding apply_cont =
-  if ART.do_not_rebuild_terms are_rebuilding then Lazy.force invalid
-  else Expr.create_apply_cont apply_cont
+let create_apply_cont apply_cont =
+  Expr.create_apply_cont apply_cont
 
 module Function_params_and_body = struct
   type t = Function_params_and_body.t

--- a/middle_end/flambda/simplify/rebuilt_expr.ml
+++ b/middle_end/flambda/simplify/rebuilt_expr.ml
@@ -1,0 +1,157 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                   Mark Shinwell, Jane Street Europe                    *)
+(*                                                                        *)
+(*   Copyright 2021 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+open! Flambda.Import
+
+module ART = Are_rebuilding_terms
+
+(* This is delayed to ensure evaluation happens after processing of
+   command-line flags. *)
+let invalid = lazy (Expr.create_invalid ())
+
+type t = Expr.t
+type rebuilt_expr = t
+
+let to_expr t are_rebuilding =
+  if ART.do_not_rebuild_terms are_rebuilding then
+    Misc.fatal_error "Cannot ask [Rebuilt_expr] for the built expression \
+      when [UA.do_not_rebuild_terms] is set"
+  else
+    t
+
+let to_apply_cont t are_rebuilding =
+  if ART.do_not_rebuild_terms are_rebuilding then None
+  else
+    match Expr.descr t with
+    | Apply_cont apply_cont -> Some apply_cont
+    | Let _ | Let_cont _ | Apply _ | Switch _ | Invalid _ -> None
+
+let is_unreachable t are_rebuilding =
+  if ART.do_not_rebuild_terms are_rebuilding then false
+  else
+    match Expr.descr t with
+    | Invalid Treat_as_unreachable -> true
+    | Let _ | Let_cont _ | Apply _ | Apply_cont _ | Switch _
+    | Invalid Halt_and_catch_fire -> false
+
+let print are_rebuilding ppf t =
+  if ART.do_not_rebuild_terms are_rebuilding then
+    Format.fprintf ppf "<unavailable, terms not being rebuilt>"
+  else
+    Expr.print ppf t
+
+let term_not_rebuilt () = Lazy.force invalid
+
+let create_let are_rebuilding bound_vars defining_expr ~body ~free_names_of_body =
+  if ART.do_not_rebuild_terms are_rebuilding then Lazy.force invalid
+  else
+    Let.create bound_vars defining_expr ~body
+      ~free_names_of_body:(Known free_names_of_body)
+    |> Expr.create_let
+
+let create_apply are_rebuilding apply =
+  if ART.do_not_rebuild_terms are_rebuilding then Lazy.force invalid
+  else Expr.create_apply apply
+
+let create_apply_cont are_rebuilding apply_cont =
+  if ART.do_not_rebuild_terms are_rebuilding then Lazy.force invalid
+  else Expr.create_apply_cont apply_cont
+
+module Function_params_and_body = struct
+  type t = Function_params_and_body.t
+
+  let create ~return_continuation exn_continuation params ~dbg ~body
+        ~free_names_of_body ~my_closure =
+    Function_params_and_body.create ~return_continuation exn_continuation
+      params ~dbg ~body ~free_names_of_body:(Known free_names_of_body)
+      ~my_closure
+
+  let to_function_params_and_body t are_rebuilding =
+    if ART.do_not_rebuild_terms are_rebuilding then
+      Misc.fatal_error "Cannot ask for function params and body when not \
+        rebuilding terms"
+    else
+      t
+end
+
+module Continuation_handler = struct
+  type t = Continuation_handler.t
+
+  let dummy =
+    Continuation_handler.create [] ~handler:(Lazy.force invalid)
+      ~free_names_of_handler:Unknown ~is_exn_handler:false
+
+  let create are_rebuilding params ~handler ~free_names_of_handler ~is_exn_handler =
+    if ART.do_not_rebuild_terms are_rebuilding then dummy
+    else
+      Continuation_handler.create params ~handler
+        ~free_names_of_handler:(Known free_names_of_handler)
+        ~is_exn_handler
+end
+
+let create_non_recursive_let_cont are_rebuilding cont handler ~body ~free_names_of_body =
+  if ART.do_not_rebuild_terms are_rebuilding then Lazy.force invalid
+  else
+    Let_cont.create_non_recursive cont handler ~body
+      ~free_names_of_body:(Known free_names_of_body)
+
+let create_non_recursive_let_cont' are_rebuilding cont handler ~body
+      ~num_free_occurrences_of_cont_in_body ~is_applied_with_traps =
+  if ART.do_not_rebuild_terms are_rebuilding then Lazy.force invalid
+  else
+    Let_cont.create_non_recursive' ~cont handler ~body
+      ~num_free_occurrences_of_cont_in_body:
+        (Known num_free_occurrences_of_cont_in_body)
+      ~is_applied_with_traps
+
+let create_recursive_let_cont are_rebuilding handlers ~body =
+  if ART.do_not_rebuild_terms are_rebuilding then Lazy.force invalid
+  else Let_cont.create_recursive handlers ~body
+
+let create_switch are_rebuilding switch =
+  if ART.do_not_rebuild_terms are_rebuilding then Lazy.force invalid
+  else Expr.create_switch switch
+
+let create_invalid () = Lazy.force invalid
+
+let bind_no_simplification are_rebuilding ~bindings ~body
+      ~cost_metrics_of_body ~free_names_of_body =
+  ListLabels.fold_left (List.rev bindings)
+    ~init:(body, cost_metrics_of_body, free_names_of_body)
+    ~f:(fun (expr, cost_metrics, free_names)
+            (var, size_of_defining_expr, defining_expr) ->
+      let expr =
+        create_let are_rebuilding (Bindable_let_bound.singleton var)
+          defining_expr
+          ~body:expr
+          ~free_names_of_body:free_names
+      in
+      let free_names =
+        Name_occurrences.union (Named.free_names defining_expr)
+          (Name_occurrences.remove_var free_names (Var_in_binding_pos.var var))
+      in
+      let is_phantom = Name_mode.is_phantom (Var_in_binding_pos.name_mode var) in
+      let cost_metrics_of_defining_expr =
+        Cost_metrics.from_size size_of_defining_expr
+      in
+      let cost_metrics =
+        Cost_metrics.(+)
+          cost_metrics
+          (Cost_metrics.increase_due_to_let_expr
+             ~is_phantom
+             ~cost_metrics_of_defining_expr)
+      in
+      expr, cost_metrics, free_names)

--- a/middle_end/flambda/simplify/rebuilt_expr.ml
+++ b/middle_end/flambda/simplify/rebuilt_expr.ml
@@ -19,7 +19,8 @@ open! Flambda.Import
 module ART = Are_rebuilding_terms
 
 (* This is delayed to ensure evaluation happens after processing of
-   command-line flags. *)
+   command-line flags, to ensure that the desired semantics for [Invalid]
+   is respected. *)
 let invalid = lazy (Expr.create_invalid ())
 
 type t = Expr.t

--- a/middle_end/flambda/simplify/rebuilt_expr.mli
+++ b/middle_end/flambda/simplify/rebuilt_expr.mli
@@ -1,0 +1,120 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                   Mark Shinwell, Jane Street Europe                    *)
+(*                                                                        *)
+(*   Copyright 2021 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** The type of expressions constructed by the simplifier.
+
+    Using a type that is different from [Expr.t] enables us to robustly avoid
+    rebuilding terms during simplification when unnecessary, e.g. during
+    speculative inlining tests.
+
+    Note that this module relies on the [UA.t] values passed in to determine
+    the semantics of values of type [t].  As such, values of type [t] must
+    not be passed between contexts where the value of [UA.do_not_rebuild_terms]
+    differs.
+*)
+
+open! Flambda
+
+type t
+type rebuilt_expr = t
+
+val print : Are_rebuilding_terms.t -> Format.formatter -> t -> unit
+
+(** This function may only be used when rebuilding terms. *)
+val to_expr : t -> Are_rebuilding_terms.t -> Expr.t
+
+val to_apply_cont : t -> Are_rebuilding_terms.t -> Apply_cont.t option
+
+val is_unreachable : t -> Are_rebuilding_terms.t -> bool
+
+val term_not_rebuilt : unit -> t
+
+val create_let
+   : Are_rebuilding_terms.t
+  -> Bindable_let_bound.t
+  -> Named.t
+  -> body:t
+  -> free_names_of_body:Name_occurrences.t
+  -> t
+
+val create_apply : Are_rebuilding_terms.t -> Apply.t -> t
+
+val create_apply_cont : Are_rebuilding_terms.t -> Apply_cont.t -> t
+
+module Function_params_and_body : sig
+  type t
+
+  val create
+     : return_continuation:Continuation.t
+    -> Exn_continuation.t
+    -> Kinded_parameter.t list
+    -> dbg:Debuginfo.t
+    -> body:rebuilt_expr
+    -> free_names_of_body:Name_occurrences.t
+    -> my_closure:Variable.t
+    -> t
+
+  (** This function may only be used when rebuilding terms. *)
+  val to_function_params_and_body
+     : t
+    -> Are_rebuilding_terms.t
+    -> Function_params_and_body.t
+end
+
+module Continuation_handler : sig
+  type t
+
+  val create
+     : Are_rebuilding_terms.t
+    -> Kinded_parameter.t list
+    -> handler:rebuilt_expr
+    -> free_names_of_handler:Name_occurrences.t
+    -> is_exn_handler:bool
+    -> t
+end
+
+val create_non_recursive_let_cont
+   : Are_rebuilding_terms.t
+  -> Continuation.t
+  -> Continuation_handler.t
+  -> body:t
+  -> free_names_of_body:Name_occurrences.t
+  -> t
+
+val create_non_recursive_let_cont'
+   : Are_rebuilding_terms.t
+  -> Continuation.t
+  -> Continuation_handler.t
+  -> body:t
+  -> num_free_occurrences_of_cont_in_body:Num_occurrences.t
+  -> is_applied_with_traps:bool
+  -> t
+
+val create_recursive_let_cont
+   : Are_rebuilding_terms.t
+  -> Continuation_handler.t Continuation.Map.t
+  -> body:t
+  -> t
+
+val create_switch : Are_rebuilding_terms.t -> Switch_expr.t -> t
+
+val create_invalid : unit -> t
+
+val bind_no_simplification
+   : Are_rebuilding_terms.t
+  -> bindings:(Var_in_binding_pos.t * Code_size.t * Named.t) list
+  -> body:t
+  -> cost_metrics_of_body:Cost_metrics.t
+  -> free_names_of_body:Name_occurrences.t
+  -> t * Cost_metrics.t * Name_occurrences.t

--- a/middle_end/flambda/simplify/rebuilt_expr.mli
+++ b/middle_end/flambda/simplify/rebuilt_expr.mli
@@ -34,7 +34,7 @@ val print : Are_rebuilding_terms.t -> Format.formatter -> t -> unit
 (** This function may only be used when rebuilding terms. *)
 val to_expr : t -> Are_rebuilding_terms.t -> Expr.t
 
-val to_apply_cont : t -> Are_rebuilding_terms.t -> Apply_cont.t option
+val to_apply_cont : t -> Apply_cont.t option
 
 val is_unreachable : t -> Are_rebuilding_terms.t -> bool
 
@@ -50,7 +50,9 @@ val create_let
 
 val create_apply : Are_rebuilding_terms.t -> Apply.t -> t
 
-val create_apply_cont : Are_rebuilding_terms.t -> Apply_cont.t -> t
+(** [Apply_cont] expressions are always rebuilt to allow optimisations in
+    [Simplify_switch_expr] and [Simplify_let_cont_expr]. *)
+val create_apply_cont : Apply_cont.t -> t
 
 module Function_params_and_body : sig
   type t

--- a/middle_end/flambda/simplify/rebuilt_static_const.ml
+++ b/middle_end/flambda/simplify/rebuilt_static_const.ml
@@ -16,62 +16,235 @@
 
 [@@@ocaml.warning "+a-30-40-41-42"]
 
-open! Flambda.Import
+open! Flambda
 
-type t = {
-  const : Static_const.t;
-  free_names : Name_occurrences.t;
-}
+module ART = Are_rebuilding_terms
 
-type const_wfn = t
+type t =
+  | Normal of {
+    const : Static_const.t;
+    free_names : Name_occurrences.t;
+  }
+  | Non_code_not_rebuilt of { free_names : Name_occurrences.t; }
+  | Code_not_rebuilt of Non_constructed_code.t
 
-let create (const : Static_const.t) ~(free_names : _ Or_unknown.t) =
-  let free_names =
-    match const, free_names with
-    | Code code, Unknown -> Code.free_names code
-    | Code _, Known _ ->
-      Misc.fatal_errorf "Free names of [Code] static constant must not be \
-          provided to [Static_const.create]:@ %a"
-        Static_const.print const
-    | Set_of_closures _, Known free_names
-    | Block _, Known free_names
-    | Boxed_float _, Known free_names
-    | Boxed_int32 _, Known free_names
-    | Boxed_int64 _, Known free_names
-    | Boxed_nativeint _, Known free_names
-    | Immutable_float_block _, Known free_names
-    | Immutable_float_array _, Known free_names
-    | Mutable_string _, Known free_names
-    | Immutable_string _, Known free_names -> free_names
-    | Set_of_closures _, Unknown
-    | Block _, Unknown
-    | Boxed_float _, Unknown
-    | Boxed_int32 _, Unknown
-    | Boxed_int64 _, Unknown
-    | Boxed_nativeint _, Unknown
-    | Immutable_float_block _, Unknown
-    | Immutable_float_array _, Unknown
-    | Mutable_string _, Unknown
-    | Immutable_string _, Unknown ->
-      Misc.fatal_errorf "Free names of non-[Code] static constant not \
-          provided to [Static_const.create]:@ %a"
-        Static_const.print const
-  in
-  { const;
-    free_names;
+type rebuilt_static_const = t
+
+let create_normal_non_code const =
+  Normal {
+    const;
+    free_names = Static_const.free_names const;
   }
 
-let const t = t.const
+let create_code are_rebuilding code_id ~(params_and_body : _ Or_deleted.t)
+      ~newer_version_of ~params_arity ~result_arity ~stub ~inline ~is_a_functor
+      ~recursive ~cost_metrics =
+  if ART.do_not_rebuild_terms are_rebuilding then
+    let params_and_body =
+      match params_and_body with
+      | Present (_, free_names_of_params_and_body) ->
+        Or_deleted.Present ((), free_names_of_params_and_body)
+      | Deleted -> Or_deleted.Deleted
+    in
+    let non_constructed_code =
+      Non_constructed_code.create code_id ~params_and_body
+        ~newer_version_of ~params_arity ~result_arity ~stub ~inline
+        ~is_a_functor ~recursive ~cost_metrics
+    in
+    Code_not_rebuilt non_constructed_code
+  else
+    let params_and_body =
+      match params_and_body with
+      | Present (params_and_body, free_names_of_params_and_body) ->
+        Or_deleted.Present (
+          Rebuilt_expr.Function_params_and_body.to_function_params_and_body
+            params_and_body are_rebuilding,
+          free_names_of_params_and_body)
+      | Deleted -> Or_deleted.Deleted
+    in
+    let code =
+      Code.create code_id ~params_and_body
+        ~newer_version_of ~params_arity ~result_arity ~stub ~inline
+        ~is_a_functor ~recursive ~cost_metrics
+    in
+    Normal {
+      const = Code code;
+      free_names = Code.free_names code;
+    }
 
-let free_names t = t.free_names
+let create_code' code =
+  Normal {
+    const = Code code;
+    free_names = Code.free_names code;
+  }
 
-let is_fully_static t = Static_const.is_fully_static t.const
+let create_set_of_closures are_rebuilding set =
+  let free_names = Set_of_closures.free_names set in
+  if ART.do_not_rebuild_terms are_rebuilding then
+    Non_code_not_rebuilt { free_names; }
+  else
+    Normal {
+      const = Set_of_closures set;
+      free_names;
+    }
 
-let print ppf t = Static_const.print ppf t.const
+let create_block are_rebuilding tag is_mutable ~fields =
+  if ART.do_not_rebuild_terms are_rebuilding then
+    let free_names =
+      ListLabels.fold_left fields ~init:Name_occurrences.empty
+        ~f:(fun free_names field ->
+          Name_occurrences.union free_names
+            (Static_const.Field_of_block.free_names field))
+    in
+    Non_code_not_rebuilt { free_names; }
+  else
+    create_normal_non_code (Block (tag, is_mutable, fields))
+
+let create_boxed_float are_rebuilding or_var =
+  if ART.do_not_rebuild_terms are_rebuilding then
+    Non_code_not_rebuilt { free_names = Or_variable.free_names or_var; }
+  else
+    create_normal_non_code (Boxed_float or_var)
+
+let create_boxed_int32 are_rebuilding or_var =
+  if ART.do_not_rebuild_terms are_rebuilding then
+    Non_code_not_rebuilt { free_names = Or_variable.free_names or_var; }
+  else
+    create_normal_non_code (Boxed_int32 or_var)
+
+let create_boxed_int64 are_rebuilding or_var =
+  if ART.do_not_rebuild_terms are_rebuilding then
+    Non_code_not_rebuilt { free_names = Or_variable.free_names or_var; }
+  else
+    create_normal_non_code (Boxed_int64 or_var)
+
+let create_boxed_nativeint are_rebuilding or_var =
+  if ART.do_not_rebuild_terms are_rebuilding then
+    Non_code_not_rebuilt { free_names = Or_variable.free_names or_var; }
+  else
+    create_normal_non_code (Boxed_nativeint or_var)
+
+let create_immutable_float_block are_rebuilding fields =
+  if ART.do_not_rebuild_terms are_rebuilding then
+    let free_names =
+      ListLabels.fold_left fields ~init:Name_occurrences.empty
+        ~f:(fun free_names field ->
+          Name_occurrences.union free_names (Or_variable.free_names field))
+    in
+    Non_code_not_rebuilt { free_names; }
+  else
+    create_normal_non_code (Immutable_float_block fields)
+
+let create_immutable_float_array are_rebuilding fields =
+  if ART.do_not_rebuild_terms are_rebuilding then
+    let free_names =
+      ListLabels.fold_left fields ~init:Name_occurrences.empty
+        ~f:(fun free_names field ->
+          Name_occurrences.union free_names (Or_variable.free_names field))
+    in
+    Non_code_not_rebuilt { free_names; }
+  else
+    create_normal_non_code (Immutable_float_array fields)
+
+let create_mutable_string are_rebuilding ~initial_value =
+  if ART.do_not_rebuild_terms are_rebuilding then
+    Non_code_not_rebuilt { free_names = Name_occurrences.empty; }
+  else
+    create_normal_non_code (Mutable_string { initial_value; })
+
+let create_immutable_string are_rebuilding str =
+  if ART.do_not_rebuild_terms are_rebuilding then
+    Non_code_not_rebuilt { free_names = Name_occurrences.empty; }
+  else
+    create_normal_non_code (Immutable_string str)
+
+let map_set_of_closures t ~f =
+  match t with
+  | Normal { const; _ } ->
+    begin match const with
+    | Set_of_closures set_of_closures ->
+      let set_of_closures = f set_of_closures in
+      Normal {
+        const = Set_of_closures set_of_closures;
+        free_names = Set_of_closures.free_names set_of_closures;
+      }
+    | Code _
+    | Block _
+    | Boxed_float _
+    | Boxed_int32 _
+    | Boxed_int64 _
+    | Boxed_nativeint _
+    | Immutable_float_block _
+    | Immutable_float_array _
+    | Mutable_string _
+    | Immutable_string _ -> t
+    end
+  | Non_code_not_rebuilt _ | Code_not_rebuilt _ -> t
+
+let free_names t =
+  match t with
+  | Normal { free_names; _ } -> free_names
+  | Non_code_not_rebuilt { free_names; } -> free_names
+  | Code_not_rebuilt code -> Non_constructed_code.free_names code
+
+let is_fully_static t = Name_occurrences.no_variables (free_names t)
+
+let to_const t =
+  match t with
+  | Non_code_not_rebuilt _ | Code_not_rebuilt _ -> None
+  | Normal { const; _ } -> Some const
+
+let print ppf t =
+  match t with
+  | Normal { const; _ } -> Static_const.print ppf const
+  | Non_code_not_rebuilt { free_names = _; } ->
+    Format.fprintf ppf "Non_code_not_rebuilt"
+  | Code_not_rebuilt code ->
+    Format.fprintf ppf "@[<hov 1>(Code_not_rebuilt@ %a)@]"
+      Non_constructed_code.print code
+
+let make_all_code_deleted t =
+  match t with
+  | Normal { const; _ } ->
+    begin match Static_const.to_code const with
+    | None -> t
+    | Some code ->
+      let code = Code.make_deleted code in
+      let const : Static_const.t = Code code in
+      Normal {
+        const;
+        free_names = Code.free_names code;
+      }
+    end
+  | Non_code_not_rebuilt _ -> t
+  | Code_not_rebuilt code ->
+    Code_not_rebuilt (Non_constructed_code.make_deleted code)
+
+let make_code_deleted t ~if_code_id_is_member_of =
+  match t with
+  | Normal { const; _ } ->
+    begin match Static_const.to_code const with
+    | None -> t
+    | Some code ->
+      if Code_id.Set.mem (Code.code_id code) if_code_id_is_member_of then
+        let code = Code.make_deleted code in
+        let const : Static_const.t = Code code in
+        Normal {
+          const;
+          free_names = Code.free_names code;
+        }
+      else t
+    end
+  | Non_code_not_rebuilt _ -> t
+  | Code_not_rebuilt code ->
+    if Code_id.Set.mem (Non_constructed_code.code_id code)
+       if_code_id_is_member_of
+    then Code_not_rebuilt (Non_constructed_code.make_deleted code)
+    else t
 
 module Group = struct
   type t = {
-    consts : const_wfn list;
+    consts : rebuilt_static_const list;
     mutable free_names : Name_occurrences.t Or_unknown.t;
   }
 
@@ -85,13 +258,9 @@ module Group = struct
       free_names = Unknown;
     }
 
-  let group t =
-    (* The length of [t.consts] should be short and is usually going to be
-       just one, so this seems ok. *)
-    ListLabels.map t.consts ~f:(fun (const : const_wfn) -> const.const)
-    |> Static_const.Group.create
-
-  let print ppf t = Static_const.Group.print ppf (group t)
+  let print ppf { consts; free_names = _; } =
+    Format.fprintf ppf "@[<hov 1>(%a)@]"
+      (Format.pp_print_list ~pp_sep:Format.pp_print_space print) consts
 
   let free_names t =
     match t.free_names with
@@ -99,31 +268,76 @@ module Group = struct
     | Unknown ->
       let free_names =
         ListLabels.fold_left t.consts ~init:Name_occurrences.empty
-          ~f:(fun free_names (const : const_wfn) ->
-            Name_occurrences.union free_names const.free_names)
+          ~f:(fun free_names_acc (const : rebuilt_static_const) ->
+            Name_occurrences.union free_names_acc (free_names const))
       in
       t.free_names <- Known free_names;
       free_names
 
-  let consts t =
-    ListLabels.map t.consts ~f:(fun (const : const_wfn) -> const.const)
+  let to_named t =
+    ListLabels.map t.consts ~f:(fun (const : rebuilt_static_const) ->
+      match const with
+      | Normal { const; _ } -> const
+      | Non_code_not_rebuilt _ | Code_not_rebuilt _ ->
+        Misc.fatal_error "Cannot extract static constants when not \
+          rebuilding terms")
     |> Static_const.Group.create
+    |> Named.create_static_consts
 
-  let to_list t = t.consts
-
-  let pieces_of_code t =
-    t.consts
-    |> List.filter_map (fun (const : const_wfn) ->
-      Static_const.to_code const.const)
+  let pieces_of_code_for_cmx t =
+    let consts =
+      ListLabels.filter_map t.consts ~f:(fun const ->
+        match const with
+        | Normal { const; _ } -> Static_const.to_code const
+        | Non_code_not_rebuilt _ | Code_not_rebuilt _ -> None)
+    in
+    consts
     |> List.filter_map (fun code ->
       if Code.is_deleted code then None
       else Some (Code.code_id code, code))
     |> Code_id.Map.of_list
 
-  let match_against_bound_symbols t bound_symbols ~init ~code ~set_of_closures
-        ~block_like =
-    Static_const.Group.match_against_bound_symbols (group t)
-      bound_symbols ~init ~code ~set_of_closures ~block_like
+  let function_params_and_body_for_code_not_rebuilt =
+    lazy (Function_params_and_body.create
+      ~return_continuation:(Continuation.create ())
+      (Exn_continuation.create
+        ~exn_handler:(Continuation.create ~sort:Exn ())
+        ~extra_args:[])
+      [] ~dbg:Debuginfo.none ~body:(Expr.create_invalid ())
+      ~free_names_of_body:Unknown ~my_closure:(Variable.create "my_closure"))
+
+  let pieces_of_code_including_those_not_rebuilt t =
+    let consts =
+      ListLabels.filter_map t.consts ~f:(fun const ->
+        match const with
+        | Normal { const; _ } -> Static_const.to_code const
+        | Non_code_not_rebuilt _ -> None
+        | Code_not_rebuilt code ->
+          let module NCC = Non_constructed_code in
+          (* See comment in the .mli. *)
+          let params_and_body : _ Or_deleted.t =
+            match NCC.params_and_body code with
+            | Deleted -> Deleted
+            | Present () ->
+              Present (Lazy.force function_params_and_body_for_code_not_rebuilt,
+                Name_occurrences.empty)
+          in
+          Some (Code.create (NCC.code_id code)
+            ~params_and_body
+            ~newer_version_of:(NCC.newer_version_of code)
+            ~params_arity:(NCC.params_arity code)
+            ~result_arity:(NCC.result_arity code)
+            ~stub:(NCC.stub code)
+            ~inline:(NCC.inline code)
+            ~is_a_functor:(NCC.is_a_functor code)
+            ~recursive:(NCC.recursive code)
+            ~cost_metrics:(NCC.cost_metrics code)))
+    in
+    consts
+    |> List.filter_map (fun code ->
+      if Code.is_deleted code then None
+      else Some (Code.code_id code, code))
+    |> Code_id.Map.of_list
 
   let map t ~f =
     let changed = ref false in
@@ -141,6 +355,9 @@ module Group = struct
         free_names = Unknown;
       }
 
+  let fold_left t ~init ~f =
+    ListLabels.fold_left t.consts ~init ~f
+
   let concat t1 t2 =
     let free_names : _ Or_unknown.t =
       match t1.free_names, t2.free_names with
@@ -151,4 +368,6 @@ module Group = struct
     { consts = t1.consts @ t2.consts;
       free_names;
     }
+
+  let to_list t = t.consts
 end

--- a/middle_end/flambda/simplify/rebuilt_static_const.mli
+++ b/middle_end/flambda/simplify/rebuilt_static_const.mli
@@ -14,32 +14,98 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Like [Static_const.t], but also keeps track of free names, as required
-    at various points during simplification. *)
+(** Static constants, equipped with free name information, as rebuilt by
+    the simplifier.  Definitions of the constants themselves are not kept
+    when not rebuilding terms, but some of the metadata is. *)
 
 [@@@ocaml.warning "+a-30-40-41-42"]
 
-open! Flambda.Import
+open! Flambda
 
 type t
-type const_wfn = t
+type rebuilt_static_const = t
 
 val print : Format.formatter -> t -> unit
 
-(** Free names must be provided except for [Code] constants, which already
-    hold the necessary information. *)
-(* CR mshinwell: Maybe instead of [Or_unknown] we should use
-   | Code
-   | Known of Name_occurrences.t
-   | Compute_now
-   or something *)
-val create : Static_const.t -> free_names:Name_occurrences.t Or_unknown.t -> t
+val create_code
+   : Are_rebuilding_terms.t
+  -> Code_id.t
+  -> params_and_body:
+     (Rebuilt_expr.Function_params_and_body.t * Name_occurrences.t) Or_deleted.t
+  -> newer_version_of:Code_id.t option
+  -> params_arity:Flambda_arity.With_subkinds.t
+  -> result_arity:Flambda_arity.With_subkinds.t
+  -> stub:bool
+  -> inline:Inline_attribute.t
+  -> is_a_functor:bool
+  -> recursive:Recursive.t
+  -> cost_metrics:Cost_metrics.t
+  -> t
 
-val const : t -> Static_const.t
+(* This function should be used when a [Code.t] is already in hand, e.g. from
+   the input term to the simplifier, rather than when one needs to be
+   constructed.  In the latter case, use [create_code] above, so that [Code]
+   values are not constructed unnecessarily. *)
+val create_code' : Code.t -> t
+
+val create_set_of_closures : Are_rebuilding_terms.t -> Set_of_closures.t -> t
+
+val create_block
+   : Are_rebuilding_terms.t
+  -> Tag.Scannable.t
+  -> Mutability.t
+  -> fields:Static_const.Field_of_block.t list
+  -> t
+
+val create_boxed_float
+   : Are_rebuilding_terms.t
+  -> Numbers.Float_by_bit_pattern.t Or_variable.t
+  -> t
+
+val create_boxed_int32
+   : Are_rebuilding_terms.t
+  -> Int32.t Or_variable.t
+  -> t
+
+val create_boxed_int64
+   : Are_rebuilding_terms.t
+  -> Int64.t Or_variable.t
+  -> t
+
+val create_boxed_nativeint
+   : Are_rebuilding_terms.t
+  -> Targetint.t Or_variable.t
+  -> t
+
+val create_immutable_float_block
+   : Are_rebuilding_terms.t
+  -> Numbers.Float_by_bit_pattern.t Or_variable.t list
+  -> t
+
+val create_immutable_float_array
+   : Are_rebuilding_terms.t
+  -> Numbers.Float_by_bit_pattern.t Or_variable.t list
+  -> t
+
+val create_mutable_string : Are_rebuilding_terms.t -> initial_value:string -> t
+
+val create_immutable_string : Are_rebuilding_terms.t -> string -> t
+
+val map_set_of_closures : t -> f:(Set_of_closures.t -> Set_of_closures.t) -> t
 
 val free_names : t -> Name_occurrences.t
 
 val is_fully_static : t -> bool
+
+val make_all_code_deleted : t -> t
+
+val make_code_deleted
+   : t
+  -> if_code_id_is_member_of:Code_id.Set.t
+  -> t
+
+(** This will return [None] if terms are not being rebuilt. *)
+val to_const : t -> Static_const.t option
 
 module Group : sig
   type t
@@ -48,31 +114,30 @@ module Group : sig
 
   val empty : t
 
-  val create : const_wfn list -> t
+  val create : rebuilt_static_const list -> t
 
   val free_names : t -> Name_occurrences.t
 
-  val consts : t -> Static_const.Group.t
+  (** This function may only be used when rebuilding terms (a fatal error
+      will be produced otherwise). *)
+  val to_named : t -> Named.t
 
-  val to_list : t -> const_wfn list
+  (** This function returns dummy pieces of code for those not rebuilt.
+      Such pieces of code will have all of the correct metadata but a body
+      consisting solely of an [Invalid] expression.  This seems reasonable
+      because inlining is always disabled when in not-rebuilding-terms mode. *)
+  val pieces_of_code_including_those_not_rebuilt : t -> Code.t Code_id.Map.t
 
   (** This function ignores [Deleted] code. *)
-  val pieces_of_code : t -> Code.t Code_id.Map.t
+  val pieces_of_code_for_cmx : t -> Code.t Code_id.Map.t
 
-  val match_against_bound_symbols
-     : t
-    -> Bound_symbols.t
-    -> init:'a
-    -> code:('a -> Code_id.t -> Code.t -> 'a)
-    -> set_of_closures:(
-         'a
-      -> closure_symbols:Symbol.t Closure_id.Lmap.t
-      -> Set_of_closures.t
-      -> 'a)
-    -> block_like:('a -> Symbol.t -> Static_const.t -> 'a)
-    -> 'a
+  val map : t -> f:(rebuilt_static_const -> rebuilt_static_const) -> t
 
-  val map : t -> f:(const_wfn -> const_wfn) -> t
+  val fold_left : t -> init:'a -> f:('a -> rebuilt_static_const -> 'a) -> 'a
+
+  (** [map] and [fold_left] should be used in preference, to avoid
+      allocating intermediate lists. *)
+  val to_list : t -> rebuilt_static_const list
 
   val concat : t -> t -> t
 end

--- a/middle_end/flambda/simplify/simplify.ml
+++ b/middle_end/flambda/simplify/simplify.ml
@@ -89,15 +89,6 @@ let run ~backend ~round unit =
       ~return_arity:[K.With_subkind.any_value] exn_continuation
       ~return_cont_scope ~exn_cont_scope
   in
-  let _, _uacc =
-    let exn_continuation =
-      Exn_continuation.create ~exn_handler:exn_continuation ~extra_args:[]
-    in
-    let dacc = DA.set_do_not_rebuild_terms dacc in
-    Simplify_expr.simplify_toplevel dacc (FU.body unit) ~return_continuation
-      ~return_arity:[K.With_subkind.any_value] exn_continuation
-      ~return_cont_scope ~exn_cont_scope
-  in
   let body = Rebuilt_expr.to_expr body (UA.are_rebuilding_terms uacc) in
   let name_occurrences = UA.name_occurrences uacc in
   Name_occurrences.fold_names name_occurrences ~init:()

--- a/middle_end/flambda/simplify/simplify.ml
+++ b/middle_end/flambda/simplify/simplify.ml
@@ -89,6 +89,16 @@ let run ~backend ~round unit =
       ~return_arity:[K.With_subkind.any_value] exn_continuation
       ~return_cont_scope ~exn_cont_scope
   in
+  let _, _uacc =
+    let exn_continuation =
+      Exn_continuation.create ~exn_handler:exn_continuation ~extra_args:[]
+    in
+    let dacc = DA.set_do_not_rebuild_terms dacc in
+    Simplify_expr.simplify_toplevel dacc (FU.body unit) ~return_continuation
+      ~return_arity:[K.With_subkind.any_value] exn_continuation
+      ~return_cont_scope ~exn_cont_scope
+  in
+  let body = Rebuilt_expr.to_expr body (UA.are_rebuilding_terms uacc) in
   let name_occurrences = UA.name_occurrences uacc in
   Name_occurrences.fold_names name_occurrences ~init:()
     ~f:(fun () name ->
@@ -99,15 +109,6 @@ let run ~backend ~round unit =
             Variable.print var
             Expr.print body)
         ~symbol:(fun _symbol -> ()));
-  (* CR mshinwell: We can't do this for dominator-scoped symbols.
-          if Symbol.in_compilation_unit symbol
-            (Compilation_unit.get_current_exn ())
-          then begin
-            Misc.fatal_errorf "Symbol %a (defined in current compilation unit) \
-                not expected to be free in whole-compilation-unit term:@ %a"
-              Symbol.print symbol
-              Expr.print body
-          end)); *)
   let return_cont_env = DA.continuation_uses_env (UA.creation_dacc uacc) in
   let all_code =
     Exported_code.merge (UA.all_code uacc)

--- a/middle_end/flambda/simplify/simplify_apply_cont_expr.ml
+++ b/middle_end/flambda/simplify/simplify_apply_cont_expr.ml
@@ -39,7 +39,7 @@ let inline_linearly_used_continuation uacc ~create_apply_cont ~params ~handler
         KP.List.print params
         Simple.List.print args
         Apply_cont.print apply_cont
-        Expr.print handler
+        (RE.print (UA.are_rebuilding_terms uacc)) handler
     end;
     let bindings_outermost_first =
       ListLabels.map2 params args
@@ -58,8 +58,7 @@ let inline_linearly_used_continuation uacc ~create_apply_cont ~params ~handler
         UA.with_name_occurrences uacc ~name_occurrences:free_names_of_handler
         |> UA.add_cost_metrics cost_metrics_of_handler
       in
-      Expr_builder.make_new_let_bindings uacc ~bindings_outermost_first
-        ~body:handler
+      EB.make_new_let_bindings uacc ~bindings_outermost_first ~body:handler
     in
     expr, UA.cost_metrics uacc, UA.name_occurrences uacc)
 
@@ -86,7 +85,7 @@ let rebuild_apply_cont apply_cont ~args ~rewrite_id uacc ~after_rebuild =
       in
       match rewrite with
       | None -> EB.no_rewrite apply_cont
-      | Some rewrite -> EB.rewrite_use rewrite rewrite_id apply_cont
+      | Some rewrite -> EB.rewrite_use uacc rewrite rewrite_id apply_cont
     in
     match rewrite_use_result with
     | Apply_cont apply_cont ->
@@ -131,11 +130,11 @@ let rebuild_apply_cont apply_cont ~args ~rewrite_id uacc ~after_rebuild =
     (* We allow this transformation even if there is a trap action, on the
        basis that there wouldn't be any opportunity to collect any backtrace,
        even if the [Apply_cont] were compiled as "raise". *)
-    after_rebuild (Expr.create_invalid ()) uacc
+    after_rebuild (RE.create_invalid ()) uacc
   | Non_inlinable_zero_arity _ | Non_inlinable_non_zero_arity _
   | Toplevel_or_function_return_or_exn_continuation _ ->
     create_apply_cont ~apply_cont_to_expr:(fun apply_cont ->
-      Expr.create_apply_cont apply_cont,
+      RE.create_apply_cont (UA.are_rebuilding_terms uacc) apply_cont,
       Cost_metrics.from_size (Code_size.apply_cont apply_cont),
       Apply_cont.free_names apply_cont)
 

--- a/middle_end/flambda/simplify/simplify_apply_cont_expr.ml
+++ b/middle_end/flambda/simplify/simplify_apply_cont_expr.ml
@@ -134,7 +134,7 @@ let rebuild_apply_cont apply_cont ~args ~rewrite_id uacc ~after_rebuild =
   | Non_inlinable_zero_arity _ | Non_inlinable_non_zero_arity _
   | Toplevel_or_function_return_or_exn_continuation _ ->
     create_apply_cont ~apply_cont_to_expr:(fun apply_cont ->
-      RE.create_apply_cont (UA.are_rebuilding_terms uacc) apply_cont,
+      RE.create_apply_cont apply_cont,
       Cost_metrics.from_size (Code_size.apply_cont apply_cont),
       Apply_cont.free_names apply_cont)
 

--- a/middle_end/flambda/simplify/simplify_common.ml
+++ b/middle_end/flambda/simplify/simplify_common.ml
@@ -16,10 +16,19 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
-open! Simplify_import
+open! Flambda
+
+module DA = Downwards_acc
+module K = Flambda_kind
+module KP = Kinded_parameter
+module P = Flambda_primitive
+module T = Flambda_type
+module TEE = T.Typing_env_extension
+module UA = Upwards_acc
+module UE = Upwards_env
 
 type 'a after_rebuild =
-     Expr.t
+     Rebuilt_expr.t
   -> Upwards_acc.t
   -> 'a
 
@@ -36,9 +45,9 @@ type ('a, 'b) down_to_up =
 type 'a expr_simplifier =
      Downwards_acc.t
   -> 'a
-  -> down_to_up:(Expr.t * Upwards_acc.t,
-       Expr.t * Upwards_acc.t) down_to_up
-  -> Expr.t * Upwards_acc.t
+  -> down_to_up:(Rebuilt_expr.t * Upwards_acc.t,
+       Rebuilt_expr.t * Upwards_acc.t) down_to_up
+  -> Rebuilt_expr.t * Upwards_acc.t
 
 type simplify_toplevel =
      Downwards_acc.t
@@ -48,7 +57,7 @@ type simplify_toplevel =
   -> Exn_continuation.t
   -> return_cont_scope:Scope.t
   -> exn_cont_scope:Scope.t
-  -> Expr.t * Upwards_acc.t
+  -> Rebuilt_expr.t * Upwards_acc.t
 
 let simplify_projection dacc ~original_term ~deconstructing ~shape ~result_var
       ~result_kind =
@@ -67,7 +76,7 @@ let update_exn_continuation_extra_args uacc ~exn_cont_use_id apply =
   | None -> apply
   | Some rewrite ->
     Apply.with_exn_continuation apply
-      (EB.rewrite_exn_continuation rewrite exn_cont_use_id
+      (Expr_builder.rewrite_exn_continuation rewrite exn_cont_use_id
         (Apply.exn_continuation apply))
 
 (* generate the projection of the i-th field of a n-tuple *)

--- a/middle_end/flambda/simplify/simplify_common.mli
+++ b/middle_end/flambda/simplify/simplify_common.mli
@@ -21,7 +21,7 @@
 open! Flambda
 
 type 'a after_rebuild =
-     Expr.t
+     Rebuilt_expr.t
   -> Upwards_acc.t
   -> 'a
 
@@ -38,8 +38,9 @@ type ('a, 'b) down_to_up =
 type 'a expr_simplifier =
      Downwards_acc.t
   -> 'a
-  -> down_to_up:(Expr.t * Upwards_acc.t, Expr.t * Upwards_acc.t) down_to_up
-  -> Expr.t * Upwards_acc.t
+  -> down_to_up:(Rebuilt_expr.t * Upwards_acc.t,
+       Rebuilt_expr.t * Upwards_acc.t) down_to_up
+  -> Rebuilt_expr.t * Upwards_acc.t
 
 type simplify_toplevel =
      Downwards_acc.t
@@ -49,7 +50,7 @@ type simplify_toplevel =
   -> Exn_continuation.t
   -> return_cont_scope:Scope.t
   -> exn_cont_scope:Scope.t
-  -> Expr.t * Upwards_acc.t
+  -> Rebuilt_expr.t * Upwards_acc.t
 
 val simplify_projection
    : Downwards_acc.t

--- a/middle_end/flambda/simplify/simplify_expr.ml
+++ b/middle_end/flambda/simplify/simplify_expr.ml
@@ -43,8 +43,8 @@ let rec simplify_expr dacc expr ~down_to_up =
        it were [Halt_and_catch_fire]. *)
     down_to_up dacc ~rebuild:EB.rebuild_invalid
 
-and simplify_toplevel dacc expr ~return_continuation ~return_arity
-      exn_continuation ~return_cont_scope ~exn_cont_scope =
+and simplify_toplevel dacc expr ~return_continuation
+      ~return_arity exn_continuation ~return_cont_scope ~exn_cont_scope =
   let expr, uacc =
     simplify_expr dacc expr ~down_to_up:(fun dacc ~rebuild ->
       let uenv =
@@ -75,7 +75,7 @@ and simplify_toplevel dacc expr ~return_continuation ~return_arity
             toplevel expression after simplification (return \
             continuation %a, exn continuation %a):@ %a"
           Continuation.print cont
-          Expr.print expr
+          (RE.print (UA.are_rebuilding_terms uacc)) expr
           Continuation.print return_continuation
           Continuation.print exn_continuation
       end);

--- a/middle_end/flambda/simplify/simplify_import.ml
+++ b/middle_end/flambda/simplify/simplify_import.ml
@@ -52,6 +52,7 @@ module LC = Lifted_constant
 module LCS = Lifted_constant_state
 module NM = Name_mode
 module P = Flambda_primitive
+module RE = Rebuilt_expr
 module RI = Apply_cont_rewrite_id
 module S = Simplify_simple
 module SC = Static_const

--- a/middle_end/flambda/simplify/simplify_import.mli
+++ b/middle_end/flambda/simplify/simplify_import.mli
@@ -52,6 +52,7 @@ module LC = Lifted_constant
 module LCS = Lifted_constant_state
 module NM = Name_mode
 module P = Flambda_primitive
+module RE = Rebuilt_expr
 module RI = Apply_cont_rewrite_id
 module S = Simplify_simple
 module SC = Static_const

--- a/middle_end/flambda/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda/simplify/simplify_let_cont_expr.ml
@@ -81,7 +81,7 @@ let rebuild_one_continuation_handler cont ~at_unit_toplevel
         used_as_normal, new_phantom_params
   in
   let handler, uacc =
-    Expr_builder.make_new_let_bindings uacc ~body:handler
+    EB.make_new_let_bindings uacc ~body:handler
       ~bindings_outermost_first:(List.map (fun param ->
         let v = KP.var param in
         let k = K.With_subkind.kind (KP.kind param) in
@@ -104,7 +104,9 @@ let rebuild_one_continuation_handler cont ~at_unit_toplevel
   in
   let params' = used_params @ used_extra_params in
   let cont_handler =
-    CH.create params' ~handler ~free_names_of_handler:(Known free_names)
+    RE.Continuation_handler.create (UA.are_rebuilding_terms uacc)
+      params' ~handler
+      ~free_names_of_handler:free_names
       ~is_exn_handler:(CH.is_exn_handler cont_handler)
   in
   let rewrite =
@@ -144,7 +146,8 @@ type behaviour =
 let rebuild_non_recursive_let_cont_handler cont
       (uses : Continuation_env_and_param_types.t) ~params ~handler
       ~free_names_of_handler ~is_single_inlinable_use scope ~is_exn_handler
-      (extra_params_and_args : EPA.t) cont_handler uacc ~after_rebuild =
+      (extra_params_and_args : EPA.t)
+      (cont_handler : RE.Continuation_handler.t) uacc ~after_rebuild =
   let uenv = UA.uenv uacc in
   let uenv =
     (* CR mshinwell: Change types so that [free_names_of_handler] only
@@ -160,20 +163,20 @@ let rebuild_non_recursive_let_cont_handler cont
       if is_single_inlinable_use then begin
         (* Note that [Continuation_uses] won't set [is_single_inlinable_use]
            if [cont] is an exception handler. *)
-        assert (not (CH.is_exn_handler cont_handler));
+        assert (not is_exn_handler);
         (* We pass the parameters and the handler expression, rather than
            the [CH.t], to avoid re-opening the name abstraction. *)
         UE.add_linearly_used_inlinable_continuation uenv cont scope
-          ~params ~handler ~free_names_of_handler ~cost_metrics_of_handler:(UA.cost_metrics uacc)
+          ~params ~handler ~free_names_of_handler
+          ~cost_metrics_of_handler:(UA.cost_metrics uacc)
       end else begin
         let behaviour =
           (* CR-someday mshinwell: This could be replaced by a more sophisticated
             analysis, but for the moment we just use a simple syntactic check. *)
-          if is_exn_handler then
-            Unknown
+          if is_exn_handler then Unknown
           else
-            match Expr.descr handler with
-            | Apply_cont apply_cont ->
+            match RE.to_apply_cont handler (UA.are_rebuilding_terms uacc) with
+            | Some apply_cont ->
               begin match Apply_cont.trap_action apply_cont with
               | Some _ -> Unknown
               | None ->
@@ -184,9 +187,10 @@ let rebuild_non_recursive_let_cont_handler cont
                 else
                   Unknown
               end
-            | Invalid Treat_as_unreachable -> Unreachable
-            | Invalid Halt_and_catch_fire | Let _ | Let_cont _
-            | Apply _ | Switch _ -> Unknown
+            | None ->
+              if RE.is_unreachable handler (UA.are_rebuilding_terms uacc)
+              then Unreachable
+              else Unknown
         in
         match behaviour with
         | Unreachable ->
@@ -215,8 +219,8 @@ let rebuild_non_recursive_let_cont_handler cont
   after_rebuild cont_handler ~handler_expr:handler (UA.with_uenv uacc uenv)
 
 let simplify_non_recursive_let_cont_handler ~simplify_expr
-      ~denv_before_body ~dacc_after_body
-      cont params ~(handler : Expr.t) cont_handler ~prior_lifted_constants
+      ~denv_before_body ~dacc_after_body cont params
+      ~(handler : Expr.t) (cont_handler : CH.t) ~prior_lifted_constants
       ~inlining_state_at_let_cont ~inlined_debuginfo_at_let_cont
       ~scope ~is_exn_handler ~denv_for_toplevel_check ~unit_toplevel_exn_cont
       ~prior_cont_uses_env ~down_to_up =
@@ -252,9 +256,16 @@ let simplify_non_recursive_let_cont_handler ~simplify_expr
     down_to_up dacc
       ~continuation_has_zero_uses:true
       ~rebuild:(fun uacc ~after_rebuild ->
-        (* Even though the handler is discarded we removing an operation
+        (* The code will never be used, so we can swap it out for [Invalid]. *)
+        let handler = RE.create_invalid () in
+        let cont_handler =
+          RE.Continuation_handler.create (UA.are_rebuilding_terms uacc)
+            params ~handler ~free_names_of_handler:Name_occurrences.empty
+            ~is_exn_handler
+        in
+        (* Even though the handler is discarded, marking an operation as removed
            is unnecessary: the handler would have been left untouched during
-           execution.*)
+           execution. *)
         rebuild_non_recursive_let_cont_handler cont uses ~params
           ~handler ~free_names_of_handler:Name_occurrences.empty
           ~is_single_inlinable_use:false scope ~is_exn_handler
@@ -291,7 +302,7 @@ let simplify_non_recursive_let_cont_handler ~simplify_expr
          handler for the environment can remain marked as toplevel (and suitable
          for "let symbol" bindings); otherwise, it cannot. *)
       DE.at_unit_toplevel denv_for_toplevel_check
-        && (not (CH.is_exn_handler cont_handler))
+        && (not is_exn_handler)
         && Continuation.Set.subset
           (CUE.all_continuations_used cont_uses_env)
           (Continuation.Set.of_list [cont; unit_toplevel_exn_cont])
@@ -475,13 +486,15 @@ let simplify_non_recursive_let_cont ~simplify_expr dacc non_rec ~down_to_up =
                           |> UA.notify_removed
                                ~operation:Removed_operations.alloc
                         in
-                        (* The cost_metrics stored in uacc is the cost_metrics of the body at
-                           this point *)
+                        (* The cost_metrics stored in uacc is the cost_metrics
+                           of the body at this point *)
                         body, uacc
                       else
                         let remove_let_cont_leaving_handler =
-                          match Expr.descr body with
-                          | Apply_cont apply_cont ->
+                          match
+                            RE.to_apply_cont body (UA.are_rebuilding_terms uacc)
+                          with
+                          | Some apply_cont ->
                             if not (Continuation.equal cont
                               (Apply_cont.continuation apply_cont))
                             then false
@@ -492,8 +505,7 @@ let simplify_non_recursive_let_cont ~simplify_expr dacc non_rec ~down_to_up =
                                   (Apply_cont.trap_action apply_cont)
                               | _::_ -> false
                               end
-                          | Let _ | Apply _ | Switch _ | Invalid _
-                          | Let_cont _ -> false
+                          | None -> false
                         in
                         if remove_let_cont_leaving_handler then
                           let uacc =
@@ -502,9 +514,10 @@ let simplify_non_recursive_let_cont ~simplify_expr dacc non_rec ~down_to_up =
                                 name_occurrences_subsequent_exprs
                             in
                             UA.with_name_occurrences uacc ~name_occurrences
-                            (* The body was discarded -- the cost_metrics in uacc should
-                               be set to the cost_metrics of handler.*)
-                            |>  UA.with_cost_metrics cost_metrics_of_handler
+                            (* The body was discarded -- the cost_metrics in
+                               uacc should be set to the cost_metrics of
+                               handler. *)
+                            |> UA.with_cost_metrics cost_metrics_of_handler
                           in
                           handler_expr, uacc
                         else
@@ -517,9 +530,10 @@ let simplify_non_recursive_let_cont ~simplify_expr dacc non_rec ~down_to_up =
                             UA.with_name_occurrences uacc ~name_occurrences
                           in
                           let expr =
-                            Let_cont.create_non_recursive' ~cont handler ~body
-                              ~num_free_occurrences_of_cont_in_body:
-                                (Known num_free_occurrences_of_cont_in_body)
+                            RE.create_non_recursive_let_cont'
+                              (UA.are_rebuilding_terms uacc)
+                              cont handler ~body
+                              ~num_free_occurrences_of_cont_in_body
                               ~is_applied_with_traps
                           in
                           let uacc =
@@ -615,9 +629,11 @@ let simplify_recursive_let_cont_handlers ~simplify_expr
             ~after_rebuild)))
 
 let rebuild_recursive_let_cont ~body handlers ~cost_metrics_of_handlers
-      ~uenv_without_cont uacc ~after_rebuild : Expr.t * UA.t =
+      ~uenv_without_cont uacc ~after_rebuild =
   let uacc = UA.with_uenv uacc uenv_without_cont in
-  let expr = Flambda.Let_cont.create_recursive handlers ~body in
+  let expr =
+    RE.create_recursive_let_cont (UA.are_rebuilding_terms uacc) handlers ~body
+  in
   let uacc =
     UA.add_cost_metrics
       (Cost_metrics.increase_due_to_let_cont_recursive
@@ -628,8 +644,7 @@ let rebuild_recursive_let_cont ~body handlers ~cost_metrics_of_handlers
 
 (* CR mshinwell: We should not simplify recursive continuations with no
    entry point -- could loop forever.  (Need to think about this again.) *)
-let simplify_recursive_let_cont ~simplify_expr dacc recs ~down_to_up
-      : Expr.t * UA.t =
+let simplify_recursive_let_cont ~simplify_expr dacc recs ~down_to_up =
   let module CH = Continuation_handler in
   Recursive_let_cont_handlers.pattern_match recs ~f:(fun ~body rec_handlers ->
     assert (not (Continuation_handlers.contains_exn_handler rec_handlers));
@@ -682,8 +697,7 @@ let simplify_recursive_let_cont ~simplify_expr dacc recs ~down_to_up
                       ~uenv_without_cont uacc ~cost_metrics_of_handlers
                       ~after_rebuild)))))))
 
-let simplify_let_cont ~simplify_expr dacc (let_cont : Let_cont.t) ~down_to_up
-      : Expr.t * UA.t =
+let simplify_let_cont ~simplify_expr dacc (let_cont : Let_cont.t) ~down_to_up =
   match let_cont with
   | Non_recursive { handler; _ } ->
     simplify_non_recursive_let_cont ~simplify_expr dacc handler ~down_to_up

--- a/middle_end/flambda/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda/simplify/simplify_let_cont_expr.ml
@@ -173,7 +173,8 @@ let rebuild_non_recursive_let_cont_handler cont
         let behaviour =
           (* CR-someday mshinwell: This could be replaced by a more sophisticated
             analysis, but for the moment we just use a simple syntactic check. *)
-          if is_exn_handler then Unknown
+          if is_exn_handler then
+            Unknown
           else
             match RE.to_apply_cont handler (UA.are_rebuilding_terms uacc) with
             | Some apply_cont ->

--- a/middle_end/flambda/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda/simplify/simplify_let_cont_expr.ml
@@ -176,7 +176,7 @@ let rebuild_non_recursive_let_cont_handler cont
           if is_exn_handler then
             Unknown
           else
-            match RE.to_apply_cont handler (UA.are_rebuilding_terms uacc) with
+            match RE.to_apply_cont handler with
             | Some apply_cont ->
               begin match Apply_cont.trap_action apply_cont with
               | Some _ -> Unknown
@@ -492,9 +492,7 @@ let simplify_non_recursive_let_cont ~simplify_expr dacc non_rec ~down_to_up =
                         body, uacc
                       else
                         let remove_let_cont_leaving_handler =
-                          match
-                            RE.to_apply_cont body (UA.are_rebuilding_terms uacc)
-                          with
+                          match RE.to_apply_cont body with
                           | Some apply_cont ->
                             if not (Continuation.equal cont
                               (Apply_cont.continuation apply_cont))

--- a/middle_end/flambda/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda/simplify/simplify_switch_expr.ml
@@ -33,20 +33,12 @@ let rebuild_switch ~simplify_let dacc ~arms ~scrutinee ~scrutinee_ty uacc
             (* First try to absorb any [Apply_cont] expression that forms the
                entirety of the arm's action (via an intermediate zero-arity
                continuation without trap action) into the [Switch] expression
-               itself.
-               Note that these optimisations do not currently apply when not
-               rebuilding terms, since the expression that is potentially an
-               [Apply_cont] is not available under such circumstances. *)
-            (* CR-someday mshinwell: Maybe [Rebuilt_expr] could preserve
-               [Apply_cont]? *)
+               itself. *)
             if not (Apply_cont.is_goto action) then Some action
             else
               let cont = Apply_cont.continuation action in
               let check_handler ~handler ~action =
-                match
-                  Rebuilt_expr.to_apply_cont handler
-                    (DA.are_rebuilding_terms dacc)
-                with
+                match RE.to_apply_cont handler with
                 | Some action -> Some action
                 | None -> Some action
               in

--- a/middle_end/flambda/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda/simplify/simplify_switch_expr.ml
@@ -37,6 +37,8 @@ let rebuild_switch ~simplify_let dacc ~arms ~scrutinee ~scrutinee_ty uacc
                Note that these optimisations do not currently apply when not
                rebuilding terms, since the expression that is potentially an
                [Apply_cont] is not available under such circumstances. *)
+            (* CR-someday mshinwell: Maybe [Rebuilt_expr] could preserve
+               [Apply_cont]? *)
             if not (Apply_cont.is_goto action) then Some action
             else
               let cont = Apply_cont.continuation action in

--- a/middle_end/flambda/terms/expr.rec.mli
+++ b/middle_end/flambda/terms/expr.rec.mli
@@ -60,13 +60,6 @@ val create_switch : Switch_expr.t -> t
 (** Create an expression indicating type-incorrect or unreachable code. *)
 val create_invalid : ?semantics:Invalid_term_semantics.t -> unit -> t
 
-val bind_no_simplification
-   : bindings:(Var_in_binding_pos.t * Code_size.t * Named.t) list
-  -> body:Expr.t
-  -> cost_metrics_of_body:Cost_metrics.t
-  -> free_names_of_body:Name_occurrences.t
-  -> Expr.t * Cost_metrics.t * Name_occurrences.t
-
 val bind_parameters_to_args_no_simplification
    : params:Kinded_parameter.t list
   -> args:Simple.t list

--- a/middle_end/flambda/terms/flambda.mli
+++ b/middle_end/flambda/terms/flambda.mli
@@ -78,13 +78,6 @@ module rec Expr : sig
   (** Create an expression indicating type-incorrect or unreachable code. *)
   val create_invalid : ?semantics:Invalid_term_semantics.t -> unit -> t
 
-  val bind_no_simplification
-     : bindings:(Var_in_binding_pos.t * Code_size.t * Named.t) list
-    -> body:Expr.t
-    -> cost_metrics_of_body:Cost_metrics.t
-    -> free_names_of_body:Name_occurrences.t
-    -> Expr.t * Cost_metrics.t * Name_occurrences.t
-
   val bind_parameters_to_args_no_simplification
      : params:Kinded_parameter.t list
     -> args:Simple.t list


### PR DESCRIPTION
This provides a function in `DA` that one can call to prevent rebuilding of terms during simplification, as desired for the speculative inlining work.  Everything else in `UA` is accumulated as normal, e.g. cost metrics and free names.

I'm putting this up now for CI testing.  I'll split some parts out of this patch and also provide explanations for certain interesting things that have arisen during its development (including some bug fixes).

The main thing to take away is that there are now separate types for "terms rebuilt by the simplifier", with cheap (sometimes free) conversions back to normal terms at the end of simplification, when that is required.