### PR TITLE
Functorise Code

### DIFF
--- a/.depend
+++ b/.depend
@@ -6381,34 +6381,6 @@ middle_end/flambda/simplify/simplify_expr.cmx : \
 middle_end/flambda/simplify/simplify_expr.cmi : \
     middle_end/flambda/simplify/simplify_common.cmi \
     middle_end/flambda/terms/flambda.cmi
-middle_end/flambda/simplify/simplify_expr.rec.cmo : \
-    middle_end/flambda/simplify/simplify_switch_expr.cmi \
-    middle_end/flambda/simplify/simplify_let_expr.cmi \
-    middle_end/flambda/simplify/simplify_let_cont_expr.cmi \
-    middle_end/flambda/simplify/simplify_import.cmi \
-    middle_end/flambda/simplify/simplify_common.cmi \
-    middle_end/flambda/simplify/simplify_apply_expr.cmi \
-    middle_end/flambda/simplify/simplify_apply_cont_expr.cmi \
-    middle_end/flambda/naming/name_occurrences.cmi \
-    utils/misc.cmi \
-    middle_end/flambda/basic/exn_continuation.cmi \
-    middle_end/flambda/basic/continuation.cmi \
-    middle_end/flambda/simplify/simplify_expr.rec.cmi
-middle_end/flambda/simplify/simplify_expr.rec.cmx : \
-    middle_end/flambda/simplify/simplify_switch_expr.cmx \
-    middle_end/flambda/simplify/simplify_let_expr.cmx \
-    middle_end/flambda/simplify/simplify_let_cont_expr.cmx \
-    middle_end/flambda/simplify/simplify_import.cmx \
-    middle_end/flambda/simplify/simplify_common.cmx \
-    middle_end/flambda/simplify/simplify_apply_expr.cmx \
-    middle_end/flambda/simplify/simplify_apply_cont_expr.cmx \
-    middle_end/flambda/naming/name_occurrences.cmx \
-    utils/misc.cmx \
-    middle_end/flambda/basic/exn_continuation.cmx \
-    middle_end/flambda/basic/continuation.cmx \
-    middle_end/flambda/simplify/simplify_expr.rec.cmi
-middle_end/flambda/simplify/simplify_expr.rec.cmi : \
-    middle_end/flambda/simplify/simplify_common.cmi
 middle_end/flambda/simplify/simplify_import.cmo : \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
     middle_end/flambda/simplify/env/upwards_env.cmi \
@@ -7547,6 +7519,14 @@ middle_end/flambda/terms/call_kind.cmi : \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/terms/code.rec.cmo : \
+    middle_end/flambda/terms/code0.cmi \
+    middle_end/flambda/terms/code.rec.cmi
+middle_end/flambda/terms/code.rec.cmx : \
+    middle_end/flambda/terms/code0.cmx \
+    middle_end/flambda/terms/code.rec.cmi
+middle_end/flambda/terms/code.rec.cmi : \
+    middle_end/flambda/terms/code_intf.cmo
+middle_end/flambda/terms/code0.cmo : \
     middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/basic/recursive.cmi \
     utils/printing_cache.cmi \
@@ -7559,9 +7539,10 @@ middle_end/flambda/terms/code.rec.cmo : \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/types/kinds/flambda_arity.cmi \
+    middle_end/flambda/cmx/contains_ids.cmo \
     middle_end/flambda/basic/code_id.cmi \
-    middle_end/flambda/terms/code.rec.cmi
-middle_end/flambda/terms/code.rec.cmx : \
+    middle_end/flambda/terms/code0.cmi
+middle_end/flambda/terms/code0.cmx : \
     middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/basic/recursive.cmx \
     utils/printing_cache.cmx \
@@ -7574,9 +7555,15 @@ middle_end/flambda/terms/code.rec.cmx : \
     middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/types/kinds/flambda_arity.cmx \
+    middle_end/flambda/cmx/contains_ids.cmx \
     middle_end/flambda/basic/code_id.cmx \
