### PR TITLE
Add Non_constructed_code

### DIFF
--- a/.depend
+++ b/.depend
@@ -5301,20 +5301,13 @@ middle_end/flambda/inlining/inlining_transforms.cmi : \
     lambda/debuginfo.cmi
 middle_end/flambda/lifting/lifted_constant.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
-    middle_end/flambda/basic/var_within_closure.cmi \
-    utils/targetint.cmi \
     middle_end/flambda/compilenv_deps/target_imm.cmi \
-    lambda/tag.cmi \
     middle_end/flambda/terms/symbol_projection.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/simplify/rebuilt_static_const.cmi \
-    middle_end/flambda/basic/simple.cmi \
-    middle_end/flambda/terms/set_of_closures.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
-    middle_end/flambda/basic/mutability.cmi \
     utils/misc.cmi \
-    middle_end/flambda/terms/function_declarations.cmi \
     middle_end/flambda/types/flambda_type.cmi \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/simplify/env/downwards_env.cmi \
@@ -5324,20 +5317,13 @@ middle_end/flambda/lifting/lifted_constant.cmo : \
     middle_end/flambda/lifting/lifted_constant.cmi
 middle_end/flambda/lifting/lifted_constant.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
-    middle_end/flambda/basic/var_within_closure.cmx \
-    utils/targetint.cmx \
     middle_end/flambda/compilenv_deps/target_imm.cmx \
-    lambda/tag.cmx \
     middle_end/flambda/terms/symbol_projection.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/simplify/rebuilt_static_const.cmx \
-    middle_end/flambda/basic/simple.cmx \
-    middle_end/flambda/terms/set_of_closures.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
-    middle_end/flambda/basic/mutability.cmx \
     utils/misc.cmx \
-    middle_end/flambda/terms/function_declarations.cmx \
     middle_end/flambda/types/flambda_type.cmx \
     middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/simplify/env/downwards_env.cmx \
@@ -5349,8 +5335,8 @@ middle_end/flambda/lifting/lifted_constant.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/terms/symbol_projection.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/simplify/rebuilt_static_const.cmi \
     middle_end/flambda/basic/simple.cmi \
+    middle_end/flambda/simplify/rebuilt_static_const.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/types/flambda_type.cmi \
     middle_end/flambda/simplify/env/downwards_env.cmi \
@@ -5385,10 +5371,10 @@ middle_end/flambda/lifting/reification.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/simplify/rebuilt_static_const.cmi \
     middle_end/flambda/simplify/simplify_import.cmi \
     middle_end/flambda/simplify/basic/simplified_named.cmi \
     middle_end/flambda/basic/simple.cmi \
+    middle_end/flambda/simplify/rebuilt_static_const.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/basic/mutability.cmi \
@@ -5401,10 +5387,10 @@ middle_end/flambda/lifting/reification.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
     middle_end/flambda/naming/var_in_binding_pos.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
-    middle_end/flambda/simplify/rebuilt_static_const.cmx \
     middle_end/flambda/simplify/simplify_import.cmx \
     middle_end/flambda/simplify/basic/simplified_named.cmx \
     middle_end/flambda/basic/simple.cmx \
+    middle_end/flambda/simplify/rebuilt_static_const.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/basic/mutability.cmx \
@@ -5417,7 +5403,6 @@ middle_end/flambda/lifting/reification.cmi : \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
     middle_end/flambda/simplify/basic/simplified_named.cmi \
     middle_end/flambda/types/flambda_type.cmi \
-    middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/simplify/env/downwards_acc.cmi
 middle_end/flambda/lifting/sort_lifted_constants.cmo : \
     utils/strongly_connected_components.cmi \
@@ -6045,10 +6030,10 @@ middle_end/flambda/simplify/expr_builder.cmo : \
     middle_end/flambda/basic/symbol_scoping_rule.cmi \
     middle_end/flambda/terms/symbol_projection.cmi \
     lambda/switch.cmi \
-    middle_end/flambda/simplify/rebuilt_static_const.cmi \
     middle_end/flambda/simplify/basic/simplified_named.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/terms/set_of_closures.cmi \
