### PR TITLE
Remove Renaming.has_no_action and Import_map.has_no_action

### DIFF
--- a/middle_end/flambda/cmx/exported_code.ml
+++ b/middle_end/flambda/cmx/exported_code.ml
@@ -192,7 +192,7 @@ let all_ids_for_export t =
     Ids_for_export.empty
 
 let apply_renaming code_id_map renaming t =
-  if Renaming.has_no_action renaming
+  if Renaming.is_empty renaming
     && Code_id.Map.is_empty code_id_map
   then t
   else

--- a/middle_end/flambda/cmx/ids_for_export.ml
+++ b/middle_end/flambda/cmx/ids_for_export.ml
@@ -150,17 +150,6 @@ module Import_map = struct
        are really missing at this point). *)
   }
 
-  let has_no_action
-        { symbols; variables; simples; consts; code_ids; continuations;
-          used_closure_vars = _;
-        } =
-    Symbol.Map.is_empty symbols
-    && Variable.Map.is_empty variables
-    && Simple.Map.is_empty simples
-    && Const.Map.is_empty consts
-    && Code_id.Map.is_empty code_ids
-    && Continuation.Map.is_empty continuations
-
   let is_empty
         { symbols; variables; simples; consts; code_ids; continuations;
           used_closure_vars;

--- a/middle_end/flambda/cmx/ids_for_export.mli
+++ b/middle_end/flambda/cmx/ids_for_export.mli
@@ -75,8 +75,6 @@ module Import_map : sig
 
   val is_empty : t -> bool
 
-  val has_no_action : t -> bool
-
   val const : t -> Reg_width_things.Const.t -> Reg_width_things.Const.t
   val variable : t -> Variable.t -> Variable.t
   val symbol : t -> Symbol.t -> Symbol.t

--- a/middle_end/flambda/naming/name_abstraction.ml
+++ b/middle_end/flambda/naming/name_abstraction.ml
@@ -111,7 +111,7 @@ module Make (Bindable : Bindable.S) (Term : Term) = struct
     f fresh_name fresh_term0 fresh_term1
 
   let apply_renaming ((name, term) as t) perm =
-    if Renaming.has_no_action perm then t
+    if Renaming.is_empty perm then t
     else
       let name = Bindable.apply_renaming name perm in
       let term = Term.apply_renaming term perm in

--- a/middle_end/flambda/naming/name_occurrences.ml
+++ b/middle_end/flambda/naming/name_occurrences.ml
@@ -1159,7 +1159,7 @@ let apply_renaming
          continuations_in_trap_actions;
          closure_vars; code_ids; newer_version_of_code_ids; } as t)
       renaming =
-  if Renaming.has_no_action renaming then t
+  if Renaming.is_empty renaming then t
   else
     let names = For_names.apply_renaming names renaming in
     let continuations =

--- a/middle_end/flambda/naming/renaming.ml
+++ b/middle_end/flambda/naming/renaming.ml
@@ -60,16 +60,6 @@ let print ppf
     Code_ids.print code_ids
     Symbols.print symbols
 
-let has_no_action
-      { continuations; variables; code_ids; symbols; import_map; } =
-  Continuations.is_empty continuations
-  && Variables.is_empty variables
-  && Code_ids.is_empty code_ids
-  && Symbols.is_empty symbols
-  && match import_map with
-     | None -> true
-     | Some import_map -> Import_map.has_no_action import_map
-
 let is_empty
       { continuations; variables; code_ids; symbols; import_map; } =
   Continuations.is_empty continuations

--- a/middle_end/flambda/naming/renaming.mli
+++ b/middle_end/flambda/naming/renaming.mli
@@ -28,7 +28,7 @@ val empty : t
 
 val print : Format.formatter -> t -> unit
 
-val has_no_action : t -> bool
+val is_empty : t -> bool
 
 val of_import_map : Ids_for_export.Import_map.t -> t
 

--- a/middle_end/flambda/naming/with_delayed_permutation.ml
+++ b/middle_end/flambda/naming/with_delayed_permutation.ml
@@ -44,7 +44,7 @@ end) = struct
   let peek_descr t = t.descr
 
   let descr t =
-    if Renaming.has_no_action t.delayed_permutation then begin
+    if Renaming.is_empty t.delayed_permutation then begin
       t.descr
     end else begin
       let descr = Descr.apply_renaming t.descr t.delayed_permutation in

--- a/middle_end/flambda/terms/expr.rec.ml
+++ b/middle_end/flambda/terms/expr.rec.ml
@@ -84,7 +84,7 @@ let create descr =
 let peek_descr t = t.descr
 
 let descr t =
-  if Renaming.has_no_action t.delayed_permutation then begin
+  if Renaming.is_empty t.delayed_permutation then begin
     t.descr
   end else begin
     let descr = Descr.apply_renaming t.descr t.delayed_permutation in

--- a/middle_end/flambda/terms/static_const.rec.ml
+++ b/middle_end/flambda/terms/static_const.rec.ml
@@ -267,7 +267,7 @@ let free_names t =
       fields
 
 let apply_renaming t renaming =
-  if Renaming.has_no_action renaming then t
+  if Renaming.is_empty renaming then t
   else
     match t with
     | Code code ->

--- a/middle_end/flambda/types/type_descr.rec.ml
+++ b/middle_end/flambda/types/type_descr.rec.ml
@@ -59,7 +59,7 @@ module Make (Head : Type_head_intf.S
       print_with_cache ~cache:(Printing_cache.create ()) ppf t
 
     let apply_renaming t renaming =
-      if Renaming.has_no_action renaming then t
+      if Renaming.is_empty renaming then t
       else
         match t with
         | No_alias Bottom | No_alias Unknown -> t


### PR DESCRIPTION
I think the use of these functions, introduced in #332, was causing used closure var information to be dropped.