-    middle_end/flambda/terms/code.rec.cmi
-middle_end/flambda/terms/code.rec.cmi : \
+    middle_end/flambda/terms/code0.cmi
+middle_end/flambda/terms/code0.cmi : \
+    middle_end/flambda/naming/renaming.cmi \
+    utils/printing_cache.cmi \
+    middle_end/flambda/cmx/contains_ids.cmo \
+    middle_end/flambda/terms/code_intf.cmo
+middle_end/flambda/terms/code_intf.cmo : \
     middle_end/flambda/basic/recursive.cmi \
     utils/printing_cache.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
@@ -7587,6 +7574,17 @@ middle_end/flambda/terms/code.rec.cmi : \
     middle_end/flambda/types/kinds/flambda_arity.cmi \
     middle_end/flambda/naming/contains_names.cmo \
     middle_end/flambda/basic/code_id.cmi
+middle_end/flambda/terms/code_intf.cmx : \
+    middle_end/flambda/basic/recursive.cmx \
+    utils/printing_cache.cmx \
+    middle_end/flambda/types/basic/or_unknown.cmx \
+    middle_end/flambda/basic/or_deleted.cmx \
+    middle_end/flambda/naming/name_occurrences.cmx \
+    middle_end/flambda/basic/inline_attribute.cmx \
+    middle_end/flambda/cmx/ids_for_export.cmx \
+    middle_end/flambda/types/kinds/flambda_arity.cmx \
+    middle_end/flambda/naming/contains_names.cmx \
+    middle_end/flambda/basic/code_id.cmx
 middle_end/flambda/terms/continuation_handler.rec.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/simple.cmi \
@@ -7754,7 +7752,6 @@ middle_end/flambda/terms/flambda.cmo : \
     utils/printing_cache.cmi \
     middle_end/flambda/basic/or_variable.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
-    middle_end/flambda/basic/or_deleted.cmi \
     utils/numbers.cmi \
     middle_end/flambda/naming/num_occurrences.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
@@ -7766,7 +7763,6 @@ middle_end/flambda/terms/flambda.cmo : \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/basic/invariant_env.cmi \
     middle_end/flambda/basic/invalid_term_semantics.cmi \
-    middle_end/flambda/basic/inline_attribute.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     utils/identifiable.cmi \
     middle_end/flambda/terms/function_declarations.cmi \
@@ -7782,7 +7778,9 @@ middle_end/flambda/terms/flambda.cmo : \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/naming/contains_names.cmo \
     middle_end/flambda/cmx/contains_ids.cmo \
+    middle_end/flambda/terms/code_intf.cmo \
     middle_end/flambda/basic/code_id.cmi \
+    middle_end/flambda/terms/code0.cmi \
     middle_end/flambda/basic/closure_id.cmi \
     utils/clflags.cmi \
     middle_end/flambda/terms/bound_symbols.cmi \
@@ -7809,7 +7807,6 @@ middle_end/flambda/terms/flambda.cmx : \
     utils/printing_cache.cmx \
     middle_end/flambda/basic/or_variable.cmx \
     middle_end/flambda/types/basic/or_unknown.cmx \
-    middle_end/flambda/basic/or_deleted.cmx \
     utils/numbers.cmx \
     middle_end/flambda/naming/num_occurrences.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
@@ -7821,7 +7818,6 @@ middle_end/flambda/terms/flambda.cmx : \
     middle_end/flambda/basic/kinded_parameter.cmx \
     middle_end/flambda/basic/invariant_env.cmx \
     middle_end/flambda/basic/invalid_term_semantics.cmx \
-    middle_end/flambda/basic/inline_attribute.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     utils/identifiable.cmx \
     middle_end/flambda/terms/function_declarations.cmx \
@@ -7837,7 +7833,9 @@ middle_end/flambda/terms/flambda.cmx : \
     middle_end/flambda/basic/continuation.cmx \
     middle_end/flambda/naming/contains_names.cmx \
     middle_end/flambda/cmx/contains_ids.cmx \
