### PR TITLE
Do not export Reification.create_static_const

### DIFF
--- a/middle_end/flambda/lifting/reification.mli
+++ b/middle_end/flambda/lifting/reification.mli
@@ -18,8 +18,6 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
-val create_static_const : Flambda_type.to_lift -> Flambda.Static_const.t
-
 val try_to_reify
    : Downwards_acc.t
   -> Simplified_named.t


### PR DESCRIPTION
This function is no longer used outside of `Reification`.