### PR TITLE
Relax constraint on let-code placement

### DIFF
--- a/middle_end/flambda/naming/bindable_let_bound.ml
+++ b/middle_end/flambda/naming/bindable_let_bound.ml
@@ -26,6 +26,8 @@ type t =
       closure_vars : Var_in_binding_pos.t list;
     }
   | Symbols of symbols
+  (* CR mshinwell: Add a case here for let-code and move it out of
+     Symbols *)
 
 include Identifiable.Make (struct
   type nonrec t = t

--- a/middle_end/flambda/simplify/simplify_named.ml
+++ b/middle_end/flambda/simplify/simplify_named.ml
@@ -218,7 +218,8 @@ let simplify_named0 dacc (bindable_let_bound : Bindable_let_bound.t)
     let { Bindable_let_bound. bound_symbols; scoping_rule = _; } =
       Bindable_let_bound.must_be_symbols bindable_let_bound
     in
-    if not (DE.at_unit_toplevel (DA.denv dacc)) then begin
+    let binds_symbols = Bound_symbols.binds_symbols bound_symbols in
+    if binds_symbols && not (DE.at_unit_toplevel (DA.denv dacc)) then begin
       Misc.fatal_errorf "[Let] binding symbols is only allowed at the toplevel \
           of compilation units (not even at the toplevel of function \
           bodies):@ %a@ =@ %a"

--- a/middle_end/flambda/terms/bound_symbols.ml
+++ b/middle_end/flambda/terms/bound_symbols.ml
@@ -76,6 +76,11 @@ module Pattern = struct
     | Code _ -> true
     | Set_of_closures _ | Block_like _ -> false
 
+  let binds_symbols t =
+    match t with
+    | Code _ -> false
+    | Set_of_closures _ | Block_like _ -> true
+
   let closure_symbols_being_defined t =
     match t with
     | Code _ | Block_like _ -> Symbol.Set.empty
@@ -157,6 +162,9 @@ let code_being_defined t =
 
 let binds_code t =
   List.exists Pattern.binds_code t
+
+let binds_symbols t =
+  List.exists Pattern.binds_symbols t
 
 let everything_being_defined t =
   List.map Pattern.everything_being_defined t

--- a/middle_end/flambda/terms/bound_symbols.mli
+++ b/middle_end/flambda/terms/bound_symbols.mli
@@ -47,6 +47,8 @@ val code_being_defined : t -> Code_id.Set.t
 
 val binds_code : t -> bool
 
+val binds_symbols : t -> bool
+
 val non_closure_symbols_being_defined : t -> Symbol.Set.t
 
 val closure_symbols_being_defined : t -> Symbol.Set.t


### PR DESCRIPTION
This relaxes the check, on the downwards pass of Simplify, that let-code and let-symbol bindings may only occur at toplevel (not under a lambda or other control flow).

Code is closed except for symbols (and closure vars, but they aren't scoped so don't matter here).  The Cmm data items corresponding to code will always be constant -- there is never any initialisation required at runtime.  As such, it would appear to be fine to allow let-code anywhere, not just at toplevel.  (The same probably applies for let-symbol so long as the defining expression is a constant, i.e. doesn't contain variables; however, I don't have an immediate use for this.)

Assuming that `Un_cps` can compile this correctly (see below), then one concern might be the algorithm in `Expr_builder` for removing redundant let-code, and what would happen if a lifted set of closures referred to code IDs whose definition was under a lambda.  However I think is going to work fine: static constants of all forms (including let-code and let-symbol) are always transmitted upwards via the lifted (in)constant infrastructure.  This means that, just like any associated sets of closures referencing the code IDs defined under a lambda, the code definitions themselves will in fact be floated to toplevel.

The reason I'd like this change is because I think we can simplify the slightly nasty logic for dealing with partial application wrapper creation in `Simplify_apply_expr`.  At the moment that has to mess with lifted constant creation and, in particular, this doesn't play nicely with the not-rebuilding-terms model.  Effectively the code is trying to create "simplified code" when we are not yet in that stage of simplification.  An escape hatch could be added for this, but I would rather not.  If we allow let-code anywhere, then the partial application code can simply generate a new `Static_consts` let-expression, which will be simplified in the normal manner.  There shouldn't be any need to mention lifted constants during the partial application code nor to be concerned about potential non-removal of the "old" version of the wrapper code; that should be removed as usual.

@Gbury Could you confirm that `Un_cps` will correctly compile let-code if it appears in the middle of a function?  It doesn't need to do anything different from usual, but perhaps it might not expect to see such a construct under a lambda.  This situation would also not arise unless Simplify was bypassed (we should probably try doing that sometime as a test for `Un_cps`).

As an aside, I think the current setup in `Bindable_let_bound` isn't right; there should be a separate case here for let-code rather than lumping it in with let-symbol.  I'll investigate fixing that in due course.