+    middle_end/flambda/simplify/rebuilt_static_const.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     utils/misc.cmi \
@@ -6058,7 +6043,9 @@ middle_end/flambda/simplify/expr_builder.cmo : \
     middle_end/flambda/terms/flambda_primitive.cmi \
     middle_end/flambda/types/kinds/flambda_arity.cmi \
     middle_end/flambda/terms/flambda.cmi \
+    middle_end/flambda/basic/exn_continuation.cmi \
     lambda/debuginfo.cmi \
+    middle_end/flambda/basic/continuation_extra_params_and_args.cmi \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/basic/code_id_or_symbol.cmi \
     middle_end/flambda/basic/code_id.cmi \
@@ -6080,10 +6067,10 @@ middle_end/flambda/simplify/expr_builder.cmx : \
     middle_end/flambda/basic/symbol_scoping_rule.cmx \
     middle_end/flambda/terms/symbol_projection.cmx \
     lambda/switch.cmx \
-    middle_end/flambda/simplify/rebuilt_static_const.cmx \
     middle_end/flambda/simplify/basic/simplified_named.cmx \
     middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/terms/set_of_closures.cmx \
+    middle_end/flambda/simplify/rebuilt_static_const.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     utils/misc.cmx \
@@ -6093,7 +6080,9 @@ middle_end/flambda/simplify/expr_builder.cmx : \
     middle_end/flambda/terms/flambda_primitive.cmx \
     middle_end/flambda/types/kinds/flambda_arity.cmx \
     middle_end/flambda/terms/flambda.cmx \
+    middle_end/flambda/basic/exn_continuation.cmx \
     lambda/debuginfo.cmx \
+    middle_end/flambda/basic/continuation_extra_params_and_args.cmx \
     middle_end/flambda/basic/continuation.cmx \
     middle_end/flambda/basic/code_id_or_symbol.cmx \
     middle_end/flambda/basic/code_id.cmx \
@@ -6115,12 +6104,52 @@ middle_end/flambda/simplify/expr_builder.cmi : \
     middle_end/flambda/lifting/lifted_constant.cmi \
     middle_end/flambda/types/kinds/flambda_arity.cmi \
     middle_end/flambda/terms/flambda.cmi \
+    middle_end/flambda/basic/exn_continuation.cmi \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/types/structures/code_age_relation.cmi \
     middle_end/flambda/naming/bindable_let_bound.cmi \
     middle_end/flambda/terms/apply_expr.cmi \
     middle_end/flambda/basic/apply_cont_rewrite_id.cmi \
+    middle_end/flambda/simplify/basic/apply_cont_rewrite.cmi \
     middle_end/flambda/terms/apply_cont_expr.cmi
+middle_end/flambda/simplify/non_constructed_code.cmo : \
+    middle_end/flambda/types/basic/unit.cmi \
+    middle_end/flambda/cmx/ids_for_export.cmi \
+    middle_end/flambda/terms/flambda.cmi \
+    middle_end/flambda/terms/code0.cmi \
+    middle_end/flambda/simplify/non_constructed_code.cmi
+middle_end/flambda/simplify/non_constructed_code.cmx : \
+    middle_end/flambda/types/basic/unit.cmx \
+    middle_end/flambda/cmx/ids_for_export.cmx \
+    middle_end/flambda/terms/flambda.cmx \
+    middle_end/flambda/terms/code0.cmx \
+    middle_end/flambda/simplify/non_constructed_code.cmi
+middle_end/flambda/simplify/non_constructed_code.cmi : \
+    middle_end/flambda/terms/flambda.cmi \
+    middle_end/flambda/terms/code_intf.cmo
+middle_end/flambda/simplify/rebuilt_static_const.cmo : \
+    middle_end/flambda/types/basic/or_unknown.cmi \
+    middle_end/flambda/naming/name_occurrences.cmi \
+    utils/misc.cmi \
+    middle_end/flambda/terms/flambda.cmi \
+    middle_end/flambda/basic/code_id.cmi \
+    middle_end/flambda/simplify/rebuilt_static_const.cmi
+middle_end/flambda/simplify/rebuilt_static_const.cmx : \
+    middle_end/flambda/types/basic/or_unknown.cmx \
+    middle_end/flambda/naming/name_occurrences.cmx \
+    utils/misc.cmx \
+    middle_end/flambda/terms/flambda.cmx \
+    middle_end/flambda/basic/code_id.cmx \
+    middle_end/flambda/simplify/rebuilt_static_const.cmi
+middle_end/flambda/simplify/rebuilt_static_const.cmi : \
+    middle_end/flambda/compilenv_deps/symbol.cmi \
+    middle_end/flambda/terms/set_of_closures.cmi \
+    middle_end/flambda/types/basic/or_unknown.cmi \
+    middle_end/flambda/naming/name_occurrences.cmi \
+    middle_end/flambda/terms/flambda.cmi \
+    middle_end/flambda/basic/code_id.cmi \
+    middle_end/flambda/basic/closure_id.cmi \
+    middle_end/flambda/terms/bound_symbols.cmi
 middle_end/flambda/simplify/simplify.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
