### PR TITLE
Remove Continuation_handler.Behaviour

### DIFF
--- a/middle_end/flambda/terms/continuation_handler.rec.mli
+++ b/middle_end/flambda/terms/continuation_handler.rec.mli
@@ -79,17 +79,6 @@ val pattern_match_pair
     -> 'a)
   -> ('a, Pattern_match_pair_error.t) Result.t
 
-module Behaviour : sig
-  type t = private
-    | Unreachable
-    | Alias_for of Continuation.t
-    | Unknown
-
-  include Contains_ids.S with type t := t
-end
-
-val behaviour : t -> Behaviour.t
-
 (** Whether the continuation is an exception handler.
 
     Continuations used as exception handlers are always [Non_recursive]. To

--- a/middle_end/flambda/terms/flambda.mli
+++ b/middle_end/flambda/terms/flambda.mli
@@ -370,15 +370,6 @@ end and Continuation_handler : sig
       simultaneously-defined continuations when one or more of them is an
       exception handler.) *)
   val is_exn_handler : t -> bool
-
-  module Behaviour : sig
-    type t = private
-      | Unreachable
-      | Alias_for of Continuation.t
-      | Unknown
-  end
-
-  val behaviour : t -> Behaviour.t
 end and Recursive_let_cont_handlers : sig
   (** The representation of the alpha-equivalence class of a group of possibly
       (mutually-) recursive continuation handlers that are bound both over a


### PR DESCRIPTION
`Continuation_handler.Behaviour` isn't any good in the not-rebuilding-terms world because we need to do the analysis on rebuilt expressions.  It turns out, in any case, to make the code simpler if we just inline the relevant code into `Simplify_let_cont`.