### PR TITLE
Better types in join

### DIFF
--- a/middle_end/flambda/types/env/typing_env_level.rec.ml
+++ b/middle_end/flambda/types/env/typing_env_level.rec.ml
@@ -226,7 +226,7 @@ let join_types ~params ~env_at_fork envs_with_levels =
      So we start the join with equations binding the parameters to Bottom,
      to make sure we end up with the right type in the end.
   *)
-  let initial_types =
+  let initial_joined_types =
     let bottom_ty param =
       Type_grammar.bottom
         (Flambda_kind.With_subkind.kind (Kinded_parameter.kind param))
@@ -239,7 +239,7 @@ let join_types ~params ~env_at_fork envs_with_levels =
   in
   (* Now fold over the levels doing the actual join operation on equations. *)
   ListLabels.fold_left envs_with_levels
-    ~init:(initial_types, Variable.Set.empty)
+    ~init:(initial_joined_types, Variable.Set.empty)
     ~f:(fun (joined_types, defined_variables) (env_at_use, _, _, t) ->
       let left_env =
         (* CR vlaviron: This is very likely quadratic (number of uses times

--- a/middle_end/flambda/types/env/typing_env_level.rec.ml
+++ b/middle_end/flambda/types/env/typing_env_level.rec.ml
@@ -270,10 +270,7 @@ let join_types ~params ~env_at_fork envs_with_levels =
            While it is possible that its type could be refined by all of the
            branches, it is unlikely. *)
         match Name.must_be_var_opt name with
-        | None ->
-          (* Symbol: assume the best equations are either already
-             in [env_at_fork] or in the lifted constants *)
-          None
+        | None -> (* Symbol *) None
         | Some var ->
           let joined_ty =
             match joined_ty, use_ty with


### PR DESCRIPTION
This is a slight improvement to the types of variables that are not defined on all sides of the join.
Before this patch, they're considered as having type `Unknown` in the branches where they're not defined, while this patch considers that their type is Bottom on the branches where they're not defined.

This showed up in the following example:

```ocaml
type foo =
  | Foo1 of int
  | Foo2 of float

type bar =
  | Foobar of int
  | Bar of foo

let test b b' x f =
  let z =
    if b then Foobar x
    else if b' then Bar (Foo1 x)
    else Bar (Foo2 f)
  in
  match z with
  | Foobar i -> i
  | Bar Foo1 i -> i
  | Bar Foo2 _ -> 57
```

Here we expect that `| Bar Foo1 i -> i` could be simplified to `Bar Foo1 _ -> x`. Without this patch, this is not possible as the type for `z` looks like `Foobar (= x) | Bar (Top)`. With this patch, the type becomes `Foobar (= x) | Bar (Foo1 (= x) | Foo2 (= f))`.

I'm confident that the reasoning behind the patch is sound... but I wouldn't be completely surprised if I had missed an important detail in the implementation, so I think this needs to be reviewed a bit carefully. (I've updated the comments that explain how this works, so it should make reviewing a bit easier).