@@ -6176,7 +6205,6 @@ middle_end/flambda/simplify/simplify_apply_cont_expr.cmo : \
     middle_end/flambda/simplify/env/continuation_use_kind.cmi \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/naming/bindable_let_bound.cmi \
-    middle_end/flambda/simplify/basic/apply_cont_rewrite.cmi \
     middle_end/flambda/simplify/simplify_apply_cont_expr.cmi
 middle_end/flambda/simplify/simplify_apply_cont_expr.cmx : \
     middle_end/flambda/naming/var_in_binding_pos.cmx \
@@ -6190,7 +6218,6 @@ middle_end/flambda/simplify/simplify_apply_cont_expr.cmx : \
     middle_end/flambda/simplify/env/continuation_use_kind.cmx \
     middle_end/flambda/basic/continuation.cmx \
     middle_end/flambda/naming/bindable_let_bound.cmx \
-    middle_end/flambda/simplify/basic/apply_cont_rewrite.cmx \
     middle_end/flambda/simplify/simplify_apply_cont_expr.cmi
 middle_end/flambda/simplify/simplify_apply_cont_expr.cmi : \
     middle_end/flambda/simplify/simplify_common.cmi \
@@ -6200,12 +6227,12 @@ middle_end/flambda/simplify/simplify_apply_expr.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
-    middle_end/flambda/simplify/rebuilt_static_const.cmi \
     middle_end/flambda/simplify/simplify_import.cmi \
     middle_end/flambda/simplify/simplify_common.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/terms/set_of_closures.cmi \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
+    middle_end/flambda/simplify/rebuilt_static_const.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     utils/misc.cmi \
@@ -6233,12 +6260,12 @@ middle_end/flambda/simplify/simplify_apply_expr.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
     middle_end/flambda/basic/var_within_closure.cmx \
     middle_end/flambda/naming/var_in_binding_pos.cmx \
-    middle_end/flambda/simplify/rebuilt_static_const.cmx \
     middle_end/flambda/simplify/simplify_import.cmx \
     middle_end/flambda/simplify/simplify_common.cmx \
     middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/terms/set_of_closures.cmx \
     middle_end/flambda/compilenv_deps/rec_info.cmx \
+    middle_end/flambda/simplify/rebuilt_static_const.cmx \
     middle_end/flambda/types/basic/or_bottom.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     utils/misc.cmx \
@@ -6328,7 +6355,6 @@ middle_end/flambda/simplify/simplify_common.cmo : \
     middle_end/flambda/simplify/env/downwards_acc.cmi \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/terms/call_kind.cmi \
-    middle_end/flambda/simplify/basic/apply_cont_rewrite.cmi \
     middle_end/flambda/simplify/simplify_common.cmi
 middle_end/flambda/simplify/simplify_common.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
@@ -6346,7 +6372,6 @@ middle_end/flambda/simplify/simplify_common.cmx : \
     middle_end/flambda/simplify/env/downwards_acc.cmx \
     middle_end/flambda/basic/continuation.cmx \
     middle_end/flambda/terms/call_kind.cmx \
