### PR TITLE
Tidy up arity handling in Continuation_in_env, etc.

### DIFF
--- a/middle_end/flambda/simplify/basic/continuation_in_env.ml
+++ b/middle_end/flambda/simplify/basic/continuation_in_env.ml
@@ -23,9 +23,11 @@ type t =
       free_names_of_handler : Name_occurrences.t;
       cost_metrics_of_handler : Flambda.Cost_metrics.t;
     }
-  | Non_inlinable of {
-      params : Kinded_parameter.t list;
+  | Non_inlinable_zero_arity of {
       handler : Flambda.Expr.t Or_unknown.t;
+    }
+  | Non_inlinable_non_zero_arity of {
+      arity : Flambda_arity.With_subkinds.t;
     }
   | Toplevel_or_function_return_or_exn_continuation of {
       arity : Flambda_arity.With_subkinds.t;
@@ -38,8 +40,10 @@ let print ppf t =
   | Linearly_used_and_inlinable { params = _; handler = _;
       free_names_of_handler = _; cost_metrics_of_handler = _ } ->
     Format.pp_print_string ppf "Linearly_used_and_inlinable _"
-  | Non_inlinable { params = _; handler = _; } ->
-    Format.pp_print_string ppf "Non_inlinable _"
+  | Non_inlinable_zero_arity { handler = _; } ->
+    Format.pp_print_string ppf "Non_inlinable_zero_arity _"
+  | Non_inlinable_non_zero_arity { arity = _; } ->
+    Format.pp_print_string ppf "Non_inlinable_non_zero_arity _"
   | Toplevel_or_function_return_or_exn_continuation { arity = _; } ->
     Format.pp_print_string ppf
       "Toplevel_or_function_return_or_exn_continuation _"
@@ -48,9 +52,10 @@ let print ppf t =
 let arity t =
   match t with
   | Linearly_used_and_inlinable { params; handler = _;
-      free_names_of_handler = _; cost_metrics_of_handler = _ }
-  | Non_inlinable { params; handler = _; } ->
+      free_names_of_handler = _; cost_metrics_of_handler = _ } ->
     Kinded_parameter.List.arity_with_subkinds params
+  | Non_inlinable_zero_arity _ -> []
+  | Non_inlinable_non_zero_arity { arity; }
   | Toplevel_or_function_return_or_exn_continuation { arity; }
   | Unreachable { arity; } ->
     arity

--- a/middle_end/flambda/simplify/basic/continuation_in_env.ml
+++ b/middle_end/flambda/simplify/basic/continuation_in_env.ml
@@ -18,32 +18,39 @@
 
 type t =
   | Linearly_used_and_inlinable of {
-      arity : Flambda_arity.With_subkinds.t;
       params : Kinded_parameter.t list;
       handler : Flambda.Expr.t;
       free_names_of_handler : Name_occurrences.t;
       cost_metrics_of_handler : Flambda.Cost_metrics.t;
     }
-  | Other of {
+  | Non_inlinable of {
+      params : Kinded_parameter.t list;
+      handler : Flambda.Expr.t Or_unknown.t;
+    }
+  | Toplevel_or_function_return_or_exn_continuation of {
       arity : Flambda_arity.With_subkinds.t;
-      handler : Flambda.Continuation_handler.t option;
     }
   | Unreachable of { arity : Flambda_arity.With_subkinds.t; }
 
 (* CR mshinwell: Write a proper printer *)
 let print ppf t =
   match t with
-  | Linearly_used_and_inlinable { arity = _; params = _; handler = _;
+  | Linearly_used_and_inlinable { params = _; handler = _;
       free_names_of_handler = _; cost_metrics_of_handler = _ } ->
     Format.pp_print_string ppf "Linearly_used_and_inlinable _"
-  | Other { arity = _; handler = _; } ->
-    Format.pp_print_string ppf "Other"
-  | Unreachable { arity = _; } -> Format.pp_print_string ppf "Unreachable"
+  | Non_inlinable { params = _; handler = _; } ->
+    Format.pp_print_string ppf "Non_inlinable _"
+  | Toplevel_or_function_return_or_exn_continuation { arity = _; } ->
+    Format.pp_print_string ppf
+      "Toplevel_or_function_return_or_exn_continuation _"
+  | Unreachable { arity = _; } -> Format.pp_print_string ppf "Unreachable _"
 
 let arity t =
   match t with
-  | Linearly_used_and_inlinable { arity; params = _; handler = _;
+  | Linearly_used_and_inlinable { params; handler = _;
       free_names_of_handler = _; cost_metrics_of_handler = _ }
-  | Other { arity; handler = _; }
+  | Non_inlinable { params; handler = _; } ->
+    Kinded_parameter.List.arity_with_subkinds params
+  | Toplevel_or_function_return_or_exn_continuation { arity; }
   | Unreachable { arity; } ->
     arity

--- a/middle_end/flambda/simplify/basic/continuation_in_env.mli
+++ b/middle_end/flambda/simplify/basic/continuation_in_env.mli
@@ -20,8 +20,12 @@ type t =
   | Linearly_used_and_inlinable of {
       params : Kinded_parameter.t list;
       (** To avoid re-opening name abstractions, we store the opened
-          parameters and handler here.  This is only correct because the
-          inlining we perform is linear. *)
+          parameters and handler here.  Note that the properties of
+          [Name_abstraction] mean that this is safe even if the expression
+          were to be substituted in multiple places, with corresponding
+          bindings of the [params].  There is no requirement for binders to
+          use fresh names when name abstractions are being constructed; they
+          just have to match the ones in the terms being closed over. *)
       handler : Flambda.Expr.t;
       (** [free_names_of_handler] includes entries for any occurrences of the
           [params] in the [handler]. *)
@@ -29,9 +33,12 @@ type t =
       (** [cost_metrics_of_handler] is the size of the handler. *)
       cost_metrics_of_handler : Flambda.Cost_metrics.t;
     }
-  | Non_inlinable of {
-      params : Kinded_parameter.t list;
+  | Non_inlinable_zero_arity of {
       handler : Flambda.Expr.t Or_unknown.t;
+      (** The handler, if available, is stored for [Simplify_switch_expr]. *)
+    }
+  | Non_inlinable_non_zero_arity of {
+      arity : Flambda_arity.With_subkinds.t;
     }
   | Toplevel_or_function_return_or_exn_continuation of {
       arity : Flambda_arity.With_subkinds.t;

--- a/middle_end/flambda/simplify/basic/continuation_in_env.mli
+++ b/middle_end/flambda/simplify/basic/continuation_in_env.mli
@@ -18,11 +18,10 @@
 
 type t =
   | Linearly_used_and_inlinable of {
-      arity : Flambda_arity.With_subkinds.t;
+      params : Kinded_parameter.t list;
       (** To avoid re-opening name abstractions, we store the opened
           parameters and handler here.  This is only correct because the
           inlining we perform is linear. *)
-      params : Kinded_parameter.t list;
       handler : Flambda.Expr.t;
       (** [free_names_of_handler] includes entries for any occurrences of the
           [params] in the [handler]. *)
@@ -30,9 +29,12 @@ type t =
       (** [cost_metrics_of_handler] is the size of the handler. *)
       cost_metrics_of_handler : Flambda.Cost_metrics.t;
     }
-  | Other of {
+  | Non_inlinable of {
+      params : Kinded_parameter.t list;
+      handler : Flambda.Expr.t Or_unknown.t;
+    }
+  | Toplevel_or_function_return_or_exn_continuation of {
       arity : Flambda_arity.With_subkinds.t;
-      handler : Flambda.Continuation_handler.t option;
     }
   | Unreachable of { arity : Flambda_arity.With_subkinds.t; }
 

--- a/middle_end/flambda/simplify/env/continuation_env_and_param_types.ml
+++ b/middle_end/flambda/simplify/env/continuation_env_and_param_types.ml
@@ -26,5 +26,4 @@ type t =
       arg_types_by_use_id : (TE.t * T.t) Apply_cont_rewrite_id.Map.t list;
       extra_params_and_args : Continuation_extra_params_and_args.t;
       is_single_inlinable_use : bool;
-      is_single_use : bool;
     }

--- a/middle_end/flambda/simplify/env/continuation_env_and_param_types.mli
+++ b/middle_end/flambda/simplify/env/continuation_env_and_param_types.mli
@@ -25,5 +25,4 @@ type t =
           Apply_cont_rewrite_id.Map.t list;
       extra_params_and_args : Continuation_extra_params_and_args.t;
       is_single_inlinable_use : bool;
-      is_single_use : bool;
     }

--- a/middle_end/flambda/simplify/env/upwards_env.ml
+++ b/middle_end/flambda/simplify/env/upwards_env.ml
@@ -80,9 +80,11 @@ let resolve_exn_continuation_aliases t exn_cont =
 
 let continuation_arity t cont =
   match find_continuation t cont with
-  | Other { arity; handler = _; }
-  | Unreachable { arity; }
-  | Linearly_used_and_inlinable { arity; _ } -> arity
+  | Linearly_used_and_inlinable { params; _ }
+  | Non_inlinable { params; _ } ->
+    Kinded_parameter.List.arity_with_subkinds params
+  | Toplevel_or_function_return_or_exn_continuation { arity; }
+  | Unreachable { arity; } -> arity
 
 let add_continuation0 t cont scope cont_in_env =
   let continuations =
@@ -92,11 +94,8 @@ let add_continuation0 t cont scope cont_in_env =
     continuations;
   }
 
-let add_continuation t cont scope arity =
-  add_continuation0 t cont scope (Other { arity; handler = None; })
-
-let add_continuation_with_handler t cont scope arity handler =
-  add_continuation0 t cont scope (Other { arity; handler = Some handler; })
+let add_non_inlinable_continuation t cont scope ~params ~handler =
+  add_continuation0 t cont scope (Non_inlinable { params; handler; })
 
 let add_unreachable_continuation t cont scope arity =
   add_continuation0 t cont scope (Unreachable { arity; })
@@ -141,18 +140,24 @@ let add_continuation_alias t cont arity ~alias_for =
     continuation_aliases;
   }
 
-let add_linearly_used_inlinable_continuation t cont scope arity ~params
+let add_linearly_used_inlinable_continuation t cont scope ~params
       ~handler ~free_names_of_handler ~cost_metrics_of_handler =
   add_continuation0 t cont scope
-    (Linearly_used_and_inlinable { arity; handler; free_names_of_handler;
+    (Linearly_used_and_inlinable { handler; free_names_of_handler;
       params; cost_metrics_of_handler })
+
+let add_return_continuation t cont scope arity =
+  add_continuation0 t cont scope
+    (Toplevel_or_function_return_or_exn_continuation { arity; })
 
 let add_exn_continuation t exn_cont scope =
   (* CR mshinwell: Think more about keeping these in both maps *)
   let continuations =
     let cont = Exn_continuation.exn_handler exn_cont in
     let cont_in_env : Continuation_in_env.t =
-      Other { arity = Exn_continuation.arity exn_cont; handler = None; }
+      Toplevel_or_function_return_or_exn_continuation {
+        arity = Exn_continuation.arity exn_cont;
+      }
     in
     Continuation.Map.add cont (scope, cont_in_env) t.continuations
   in
@@ -202,5 +207,6 @@ let delete_apply_cont_rewrite t cont =
 
 let will_inline_continuation t cont =
   match find_continuation t cont with
-  | Other _ | Unreachable _ -> false
   | Linearly_used_and_inlinable _ -> true
+  | Non_inlinable _ | Toplevel_or_function_return_or_exn_continuation _
+  | Unreachable _ -> false

--- a/middle_end/flambda/simplify/env/upwards_env.mli
+++ b/middle_end/flambda/simplify/env/upwards_env.mli
@@ -26,19 +26,12 @@ val invariant : t -> unit
 
 val print : Format.formatter -> t -> unit
 
-val add_continuation
+val add_non_inlinable_continuation
    : t
   -> Continuation.t
   -> Scope.t
-  -> Flambda_arity.With_subkinds.t
-  -> t
-
-val add_continuation_with_handler
-   : t
-  -> Continuation.t
-  -> Scope.t
-  -> Flambda_arity.With_subkinds.t
-  -> Continuation_handler.t
+  -> params:Kinded_parameter.t list
+  -> handler:Flambda.Expr.t Or_unknown.t
   -> t
 
 val add_unreachable_continuation
@@ -59,11 +52,17 @@ val add_linearly_used_inlinable_continuation
    : t
   -> Continuation.t
   -> Scope.t
-  -> Flambda_arity.With_subkinds.t  (* CR mshinwell: redundant *)
   -> params:Kinded_parameter.t list
   -> handler:Flambda.Expr.t
   -> free_names_of_handler:Name_occurrences.t
   -> cost_metrics_of_handler:Cost_metrics.t
+  -> t
+
+val add_return_continuation
+   : t
+  -> Continuation.t
+  -> Scope.t
+  -> Flambda_arity.With_subkinds.t
   -> t
 
 val add_exn_continuation

--- a/middle_end/flambda/simplify/simplify_apply_cont_expr.ml
+++ b/middle_end/flambda/simplify/simplify_apply_cont_expr.ml
@@ -113,7 +113,7 @@ let rebuild_apply_cont apply_cont ~args ~rewrite_id uacc ~after_rebuild =
        basis that there wouldn't be any opportunity to collect any backtrace,
        even if the [Apply_cont] were compiled as "raise". *)
     after_rebuild (Expr.create_invalid ()) uacc
-  | Non_inlinable _
+  | Non_inlinable_zero_arity _ | Non_inlinable_non_zero_arity _
   | Toplevel_or_function_return_or_exn_continuation _ ->
     create_apply_cont ~apply_cont_to_expr:(fun apply_cont ->
       Expr.create_apply_cont apply_cont,

--- a/middle_end/flambda/simplify/simplify_apply_cont_expr.ml
+++ b/middle_end/flambda/simplify/simplify_apply_cont_expr.ml
@@ -102,7 +102,7 @@ let rebuild_apply_cont apply_cont ~args ~rewrite_id uacc ~after_rebuild =
       after_rebuild expr uacc
   in
   match UE.find_continuation uenv cont with
-  | Linearly_used_and_inlinable { arity = _; params; handler;
+  | Linearly_used_and_inlinable { params; handler;
       free_names_of_handler; cost_metrics_of_handler } ->
     (* We must not fail to inline here, since we've already decided that the
        relevant [Let_cont] is no longer needed. *)
@@ -113,7 +113,8 @@ let rebuild_apply_cont apply_cont ~args ~rewrite_id uacc ~after_rebuild =
        basis that there wouldn't be any opportunity to collect any backtrace,
        even if the [Apply_cont] were compiled as "raise". *)
     after_rebuild (Expr.create_invalid ()) uacc
-  | Other { arity = _; handler = _; } ->
+  | Non_inlinable _
+  | Toplevel_or_function_return_or_exn_continuation _ ->
     create_apply_cont ~apply_cont_to_expr:(fun apply_cont ->
       Expr.create_apply_cont apply_cont,
       Cost_metrics.apply_cont apply_cont,

--- a/middle_end/flambda/simplify/simplify_expr.ml
+++ b/middle_end/flambda/simplify/simplify_expr.ml
@@ -48,7 +48,7 @@ and simplify_toplevel dacc expr ~return_continuation ~return_arity
   let expr, uacc =
     simplify_expr dacc expr ~down_to_up:(fun dacc ~rebuild ->
       let uenv =
-        UE.add_continuation UE.empty return_continuation
+        UE.add_return_continuation UE.empty return_continuation
           return_cont_scope return_arity
       in
       let uenv =

--- a/middle_end/flambda/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda/simplify/simplify_switch_expr.ml
@@ -38,23 +38,24 @@ let rebuild_switch ~simplify_let dacc ~arms ~scrutinee ~scrutinee_ty uacc
             else
               let cont = Apply_cont.continuation action in
               match UE.find_continuation (UA.uenv uacc) cont with
-              | Linearly_used_and_inlinable { arity = _; handler;
-                  free_names_of_handler = _; params; cost_metrics_of_handler = _ } ->
+              | Linearly_used_and_inlinable { handler;
+                  free_names_of_handler = _; params;
+                  cost_metrics_of_handler = _ } ->
                 assert (List.length params = 0);
                 begin match Expr.descr handler with
                 | Apply_cont action -> Some action
                 | Let _ | Let_cont _ | Apply _
                 | Switch _ | Invalid _ -> Some action
                 end
-              | Other { arity = _; handler = Some handler; } ->
-                Continuation_handler.pattern_match handler
-                  ~f:(fun params ~handler ->
-                    assert (List.length params = 0);
-                    match Expr.descr handler with
-                    | Apply_cont action -> Some action
-                    | Let _ | Let_cont _ | Apply _
-                    | Switch _ | Invalid _ -> Some action)
-              | Other _ -> Some action
+              | Non_inlinable { params; handler = Known handler; } ->
+                assert (List.length params = 0);
+                begin match Expr.descr handler with
+                | Apply_cont action -> Some action
+                | Let _ | Let_cont _ | Apply _
+                | Switch _ | Invalid _ -> Some action
+                end
+              | Non_inlinable { params = _; handler = Unknown; }
+              | Toplevel_or_function_return_or_exn_continuation _
               | Unreachable _ -> None
           in
           begin match action with

--- a/middle_end/flambda/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda/simplify/simplify_switch_expr.ml
@@ -51,7 +51,7 @@ let rebuild_switch ~simplify_let dacc ~arms ~scrutinee ~scrutinee_ty uacc
                 check_handler ~handler ~action
               | Non_inlinable_zero_arity { handler = Known handler; } ->
                 check_handler ~handler ~action
-              | Non_inlinable_zero_arity { handler = Unknown; }
+              | Non_inlinable_zero_arity { handler = Unknown; } -> Some action
               | Unreachable _ -> None
               | Non_inlinable_non_zero_arity _
               | Toplevel_or_function_return_or_exn_continuation _ ->

--- a/middle_end/flambda/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda/simplify/simplify_switch_expr.ml
@@ -37,26 +37,29 @@ let rebuild_switch ~simplify_let dacc ~arms ~scrutinee ~scrutinee_ty uacc
             if not (Apply_cont.is_goto action) then Some action
             else
               let cont = Apply_cont.continuation action in
+              let check_handler ~handler ~action =
+                match Expr.descr handler with
+                | Apply_cont action -> Some action
+                | Let _ | Let_cont _ | Apply _
+                | Switch _ | Invalid _ -> Some action
+              in
               match UE.find_continuation (UA.uenv uacc) cont with
               | Linearly_used_and_inlinable { handler;
                   free_names_of_handler = _; params;
                   cost_metrics_of_handler = _ } ->
                 assert (List.length params = 0);
-                begin match Expr.descr handler with
-                | Apply_cont action -> Some action
-                | Let _ | Let_cont _ | Apply _
-                | Switch _ | Invalid _ -> Some action
-                end
-              | Non_inlinable { params; handler = Known handler; } ->
-                assert (List.length params = 0);
-                begin match Expr.descr handler with
-                | Apply_cont action -> Some action
-                | Let _ | Let_cont _ | Apply _
-                | Switch _ | Invalid _ -> Some action
-                end
-              | Non_inlinable { params = _; handler = Unknown; }
-              | Toplevel_or_function_return_or_exn_continuation _
+                check_handler ~handler ~action
+              | Non_inlinable_zero_arity { handler = Known handler; } ->
+                check_handler ~handler ~action
+              | Non_inlinable_zero_arity { handler = Unknown; }
               | Unreachable _ -> None
+              | Non_inlinable_non_zero_arity _
+              | Toplevel_or_function_return_or_exn_continuation _ ->
+                Misc.fatal_errorf "Inconsistency for %a between \
+                    [Apply_cont.is_goto] and continuation environment \
+                    in [UA]:@ %a"
+                  Continuation.print cont
+                  UA.print uacc
           in
           begin match action with
           | None ->

--- a/middle_end/flambda/simplify/typing_helpers/continuation_uses.ml
+++ b/middle_end/flambda/simplify/typing_helpers/continuation_uses.ml
@@ -163,8 +163,7 @@ Format.eprintf "%d uses for %a\n%!"
 Format.eprintf "Unknown at or later than %a\n%!"
   Scope.print (Scope.next definition_scope_level);
 *)
-    let handler_env, extra_params_and_args, is_single_inlinable_use,
-        is_single_use =
+    let handler_env, extra_params_and_args, is_single_inlinable_use =
       match use_envs_with_ids with
       | [use_env, _, Inlinable]
           when not (Continuation.is_exn t.continuation) ->
@@ -177,7 +176,7 @@ Format.eprintf "Unknown at or later than %a\n%!"
           LCS.add_to_denv ~maybe_already_defined:() use_env
             consts_lifted_during_body
         in
-        use_env, Continuation_extra_params_and_args.empty, true, true
+        use_env, Continuation_extra_params_and_args.empty, true
       | [] | [_, _, (Inlinable | Non_inlinable)]
       | (_, _, (Inlinable | Non_inlinable)) :: _ ->
         (* The lifted constants are put into the fork environment now because
@@ -274,16 +273,11 @@ Format.eprintf "The extra params and args are:@ %a\n%!"
             TE.with_code_age_relation handler_env
               code_age_relation_after_body)
         in
-        let is_single_use =
-          match uses with
-          | [_] -> true
-          | [] | _::_::_ -> false
-        in
         match use_envs_with_ids with
         | [_, _, Inlinable] -> assert false  (* handled above *)
         | [] | [_, _, Non_inlinable]
         | (_, _, (Inlinable | Non_inlinable)) :: _ ->
-          denv, extra_params_and_args, false, is_single_use
+          denv, extra_params_and_args, false
     in
     let arg_types_by_use_id =
       List.fold_left (fun args use ->
@@ -301,7 +295,6 @@ Format.eprintf "The extra params and args are:@ %a\n%!"
       arg_types_by_use_id;
       extra_params_and_args;
       is_single_inlinable_use;
-      is_single_use;
     }
 
 let get_typing_env_no_more_than_one_use t =

--- a/middle_end/flambda/terms/continuation_handler.rec.mli
+++ b/middle_end/flambda/terms/continuation_handler.rec.mli
@@ -81,19 +81,14 @@ val pattern_match_pair
 
 module Behaviour : sig
   type t = private
-    | Unreachable of { arity : Flambda_arity.With_subkinds.t; }
-    | Alias_for of {
-        arity : Flambda_arity.With_subkinds.t;
-        alias_for : Continuation.t;
-      }
-    | Unknown of { arity : Flambda_arity.With_subkinds.t; }
+    | Unreachable
+    | Alias_for of Continuation.t
+    | Unknown
 
   include Contains_ids.S with type t := t
 end
 
 val behaviour : t -> Behaviour.t
-
-val arity : t -> Flambda_arity.With_subkinds.t
 
 (** Whether the continuation is an exception handler.
 

--- a/middle_end/flambda/terms/flambda.mli
+++ b/middle_end/flambda/terms/flambda.mli
@@ -373,15 +373,10 @@ end and Continuation_handler : sig
 
   module Behaviour : sig
     type t = private
-      | Unreachable of { arity : Flambda_arity.With_subkinds.t; }
-      | Alias_for of {
-          arity : Flambda_arity.With_subkinds.t;
-          alias_for : Continuation.t;
-        }
-      | Unknown of { arity : Flambda_arity.With_subkinds.t; }
+      | Unreachable
+      | Alias_for of Continuation.t
+      | Unknown
   end
-
-  val arity : t -> Flambda_arity.With_subkinds.t
 
   val behaviour : t -> Behaviour.t
 end and Recursive_let_cont_handlers : sig


### PR DESCRIPTION
This tidies up the handling of arity fields in the continuation environment in `UE`.  It also removes the `arity` function from `Continuation_handler` itself; the only use of it was not required, and moreover got in the way of the not-rebuilding-terms work.

At the same time this fixes the bug that @Gbury found relating to failure to store continuation handler expressions for non-inlinable continuations in the environment.  We should still do this as they can be used by the switch simplifier, even if not by the inliner.