### PR TITLE
Move functions that apply [Apply_cont_rewrite]s into EB

### DIFF
--- a/middle_end/flambda/simplify/basic/apply_cont_rewrite.mli
+++ b/middle_end/flambda/simplify/basic/apply_cont_rewrite.mli
@@ -16,11 +16,10 @@
 
 (** Rewrites applied to [Apply_cont] expressions in order to reflect
     changes in continuation arities consequential to addition or removal of
-    parameters. *)
+    parameters.
+    The rewrites are actually applied via [Expr_builder]. *)
 
-[@@@ocaml.warning "+a-4-30-40-41-42"]
-
-open! Flambda
+[@@@ocaml.warning "+a-30-40-41-42"]
 
 type t
 
@@ -35,32 +34,16 @@ val create
   -> used_extra_params:Kinded_parameter.Set.t
   -> t
 
-val extra_params : t -> Kinded_parameter.t list
+val original_params : t -> Kinded_parameter.t list
+
+val used_params : t -> Kinded_parameter.Set.t
+
+val used_extra_params : t -> Kinded_parameter.t list
 
 val extra_args
    : t
   -> Apply_cont_rewrite_id.t
   -> Continuation_extra_params_and_args.Extra_arg.t list
-
-type rewrite_use_result = private
-  | Apply_cont of Apply_cont.t
-  | Expr of (
-       apply_cont_to_expr:(Apply_cont.t -> (Expr.t * Cost_metrics.t * Name_occurrences.t))
-    -> Expr.t * Cost_metrics.t * Name_occurrences.t)
-
-val no_rewrite : Apply_cont.t -> rewrite_use_result
-
-val rewrite_use
-   : t
-  -> Apply_cont_rewrite_id.t
-  -> Apply_cont.t
-  -> rewrite_use_result
-
-val rewrite_exn_continuation
-   : t
-  -> Apply_cont_rewrite_id.t
-  -> Exn_continuation.t
-  -> Exn_continuation.t
 
 val original_params_arity : t -> Flambda_arity.With_subkinds.t
 

--- a/middle_end/flambda/simplify/expr_builder.mli
+++ b/middle_end/flambda/simplify/expr_builder.mli
@@ -93,3 +93,24 @@ val add_wrapper_for_fixed_arity_apply
   -> Flambda_arity.With_subkinds.t
   -> Apply_expr.t
   -> Expr.t * Upwards_acc.t
+
+type rewrite_use_result = private
+  | Apply_cont of Apply_cont.t
+  | Expr of (
+       apply_cont_to_expr:(Apply_cont.t
+         -> (Expr.t * Cost_metrics.t * Name_occurrences.t))
+    -> Expr.t * Cost_metrics.t * Name_occurrences.t)
+
+val no_rewrite : Apply_cont.t -> rewrite_use_result
+
+val rewrite_use
+   : Apply_cont_rewrite.t
+  -> Apply_cont_rewrite_id.t
+  -> Apply_cont.t
+  -> rewrite_use_result
+
+val rewrite_exn_continuation
+   : Apply_cont_rewrite.t
+  -> Apply_cont_rewrite_id.t
+  -> Exn_continuation.t
+  -> Exn_continuation.t

--- a/middle_end/flambda/simplify/simplify_apply_cont_expr.ml
+++ b/middle_end/flambda/simplify/simplify_apply_cont_expr.ml
@@ -82,9 +82,8 @@ let rebuild_apply_cont apply_cont ~args ~rewrite_id uacc ~after_rebuild =
           else AC.clear_trap_action apply_cont
       in
       match rewrite with
-      | None -> Apply_cont_rewrite.no_rewrite apply_cont
-      | Some rewrite ->
-        Apply_cont_rewrite.rewrite_use rewrite rewrite_id apply_cont
+      | None -> EB.no_rewrite apply_cont
+      | Some rewrite -> EB.rewrite_use rewrite rewrite_id apply_cont
     in
     match rewrite_use_result with
     | Apply_cont apply_cont ->

--- a/middle_end/flambda/simplify/simplify_common.ml
+++ b/middle_end/flambda/simplify/simplify_common.ml
@@ -70,7 +70,7 @@ let update_exn_continuation_extra_args uacc ~exn_cont_use_id apply =
   | None -> apply
   | Some rewrite ->
     Apply.with_exn_continuation apply
-      (Apply_cont_rewrite.rewrite_exn_continuation rewrite exn_cont_use_id
+      (EB.rewrite_exn_continuation rewrite exn_cont_use_id
         (Apply.exn_continuation apply))
 
 (* generate the projection of the i-th field of a n-tuple *)


### PR DESCRIPTION
As subject.  The only changes to the code are to call some accessors in `Apply_cont_rewrite` rather than record projection (the type is abstract).