-    middle_end/flambda/simplify/basic/apply_cont_rewrite.cmx \
     middle_end/flambda/simplify/simplify_common.cmi
 middle_end/flambda/simplify/simplify_common.cmi : \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
@@ -6528,7 +6553,6 @@ middle_end/flambda/simplify/simplify_named.cmo : \
     middle_end/flambda/compilenv_deps/target_imm.cmi \
     middle_end/flambda/terms/symbol_projection.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/simplify/rebuilt_static_const.cmi \
     middle_end/flambda/simplify/simplify_static_const.cmi \
     middle_end/flambda/simplify/simplify_set_of_closures.cmi \
     middle_end/flambda/simplify/simplify_primitive.cmi \
@@ -6538,6 +6562,7 @@ middle_end/flambda/simplify/simplify_named.cmo : \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/lifting/reification.cmi \
     middle_end/flambda/basic/reg_width_const.cmi \
+    middle_end/flambda/simplify/rebuilt_static_const.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/basic/name.cmi \
     utils/misc.cmi \
@@ -6553,7 +6578,6 @@ middle_end/flambda/simplify/simplify_named.cmx : \
     middle_end/flambda/compilenv_deps/target_imm.cmx \
     middle_end/flambda/terms/symbol_projection.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
-    middle_end/flambda/simplify/rebuilt_static_const.cmx \
     middle_end/flambda/simplify/simplify_static_const.cmx \
     middle_end/flambda/simplify/simplify_set_of_closures.cmx \
     middle_end/flambda/simplify/simplify_primitive.cmx \
@@ -6563,6 +6587,7 @@ middle_end/flambda/simplify/simplify_named.cmx : \
     middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/lifting/reification.cmx \
     middle_end/flambda/basic/reg_width_const.cmx \
+    middle_end/flambda/simplify/rebuilt_static_const.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/basic/name.cmx \
     utils/misc.cmx \
@@ -6644,7 +6669,6 @@ middle_end/flambda/simplify/simplify_set_of_closures.cmo : \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
     middle_end/flambda/terms/symbol_projection.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/simplify/rebuilt_static_const.cmi \
     middle_end/flambda/simplify/basic/simplify_named_result.cmi \
     middle_end/flambda/simplify/simplify_import.cmi \
     middle_end/flambda/simplify/simplify_common.cmi \
@@ -6653,6 +6677,7 @@ middle_end/flambda/simplify/simplify_set_of_closures.cmo : \
     middle_end/flambda/terms/set_of_closures.cmi \
     middle_end/flambda/basic/scope.cmi \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
+    middle_end/flambda/simplify/rebuilt_static_const.cmi \
     utils/profile.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
@@ -6685,7 +6710,6 @@ middle_end/flambda/simplify/simplify_set_of_closures.cmx : \
     middle_end/flambda/naming/var_in_binding_pos.cmx \
     middle_end/flambda/terms/symbol_projection.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
-    middle_end/flambda/simplify/rebuilt_static_const.cmx \
     middle_end/flambda/simplify/basic/simplify_named_result.cmx \
     middle_end/flambda/simplify/simplify_import.cmx \
     middle_end/flambda/simplify/simplify_common.cmx \
@@ -6694,6 +6718,7 @@ middle_end/flambda/simplify/simplify_set_of_closures.cmx : \
     middle_end/flambda/terms/set_of_closures.cmx \
     middle_end/flambda/basic/scope.cmx \
     middle_end/flambda/compilenv_deps/rec_info.cmx \
+    middle_end/flambda/simplify/rebuilt_static_const.cmx \
     utils/profile.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
@@ -6722,11 +6747,11 @@ middle_end/flambda/simplify/simplify_set_of_closures.cmx : \
     middle_end/flambda/simplify/simplify_set_of_closures.cmi
 middle_end/flambda/simplify/simplify_set_of_closures.cmi : \
     middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/simplify/rebuilt_static_const.cmi \
     middle_end/flambda/simplify/basic/simplify_named_result.cmi \
     middle_end/flambda/simplify/simplify_import.cmi \
     middle_end/flambda/simplify/simplify_common.cmi \
     middle_end/flambda/terms/set_of_closures.cmi \
