### PR TITLE
Remove unused code from Typing_env_level

### DIFF
--- a/middle_end/flambda/types/env/typing_env_level.rec.mli
+++ b/middle_end/flambda/types/env/typing_env_level.rec.mli
@@ -71,8 +71,6 @@ val n_way_join
   -> extra_allowed_names:Name_occurrences.t
   -> t
 
-include Contains_names.S with type t := t
-
 (* CR vlaviron: this is only needed because Typing_env_extension creates a
    Name_abstraction over it. These functions should not be called, as levels
    are not exported. *)


### PR DESCRIPTION
This is mainly the functions associated with `Contains_names.S`.