### PR TITLE
Rework partial application code

### DIFF
--- a/middle_end/flambda/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda/simplify/simplify_apply_expr.ml
@@ -211,7 +211,7 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
   let wrapper_closure_id =
     Closure_id.wrap compilation_unit (Variable.create "partial_app_closure")
   in
-  let wrapper_taking_remaining_args, dacc, dummy_code =
+  let wrapper_taking_remaining_args, dacc, code_id, code =
     let return_continuation = Continuation.create () in
     let remaining_params =
       List.map (fun kind ->
@@ -281,17 +281,19 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
     in
     let code =
       let free_names = Function_params_and_body.free_names params_and_body in
-      Code.create
-        code_id
-        ~params_and_body:(Present (params_and_body, free_names))
-        ~newer_version_of:None
-        ~params_arity:(KP.List.arity_with_subkinds remaining_params)
-        ~result_arity
-        ~stub:true
-        ~inline:Default_inline
-        ~is_a_functor:false
-        ~recursive
-        ~cost_metrics:Unknown
+      let code =
+        Code.create code_id
+          ~params_and_body:(Present (params_and_body, free_names))
+          ~newer_version_of:None
+          ~params_arity:(KP.List.arity_with_subkinds remaining_params)
+          ~result_arity
+          ~stub:true
+          ~inline:Default_inline
+          ~is_a_functor:false
+          ~recursive
+          ~cost_metrics:Unknown
+      in
+      Static_const.Code code
     in
     let function_decl =
       Function_declaration.create ~code_id ~is_tupled:false ~dbg
@@ -303,49 +305,35 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
     let closure_elements =
       Var_within_closure.Map.of_list applied_args_with_closure_vars
     in
-    let defining_expr =
-      LC.create_code code_id
-        (Rebuilt_static_const.create (Code code) ~free_names:Unknown)
-    in
-    let dummy_defining_expr =
-      (* We should not add the real piece of code in the lifted constant.
-         A new piece of code will always be generated when the [Let] we
-         generate below is simplified.  As such we can simply add a lifted
-         constant identifying deleted code.  This will ensure, if for some
-         reason the constant makes it to Cmm stage, that code size is not
-         increased unnecessarily. *)
-      let code = Code.make_deleted code in
-      LC.create_code code_id
-        (Rebuilt_static_const.create (Code code) ~free_names:Unknown)
-    in
-    let dacc =
-      DA.add_lifted_constant dacc dummy_defining_expr
-      |> DA.map_denv ~f:(fun denv ->
-           LCS.add_singleton_to_denv denv defining_expr)
-    in
-    Set_of_closures.create function_decls ~closure_elements,
-    dacc,
-    dummy_defining_expr
+    Set_of_closures.create function_decls ~closure_elements, dacc, code_id, code
   in
   let apply_cont =
-    Apply_cont.create apply_continuation
-      ~args:[Simple.var wrapper_var] ~dbg
+    Apply_cont.create apply_continuation ~args:[Simple.var wrapper_var] ~dbg
   in
   let expr =
     let wrapper_var = VB.create wrapper_var Name_mode.normal in
     let closure_vars = [wrapper_var] in
     let bound = Bindable_let_bound.set_of_closures ~closure_vars in
-    Let.create bound
-      (Named.create_set_of_closures wrapper_taking_remaining_args)
-      ~body:(Expr.create_apply_cont apply_cont)
+    let body =
+      Let.create bound
+        (Named.create_set_of_closures wrapper_taking_remaining_args)
+        ~body:(Expr.create_apply_cont apply_cont)
+        ~free_names_of_body:Unknown
+      |> Expr.create_let
+    in
+    let bound_symbols =
+      Bound_symbols.singleton (Bound_symbols.Pattern.code code_id)
+    in
+    let static_consts = Static_const.Group.create [code] in
+    (* Since we are only generating a "let code" binding and not a "let symbol",
+       it doesn't matter if we are not at toplevel. *)
+    Let.create (Bindable_let_bound.symbols bound_symbols Dominator)
+      (Named.create_static_consts static_consts)
+      ~body
       ~free_names_of_body:Unknown
     |> Expr.create_let
   in
-  simplify_expr dacc expr
-    ~down_to_up:(fun dacc ~rebuild ->
-      down_to_up dacc ~rebuild:(fun uacc ~after_rebuild ->
-        let uacc = UA.add_outermost_lifted_constant uacc dummy_code in
-        rebuild uacc ~after_rebuild))
+  simplify_expr dacc expr ~down_to_up
 
 (* CR mshinwell: Should it be an error to encounter a non-direct application
    of a symbol after [Simplify]? This shouldn't usually happen, but I'm not 100%

--- a/middle_end/flambda/simplify/simplify_named.ml
+++ b/middle_end/flambda/simplify/simplify_named.ml
@@ -218,7 +218,8 @@ let simplify_named0 dacc (bindable_let_bound : Bindable_let_bound.t)
     let { Bindable_let_bound. bound_symbols; scoping_rule = _; } =
       Bindable_let_bound.must_be_symbols bindable_let_bound
     in
-    if not (DE.at_unit_toplevel (DA.denv dacc)) then begin
+    let binds_symbols = Bound_symbols.binds_symbols bound_symbols in
+    if binds_symbols && not (DE.at_unit_toplevel (DA.denv dacc)) then begin
       Misc.fatal_errorf "[Let] binding symbols is only allowed at the toplevel \
           of compilation units (not even at the toplevel of function \
           bodies):@ %a@ =@ %a"

--- a/middle_end/flambda/terms/bound_symbols.ml
+++ b/middle_end/flambda/terms/bound_symbols.ml
@@ -76,6 +76,11 @@ module Pattern = struct
     | Code _ -> true
     | Set_of_closures _ | Block_like _ -> false
 
+  let binds_symbols t =
+    match t with
+    | Code _ -> false
+    | Set_of_closures _ | Block_like _ -> true
+
   let closure_symbols_being_defined t =
     match t with
     | Code _ | Block_like _ -> Symbol.Set.empty
@@ -157,6 +162,9 @@ let code_being_defined t =
 
 let binds_code t =
   List.exists Pattern.binds_code t
+
+let binds_symbols t =
+  List.exists Pattern.binds_symbols t
 
 let everything_being_defined t =
   List.map Pattern.everything_being_defined t

--- a/middle_end/flambda/terms/bound_symbols.mli
+++ b/middle_end/flambda/terms/bound_symbols.mli
@@ -47,6 +47,8 @@ val code_being_defined : t -> Code_id.Set.t
 
 val binds_code : t -> bool
 
+val binds_symbols : t -> bool
+
 val non_closure_symbols_being_defined : t -> Symbol.Set.t
 
 val closure_symbols_being_defined : t -> Symbol.Set.t


### PR DESCRIPTION
This follows on from #356 and seems like a much more natural way of expressing the transformation.  It also works correctly with the not-rebuilding-terms patch, as it doesn't try to construct rebuilt expressions on the downwards pass.