+    middle_end/flambda/simplify/rebuilt_static_const.cmi \
     middle_end/flambda/naming/name_in_binding_pos.cmi \
     middle_end/flambda/simplify/env/downwards_acc.cmi \
     middle_end/flambda/basic/closure_id.cmi \
@@ -6756,11 +6781,11 @@ middle_end/flambda/simplify/simplify_simple.cmi : \
     middle_end/flambda/simplify/env/downwards_acc.cmi
 middle_end/flambda/simplify/simplify_static_const.cmo : \
     lambda/tag.cmi \
-    middle_end/flambda/simplify/rebuilt_static_const.cmi \
     middle_end/flambda/simplify/simplify_set_of_closures.cmi \
     middle_end/flambda/simplify/simplify_import.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/basic/reg_width_const.cmi \
+    middle_end/flambda/simplify/rebuilt_static_const.cmi \
     middle_end/flambda/basic/or_variable.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/naming/name_in_binding_pos.cmi \
@@ -6771,11 +6796,11 @@ middle_end/flambda/simplify/simplify_static_const.cmo : \
     middle_end/flambda/simplify/simplify_static_const.cmi
 middle_end/flambda/simplify/simplify_static_const.cmx : \
     lambda/tag.cmx \
-    middle_end/flambda/simplify/rebuilt_static_const.cmx \
     middle_end/flambda/simplify/simplify_set_of_closures.cmx \
     middle_end/flambda/simplify/simplify_import.cmx \
     middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/basic/reg_width_const.cmx \
+    middle_end/flambda/simplify/rebuilt_static_const.cmx \
     middle_end/flambda/basic/or_variable.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/naming/name_in_binding_pos.cmx \
@@ -6785,8 +6810,8 @@ middle_end/flambda/simplify/simplify_static_const.cmx : \
     middle_end/flambda/terms/bound_symbols.cmx \
     middle_end/flambda/simplify/simplify_static_const.cmi
 middle_end/flambda/simplify/simplify_static_const.cmi : \
-    middle_end/flambda/simplify/rebuilt_static_const.cmi \
     middle_end/flambda/simplify/simplify_common.cmi \
+    middle_end/flambda/simplify/rebuilt_static_const.cmi \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/simplify/env/downwards_acc.cmi \
     middle_end/flambda/terms/bound_symbols.cmi
@@ -6917,63 +6942,21 @@ middle_end/flambda/simplify/simplify_variadic_primitive.cmi : \
     middle_end/flambda/terms/flambda_primitive.cmi \
     middle_end/flambda/simplify/env/downwards_acc.cmi \
     lambda/debuginfo.cmi
-middle_end/flambda/simplify/rebuilt_static_const.cmo : \
-    middle_end/flambda/types/basic/or_unknown.cmi \
-    middle_end/flambda/naming/name_occurrences.cmi \
-    utils/misc.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/basic/code_id.cmi \
-    middle_end/flambda/simplify/rebuilt_static_const.cmi
-middle_end/flambda/simplify/rebuilt_static_const.cmx : \
-    middle_end/flambda/types/basic/or_unknown.cmx \
-    middle_end/flambda/naming/name_occurrences.cmx \
-    utils/misc.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    middle_end/flambda/basic/code_id.cmx \
-    middle_end/flambda/simplify/rebuilt_static_const.cmi
-middle_end/flambda/simplify/rebuilt_static_const.cmi : \
-    middle_end/flambda/compilenv_deps/symbol.cmi \
-    middle_end/flambda/terms/set_of_closures.cmi \
-    middle_end/flambda/types/basic/or_unknown.cmi \
-    middle_end/flambda/naming/name_occurrences.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/basic/code_id.cmi \
-    middle_end/flambda/basic/closure_id.cmi \
-    middle_end/flambda/terms/bound_symbols.cmi
 middle_end/flambda/simplify/basic/apply_cont_rewrite.cmo : \