+    middle_end/flambda/terms/code_intf.cmx \
     middle_end/flambda/basic/code_id.cmx \
+    middle_end/flambda/terms/code0.cmx \
     middle_end/flambda/basic/closure_id.cmx \
     utils/clflags.cmx \
     middle_end/flambda/terms/bound_symbols.cmx \

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -283,6 +283,8 @@ MIDDLE_END_FLAMBDA_TERMS=\
   middle_end/flambda/terms/call_kind.cmo \
   middle_end/flambda/terms/apply_expr.cmo \
   middle_end/flambda/terms/switch_expr.cmo \
+  middle_end/flambda/terms/code0.cmo \
+  middle_end/flambda/terms/code_intf.cmo \
   middle_end/flambda/terms/function_declaration.cmo \
   middle_end/flambda/terms/function_declarations.cmo \
   middle_end/flambda/terms/set_of_closures.cmo \

--- a/middle_end/flambda/terms/code.rec.mli
+++ b/middle_end/flambda/terms/code.rec.mli
@@ -20,73 +20,7 @@
     together with a field indicating whether the piece of code is a newer
     version of one that existed previously (and may still exist), for
     example after a round of simplification. *)
-type t
 
-val code_id : t -> Code_id.t
-
-val params_and_body : t -> Function_params_and_body.t Or_deleted.t
-
-val params_and_body_opt : t -> Function_params_and_body.t option
-
-val params_and_body_must_be_present
-   : error_context:string
-  -> t
-  -> Function_params_and_body.t
-
-val newer_version_of : t -> Code_id.t option
-
-val params_arity : t -> Flambda_arity.With_subkinds.t
-
-val result_arity : t -> Flambda_arity.With_subkinds.t
-
-val stub : t -> bool
-
-val inline : t -> Inline_attribute.t
-
-val is_a_functor : t -> bool
-
-val recursive : t -> Recursive.t
-
-val cost_metrics : t -> Cost_metrics.t Or_unknown.t
-
-val create
-   : Code_id.t  (** needed for [compare], although useful otherwise too *)
-  -> params_and_body:
-    (Function_params_and_body.t * Name_occurrences.t) Or_deleted.t
-  -> newer_version_of:Code_id.t option
-  -> params_arity:Flambda_arity.With_subkinds.t
-  -> result_arity:Flambda_arity.With_subkinds.t
-  -> stub:bool
-  -> inline:Inline_attribute.t
-  -> is_a_functor:bool
-  -> recursive:Recursive.t
-  -> cost_metrics:Cost_metrics.t Or_unknown.t
-  -> t
-
-val with_code_id : Code_id.t -> t -> t
-
-val with_params_and_body
-   : (Function_params_and_body.t * Name_occurrences.t) Or_deleted.t
-  -> cost_metrics:Cost_metrics.t Or_unknown.t
-  -> t
-  -> t
-
-val with_newer_version_of : Code_id.t option -> t -> t
-
-val make_deleted : t -> t
-
-val is_deleted : t -> bool
-
-include Contains_names.S with type t := t
-
-val print_with_cache : cache:Printing_cache.t -> Format.formatter -> t -> unit
-
-val print : Format.formatter -> t -> unit
-
-val all_ids_for_export : t -> Ids_for_export.t
-
-val compare : t -> t -> int
-
-(* CR mshinwell: Somewhere there should be an invariant check that
-   code has no free names. *)
-
+include Code_intf.S
+  with type function_params_and_body := Function_params_and_body.t
+  with type cost_metrics := Cost_metrics.t

