### PR TITLE
Row_like indexes allows to represent a range rather than only upward closed set

### DIFF
--- a/middle_end/flambda/types/structures/row_like.rec.ml
+++ b/middle_end/flambda/types/structures/row_like.rec.ml
@@ -40,17 +40,12 @@ module Make
     with type typing_env_extension := Typing_env_extension.t) =
 struct
 
-  (* Note: it wouldn't require much changes to change it to an interval:
-     type index = { at_least : Index.t; at_most : Index.t }
-     representing { x | at_least \subset x /\ x \subset at_most }
-  *)
   type index =
     | Known of Index.t (** Known x represents the singleton set: { x } *)
     | At_least of Index.t (** At_least x represents the set { y | x \subset y } *)
     | Range of { at_least : Index.t; at_most : Index.t; }
-    (** Range { at_least; at_most represents the set
+    (** Range { at_least; at_most } represents the set
         { x | at_least \subset x /\ x \subset at_most }
-        or { x | at_least \subset x } if at_most is None
 
         invariant: at_least is strictly smaller than at_most. If they are
         equal, this is a Known. This invariant is usefull to simplify bottom
@@ -375,8 +370,6 @@ struct
         | Ok other1, Ok other2 ->
           Ok (join_case env other1 other2)
       in
-      Format.printf "Join blocks:@ %a@ %a@ %a@."
-        print t1 print t2 print { known_tags; other_tags };
       { known_tags; other_tags }
 
     let get_singleton { known_tags; other_tags; } =


### PR DESCRIPTION
This allows to more precisely represent the size of joins of polymorphic variants. This would be useful to be able to unbox something like:
```OCaml
let f b x =
  let v =
    if b then
      `A (x, x)
    else
      `B (x, 1, 2)
  in
  match v with
  | `A (a, b) -> a + b
  | `B (a, b, c) -> a + b + c
```

Notice that this is not enough to allow simplification of `c` to `2` here. Join still considers that joining between a known case and an absent case is equivalent to joining with top, where it should be equivalent to joining with bottom. We would need to refactor a bit to do that, which I defer for later.

In a first version the `Range` constructor took an option for the `at_most` field rather than having an `At_least` and `Range` case. But there is no factorisation to gain that way and the code is a bit cleaner like that.