-    middle_end/flambda/naming/var_in_binding_pos.cmi \
-    middle_end/flambda/basic/simple.cmi \
-    middle_end/flambda/naming/name_occurrences.cmi \
-    middle_end/flambda/naming/name_mode.cmi \
     utils/misc.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
-    middle_end/flambda/types/kinds/flambda_arity.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/basic/exn_continuation.cmi \
-    lambda/debuginfo.cmi \
     middle_end/flambda/basic/continuation_extra_params_and_args.cmi \
     middle_end/flambda/basic/apply_cont_rewrite_id.cmi \
     middle_end/flambda/simplify/basic/apply_cont_rewrite.cmi
 middle_end/flambda/simplify/basic/apply_cont_rewrite.cmx : \
-    middle_end/flambda/naming/var_in_binding_pos.cmx \
-    middle_end/flambda/basic/simple.cmx \
-    middle_end/flambda/naming/name_occurrences.cmx \
-    middle_end/flambda/naming/name_mode.cmx \
     utils/misc.cmx \
     middle_end/flambda/basic/kinded_parameter.cmx \
-    middle_end/flambda/types/kinds/flambda_arity.cmx \
-    middle_end/flambda/terms/flambda.cmx \
-    middle_end/flambda/basic/exn_continuation.cmx \
-    lambda/debuginfo.cmx \
     middle_end/flambda/basic/continuation_extra_params_and_args.cmx \
     middle_end/flambda/basic/apply_cont_rewrite_id.cmx \
     middle_end/flambda/simplify/basic/apply_cont_rewrite.cmi
 middle_end/flambda/simplify/basic/apply_cont_rewrite.cmi : \
-    middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/types/kinds/flambda_arity.cmi \
-    middle_end/flambda/terms/flambda.cmi \
-    middle_end/flambda/basic/exn_continuation.cmi \
     middle_end/flambda/basic/continuation_extra_params_and_args.cmi \
     middle_end/flambda/basic/apply_cont_rewrite_id.cmi
 middle_end/flambda/simplify/basic/continuation_in_env.cmo : \

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -302,6 +302,7 @@ MIDDLE_END_FLAMBDA_SIMPLIFY=\
   middle_end/flambda/simplify/env/continuation_env_and_param_types.cmo \
   middle_end/flambda/simplify/basic/continuation_in_env.cmo \
   middle_end/flambda/simplify/basic/simplified_named.cmo \
+  middle_end/flambda/simplify/non_constructed_code.cmo \
   middle_end/flambda/simplify/rebuilt_static_const.cmo \
   middle_end/flambda/simplify/common_subexpression_elimination.cmo \
   middle_end/flambda/simplify/env/downwards_env.cmo \

--- a/middle_end/flambda/simplify/non_constructed_code.ml
+++ b/middle_end/flambda/simplify/non_constructed_code.ml
@@ -1,0 +1,24 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Pierre Chambart, OCamlPro                        *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2013--2021 OCamlPro SAS                                    *)
+(*   Copyright 2014--2021 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+include Code0.Make (struct
+    include Unit
+    let all_ids_for_export _ = Ids_for_export.empty
+    let print_with_cache ~cache:_ ppf t = print ppf t
+  end)
+  (Flambda.Cost_metrics)

--- a/middle_end/flambda/simplify/non_constructed_code.mli
+++ b/middle_end/flambda/simplify/non_constructed_code.mli
@@ -1,0 +1,24 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Pierre Chambart, OCamlPro                        *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2013--2021 OCamlPro SAS                                    *)
+(*   Copyright 2014--2021 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+(* Code without any function bodies, but with all the associated metadata,
+   e.g. free names. *)
+
+include Code_intf.S
+  with type function_params_and_body := unit
+  with type cost_metrics := Flambda.Cost_metrics.t


### PR DESCRIPTION
`Non_constructed_code` is just like `Code`, except... it doesn't hold any code.  It only has the metadata.  It will be used in `Rebuilt_static_const` when rebuilding of terms is disabled.