--- a/middle_end/flambda/terms/code0.ml
+++ b/middle_end/flambda/terms/code0.ml
@@ -1,0 +1,320 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Pierre Chambart, OCamlPro                        *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2013--2020 OCamlPro SAS                                    *)
+(*   Copyright 2014--2020 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+(* CR mshinwell: We should be able to remove the parameterisation over
+   [Cost_metrics] once e.g. [Cost_metrics.expr_size] has gone. *)
+
+module Make (Function_params_and_body : sig
+  type t
+
+  include Contains_ids.S with type t := t
+
+  val apply_renaming : t -> Renaming.t -> t
+
+  val print : Format.formatter -> t -> unit
+
+  val print_with_cache
+     : cache:Printing_cache.t
+    -> Format.formatter
+    -> t
+    -> unit
+end) (Cost_metrics : sig
+  type t
+
+  val print : Format.formatter -> t -> unit
+end) = struct
+  type t = {
+    code_id : Code_id.t;
+    params_and_body : Function_params_and_body.t Or_deleted.t;
+    free_names_of_params_and_body : Name_occurrences.t;
+    newer_version_of : Code_id.t option;
+    params_arity : Flambda_arity.With_subkinds.t;
+    result_arity : Flambda_arity.With_subkinds.t;
+    stub : bool;
+    inline : Inline_attribute.t;
+    is_a_functor : bool;
+    recursive : Recursive.t;
+    cost_metrics : Cost_metrics.t Or_unknown.t;
+  }
+
+  let code_id { code_id; _ } = code_id
+
+  let params_and_body { params_and_body; _ } = params_and_body
+
+  let params_and_body_opt { params_and_body; _ } =
+    match params_and_body with
+    | Deleted -> None
+    | Present params_and_body -> Some params_and_body
+
+  let params_and_body_must_be_present ~error_context { params_and_body; _ } =
+    match params_and_body with
+    | Deleted -> Misc.fatal_errorf "%s: params and body are deleted" error_context
+    | Present params_and_body -> params_and_body
+
+  let newer_version_of { newer_version_of; _ } = newer_version_of
+
+  let params_arity { params_arity; _ } = params_arity
+
+  let result_arity { result_arity; _ } = result_arity
+
+  let stub { stub; _ } = stub
+
+  let inline { inline; _ } = inline
+
+  let is_a_functor { is_a_functor; _ } = is_a_functor
+
+  let recursive { recursive; _ } = recursive
+
+  let cost_metrics {cost_metrics; _} = cost_metrics
+
+  let check_params_and_body code_id (params_and_body : _ Or_deleted.t) =
+    let free_names_of_params_and_body =
+      match params_and_body with
+      | Deleted -> Name_occurrences.empty
+      | Present (params_and_body, free_names) ->
+        if not (Name_occurrences.no_continuations free_names
+                && Name_occurrences.no_variables free_names)
+        then begin
+          Misc.fatal_errorf "Incorrect free names:@ %a@ for creation of code:@ \
+              %a@ =@ %a"
+            Name_occurrences.print free_names
+            Code_id.print code_id
+            Function_params_and_body.print params_and_body
+        end;
+        free_names
+    in
+    let params_and_body : _ Or_deleted.t =
+      match params_and_body with
+      | Deleted -> Deleted
+      | Present (params_and_body, _free_names) -> Present params_and_body
+    in
+    params_and_body, free_names_of_params_and_body
+
+  let create
+        code_id
+        ~(params_and_body : _ Or_deleted.t)
+        ~newer_version_of
+        ~params_arity
+        ~result_arity
+        ~stub
+        ~(inline:Inline_attribute.t)
+        ~is_a_functor
+        ~recursive
+        ~cost_metrics =
+    begin match stub, inline with
+    | true, (Hint_inline | Never_inline | Default_inline)
+    | false, (Never_inline | Default_inline | Always_inline | Hint_inline
+              | Unroll _) -> ()
+    | true, (Always_inline | Unroll _) ->
+      Misc.fatal_error "Stubs may not be annotated as [Always_inline] or \
+        [Unroll]"
+    end;
+    let params_and_body, free_names_of_params_and_body =
+      check_params_and_body code_id params_and_body
+    in
+    { code_id;
+      params_and_body;
+      free_names_of_params_and_body;
+      newer_version_of;
+      params_arity;
+      result_arity;
+      stub;
+      inline;
+      is_a_functor;
+      recursive;
+      cost_metrics;
+    }
+
+  let with_code_id code_id t = { t with code_id }
+
+  let with_params_and_body params_and_body ~cost_metrics t =
+    let params_and_body, free_names_of_params_and_body =
+      check_params_and_body t.code_id params_and_body
+    in
+    { t with params_and_body; cost_metrics; free_names_of_params_and_body; }
+
+  let with_newer_version_of newer_version_of t = { t with newer_version_of }
+
+  let print_params_and_body_with_cache ~cache ppf params_and_body =
+    match params_and_body with
+    | Or_deleted.Deleted -> Format.fprintf ppf "Deleted"
+    | Or_deleted.Present params_and_body ->
+      Function_params_and_body.print_with_cache ~cache ppf
+        params_and_body
+
+  let print_with_cache ~cache ppf
+        { code_id = _; params_and_body; newer_version_of; stub; inline;
+          is_a_functor; params_arity; result_arity; recursive;
+          free_names_of_params_and_body = _; cost_metrics } =
+    let module C = Flambda_colours in
+    match params_and_body with
+    | Present _ ->
+      Format.fprintf ppf "@[<hov 1>(\
+          @[<hov 1>@<0>%s(newer_version_of@ %a)@<0>%s@]@ \
+          @[<hov 1>@<0>%s(stub@ %b)@<0>%s@]@ \
+          @[<hov 1>@<0>%s(inline@ %a)@<0>%s@]@ \
+          @[<hov 1>@<0>%s(is_a_functor@ %b)@<0>%s@]@ \
+          @[<hov 1>@<0>%s(params_arity@ @<0>%s%a@<0>%s)@<0>%s@]@ \
+          @[<hov 1>@<0>%s(result_arity@ @<0>%s%a@<0>%s)@<0>%s@]@ \
+          @[<hov 1>@<0>%s(recursive@ %a)@<0>%s@]@ \
+          @[<hov 1>@<0>%s(cost_metrics@ %a)@<0>%s@]@ \
+          %a\
+          )@]"
+        (if Option.is_none newer_version_of then Flambda_colours.elide ()
+        else Flambda_colours.normal ())
+        (Misc.Stdlib.Option.print_compact Code_id.print) newer_version_of
+        (Flambda_colours.normal ())
+        (if not stub then Flambda_colours.elide () else C.normal ())
+        stub
+        (Flambda_colours.normal ())
+        (if Inline_attribute.is_default inline
+        then Flambda_colours.elide ()
+        else C.normal ())
+        Inline_attribute.print inline
+        (Flambda_colours.normal ())
+        (if not is_a_functor then Flambda_colours.elide () else C.normal ())
+        is_a_functor
+        (Flambda_colours.normal ())
+        (if Flambda_arity.With_subkinds.is_singleton_value params_arity
+        then Flambda_colours.elide ()
+        else Flambda_colours.normal ())
+        (Flambda_colours.normal ())
+        Flambda_arity.With_subkinds.print params_arity
+        (if Flambda_arity.With_subkinds.is_singleton_value params_arity
+        then Flambda_colours.elide ()
+        else Flambda_colours.normal ())
+        (Flambda_colours.normal ())
+        (if Flambda_arity.With_subkinds.is_singleton_value result_arity
+        then Flambda_colours.elide ()
+        else Flambda_colours.normal ())
+        (Flambda_colours.normal ())
+        Flambda_arity.With_subkinds.print result_arity
+        (if Flambda_arity.With_subkinds.is_singleton_value result_arity
+        then Flambda_colours.elide ()
+        else Flambda_colours.normal ())
+        (Flambda_colours.normal ())
+        (match recursive with
+        | Non_recursive -> Flambda_colours.elide ()
+        | Recursive -> Flambda_colours.normal ())
+        Recursive.print recursive
+        (Flambda_colours.normal ())
+        (match cost_metrics with
+        | Unknown -> Flambda_colours.elide ()
+        | Known _ -> Flambda_colours.normal ())
+        (Or_unknown.print Cost_metrics.print) cost_metrics
+        (Flambda_colours.normal ())
+        (print_params_and_body_with_cache ~cache) params_and_body
+    | Deleted ->
+      Format.fprintf ppf "@[<hov 1>(\
+          @[<hov 1>@<0>%s(newer_version_of@ %a)@<0>%s@]@ \
+          Deleted\
+          )@]"
+        (if Option.is_none newer_version_of then Flambda_colours.elide ()
+        else Flambda_colours.normal ())
+        (Misc.Stdlib.Option.print_compact Code_id.print) newer_version_of
+        (Flambda_colours.normal ())
+
+  let print ppf code =
+    print_with_cache ~cache:(Printing_cache.create ()) ppf code
+
+  let compare { code_id = code_id1; _ } { code_id = code_id2; _ } =
+    Code_id.compare code_id1 code_id2
+
+  let free_names t =
+    (* [code_id] is only in [t] for the use of [compare]; it doesn't
+        count as a free name. *)
+    let from_newer_version_of =
+      match t.newer_version_of with
+      | None -> Name_occurrences.empty
+      | Some older ->
+        Name_occurrences.add_newer_version_of_code_id
+          Name_occurrences.empty older Name_mode.normal
+    in
+    Name_occurrences.union from_newer_version_of t.free_names_of_params_and_body
+
+  let apply_renaming
+        ({ code_id; params_and_body; newer_version_of; params_arity = _;
+          result_arity = _; stub = _; inline = _; is_a_functor = _;
+          recursive = _; cost_metrics = _; free_names_of_params_and_body; } as t)
+        perm =
+    (* inlined and modified version of Option.map to preserve sharing *)
+    let newer_version_of' =
+      match newer_version_of with
+      | None -> newer_version_of
+      | Some code_id ->
+        let code_id' = Renaming.apply_code_id perm code_id in
+        if code_id == code_id'
+        then newer_version_of
+        else Some code_id'
+    in
+    let code_id' = Renaming.apply_code_id perm code_id in
+    let params_and_body' : Function_params_and_body.t Or_deleted.t =
+      match params_and_body with
+      | Deleted -> Deleted
+      | Present params_and_body_inner ->
+        let params_and_body_inner' =
+          Function_params_and_body.apply_renaming
+            params_and_body_inner perm
+        in
+        if params_and_body_inner == params_and_body_inner' then
+          params_and_body
+        else
+          Present params_and_body_inner'
+    in
+    if params_and_body == params_and_body' &&
+      code_id == code_id' &&
+      newer_version_of == newer_version_of' then t
+    else begin
+      let free_names_of_params_and_body' =
+        Name_occurrences.apply_renaming free_names_of_params_and_body perm
+      in
+      { t with code_id = code_id';
+              params_and_body = params_and_body';
+              newer_version_of = newer_version_of';
+              free_names_of_params_and_body = free_names_of_params_and_body';
+      }
+    end
+
+  let all_ids_for_export { code_id; params_and_body; newer_version_of;
+                          params_arity = _; result_arity = _; stub = _;
+                          inline = _; is_a_functor = _; recursive = _;
+                          cost_metrics = _; free_names_of_params_and_body = _; } =
+    let newer_version_of_ids =
+      match newer_version_of with
+      | None -> Ids_for_export.empty
+      | Some older ->
+        Ids_for_export.add_code_id Ids_for_export.empty older
+    in
+    let params_and_body_ids =
+      match params_and_body with
+      | Deleted -> Ids_for_export.empty
+      | Present params_and_body ->
+        Function_params_and_body.all_ids_for_export params_and_body
+    in
+    Ids_for_export.add_code_id
+      (Ids_for_export.union newer_version_of_ids params_and_body_ids)
+      code_id
+
+  let make_deleted t =
+    { t with params_and_body = Deleted; }
+
+  let is_deleted t =
+    match t.params_and_body with
+    | Deleted -> true
+    | Present _ -> false
+end

--- a/middle_end/flambda/terms/code0.mli
+++ b/middle_end/flambda/terms/code0.mli
@@ -16,4 +16,25 @@
 
 [@@@ocaml.warning "+a-30-40-41-42"]
 
-include Code0.Make (Function_params_and_body) (Cost_metrics)
+module Make (Function_params_and_body : sig
+  type t
+
+  include Contains_ids.S with type t := t
+
+  val apply_renaming : t -> Renaming.t -> t
+
+  val print : Format.formatter -> t -> unit
+
+  val print_with_cache
+     : cache:Printing_cache.t
+    -> Format.formatter
+    -> t
+    -> unit
+end) (Cost_metrics : sig
+  type t
+
+  val print : Format.formatter -> t -> unit
+end)
+  : Code_intf.S
+    with type function_params_and_body := Function_params_and_body.t
+    with type cost_metrics := Cost_metrics.t

--- a/middle_end/flambda/terms/code_intf.ml
+++ b/middle_end/flambda/terms/code_intf.ml
@@ -1,0 +1,96 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Pierre Chambart, OCamlPro                        *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2013--2020 OCamlPro SAS                                    *)
+(*   Copyright 2014--2020 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+(** A piece of code, comprising of the parameters and body of a function,
+    together with a field indicating whether the piece of code is a newer
+    version of one that existed previously (and may still exist), for
+    example after a round of simplification. *)
+module type S = sig
+  type t
+
+  type function_params_and_body
+  type cost_metrics
+
+  val code_id : t -> Code_id.t
+
+  val params_and_body : t -> function_params_and_body Or_deleted.t
+
+  val params_and_body_opt : t -> function_params_and_body option
+
+  val params_and_body_must_be_present
+    : error_context:string
+    -> t
+    -> function_params_and_body
+
+  val newer_version_of : t -> Code_id.t option
+
+  val params_arity : t -> Flambda_arity.With_subkinds.t
+
+  val result_arity : t -> Flambda_arity.With_subkinds.t
+
+  val stub : t -> bool
+
+  val inline : t -> Inline_attribute.t
+
+  val is_a_functor : t -> bool
+
+  val recursive : t -> Recursive.t
+
+  val cost_metrics : t -> cost_metrics Or_unknown.t
+
+  val create
+     : Code_id.t  (** needed for [compare], although useful otherwise too *)
+    -> params_and_body:
+      (function_params_and_body * Name_occurrences.t) Or_deleted.t
+    -> newer_version_of:Code_id.t option
+    -> params_arity:Flambda_arity.With_subkinds.t
+    -> result_arity:Flambda_arity.With_subkinds.t
+    -> stub:bool
+    -> inline:Inline_attribute.t
+    -> is_a_functor:bool
+    -> recursive:Recursive.t
+    -> cost_metrics:cost_metrics Or_unknown.t
+    -> t
+
+  val with_code_id : Code_id.t -> t -> t
+
+  val with_params_and_body
+    : (function_params_and_body * Name_occurrences.t) Or_deleted.t
+    -> cost_metrics:cost_metrics Or_unknown.t
+    -> t
+    -> t
+
+  val with_newer_version_of : Code_id.t option -> t -> t
+
+  val make_deleted : t -> t
+
+  val is_deleted : t -> bool
+
+  include Contains_names.S with type t := t
+
+  val print_with_cache : cache:Printing_cache.t -> Format.formatter -> t -> unit
+
+  val print : Format.formatter -> t -> unit
+
+  val all_ids_for_export : t -> Ids_for_export.t
+
+  val compare : t -> t -> int
+
+  (* CR mshinwell: Somewhere there should be an invariant check that
+     code has no free names. *)
+end


### PR DESCRIPTION
This introduces a new module `Code0` and functor `Code0.Make` which is now used to build `Code`.  This will allow the "not rebuilding terms" mode to use a different notion of "code", where the function body is absent, but associated metadata is still tracked.  Using the existing `Code` would have introduced some awkward complexities (e.g. lying about free names).

One nice thing here is that the recursive dependencies of `Code0` are now explicit.