### PR TITLE
Remove Cost_metrics.static_consts

### DIFF
--- a/middle_end/flambda/simplify/expr_builder.ml
+++ b/middle_end/flambda/simplify/expr_builder.ml
@@ -204,7 +204,7 @@ let create_raw_let_symbol uacc bound_symbols scoping_rule static_consts ~body =
   in
   let defining_expr, cost_metrics_of_defining_expr =
     let static_consts = Rebuilt_static_const.Group.consts static_consts in
-    Named.create_static_consts static_consts, Cost_metrics.static_consts static_consts
+    Named.create_static_consts static_consts, Cost_metrics.zero
   in
   let free_names_of_body = UA.name_occurrences uacc in
   let free_names_of_let =

--- a/middle_end/flambda/terms/cost_metrics.rec.ml
+++ b/middle_end/flambda/terms/cost_metrics.rec.ml
@@ -383,8 +383,6 @@ let simple simple = Simple.pattern_match simple ~const:(fun _ -> 1) ~name:(fun _
 
 let prim = prim_size
 
-let static_consts _ = 0
-
 (* The size of a set of closures is roughly the sum of the size of the
    functions it refers to. This is mainly due to the fact that if we do inline
    a function f where a set of closure is defined then we will copy the body of

--- a/middle_end/flambda/terms/cost_metrics.rec.mli
+++ b/middle_end/flambda/terms/cost_metrics.rec.mli
@@ -34,7 +34,6 @@ val print : Format.formatter -> t -> unit
 
 val prim : Flambda_primitive.t -> t
 val simple : Simple.t -> t
-val static_consts : Static_const.Group.t -> t
 val set_of_closures : find_cost_metrics:(Code_id.t -> Cost_metrics.t Or_unknown.t) -> Set_of_closures.t -> t
 
 val apply : Apply.t -> t

--- a/middle_end/flambda/terms/flambda.mli
+++ b/middle_end/flambda/terms/flambda.mli
@@ -688,7 +688,6 @@ end and Cost_metrics : sig
   val prim : Flambda_primitive.t -> t
   val simple : Simple.t -> t
   val set_of_closures : find_cost_metrics:(Code_id.t -> t Or_unknown.t) -> Set_of_closures.t -> t
-  val static_consts : Static_const.Group.t -> t
   val apply : Apply.t -> t
   val apply_cont : Apply_cont.t -> t
   val switch : Switch.t -> t


### PR DESCRIPTION
As discussed with @poechsel .  This isn't needed and gets in the way for the not-rebuilding-terms patch.