### PR TITLE
Stop Un_cps using Continuation_handler.arity

### DIFF
--- a/middle_end/flambda/to_cmm/un_cps_env.ml
+++ b/middle_end/flambda/to_cmm/un_cps_env.ml
@@ -265,11 +265,7 @@ let add_inline_cont env k vars ~handler_params_occurrences e =
   let conts = Continuation.Map.add k info env.conts in
   { env with conts }
 
-let add_exn_handler env k h =
-  let arity =
-    Flambda.Continuation_handler.arity h
-    |> Flambda_arity.With_subkinds.to_arity
-  in
+let add_exn_handler env k arity =
   match arity with
   | [] -> Misc.fatal_error "Exception handler with no arguments"
   | [_] -> env, []

--- a/middle_end/flambda/to_cmm/un_cps_env.mli
+++ b/middle_end/flambda/to_cmm/un_cps_env.mli
@@ -151,7 +151,7 @@ val add_inline_cont :
     a catch handler is needed, and the environment. *)
 
 val add_exn_handler :
-  t -> Continuation.t -> Flambda.Continuation_handler.t
+  t -> Continuation.t -> Flambda_arity.t
   -> t * (Backend_var.t * Flambda_kind.t) list
 (** Setup the extra mutable variables needed if the handler has extra arguments *)
 


### PR DESCRIPTION
The function `Continuation_handler.arity` is tied up with the "behaviour" concept in that module, which is about to go away.  This change adjusts `Un_cps` slightly so that the call to this function isn't needed.