### PR TITLE
Miscellaneous tidyups

### DIFF
--- a/middle_end/flambda/lifting/reification.ml
+++ b/middle_end/flambda/lifting/reification.ml
@@ -119,21 +119,7 @@ let try_to_reify dacc (term : Simplified_named.t) ~bound_to ~allow_lifting =
     | Lift to_lift ->
       if Name_mode.is_normal occ_kind && allow_lifting then
         let static_const = create_static_const to_lift in
-        (* CR mshinwell: Make sure we never need this check now
-        (* We cannot currently handle the lifting of constants that are
-           recursive with a symbol currently being defined, unless the
-           constant is a closure, which it never is in this case.
-           (An example of such a constant would be a pair, created in a
-           recursive function [f] that has no free variables, containing
-           the closure [f].) *)
-        let overlap_with_current_definitions =
-          let free_names = Static_const.free_names static_const in
-          Symbol.Set.exists (fun sym ->
-              Name_occurrences.mem_symbol free_names sym)
-            (DE.symbols_currently_being_defined denv)
-        in
-        if overlap_with_current_definitions then term, dacc, ty
-        else *) lift dacc ty ~bound_to static_const
+        lift dacc ty ~bound_to static_const
       else
         term, dacc, ty
     | Simple simple ->

--- a/middle_end/flambda/simplify/simplify_let_expr.ml
+++ b/middle_end/flambda/simplify/simplify_let_expr.ml
@@ -58,8 +58,7 @@ let rebuild_let symbol_scoping_rule simplify_named_result
     after_rebuild body uacc
   else
     let scoping_rule =
-      (* If this is a "normal" let rather than a "let symbol", then we
-         use [Dominator] scoping for any symbol bindings we place, as the
+      (* We use [Dominator] scoping for any symbol bindings we place, as the
          types of the symbols may have been used out of syntactic scope. *)
       Option.value ~default:Symbol_scoping_rule.Dominator symbol_scoping_rule
     in

--- a/middle_end/flambda/simplify/simplify_named.ml
+++ b/middle_end/flambda/simplify/simplify_named.ml
@@ -242,7 +242,7 @@ let simplify_named0 dacc (bindable_let_bound : Bindable_let_bound.t)
           static_consts ~simplify_toplevel
       with Misc.Fatal_error -> begin
         if !Clflags.flambda_context_on_error then begin
-          Format.eprintf "\n%sContext is:%s simplifying [Let_symbol] binding \
+          Format.eprintf "\n%sContext is:%s simplifying 'let symbol' binding \
                             of@ %a@ with downwards accumulator:@ %a\n"
             (Flambda_colours.error ())
             (Flambda_colours.normal ())
@@ -252,15 +252,6 @@ let simplify_named0 dacc (bindable_let_bound : Bindable_let_bound.t)
           raise Misc.Fatal_error
       end
     in
-    (* CR mshinwell: Change to be run only when invariants are on, and use
-      [Name_occurrences.iter] (to be written).
-    Symbol.Set.iter (fun sym ->
-        DE.check_symbol_is_bound (DA.denv dacc) sym)
-      (Name_occurrences.symbols bound_symbols_free_names);
-    Code_id.Set.iter (fun code_id ->
-        DE.check_code_id_is_bound (DA.denv dacc) code_id)
-      (Name_occurrences.code_ids bound_symbols_free_names);
-    *)
     let dacc =
       DA.map_denv dacc ~f:(fun denv ->
         Symbol.Set.fold (fun symbol denv ->

--- a/middle_end/flambda/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda/simplify/simplify_set_of_closures.ml
@@ -187,11 +187,7 @@ end = struct
                 Name_in_binding_pos.create name
                   (if irrelevant then NM.in_types else NM.normal)
               in
-              (* The name may be bound already when reifying the types of
-                 continuation parameters at toplevel. *)
-              (* CR mshinwell: update out of date comment.  Do we still need
-                 [define_name_if_undefined] here? *)
-              DE.define_name_if_undefined denv bound_name K.value)
+              DE.define_name denv bound_name K.value)
             closure_bound_names_inside
             denv)
         denv_inside_functions

--- a/middle_end/flambda/simplify/simplify_static_const.ml
+++ b/middle_end/flambda/simplify/simplify_static_const.ml
@@ -63,13 +63,7 @@ let simplify_static_const_of_kind_value0 dacc
       : Static_const.t * DA.t =
   let bind_result_sym typ =
     DA.map_denv dacc ~f:(fun denv ->
-      let denv =
-        (* [result_sym] will already be defined when we are lifting
-           reified continuation parameters. *)
-        (* CR mshinwell: This is kind of nasty---try to rearrange things
-           so this doesn't happen. *)
-        DE.define_symbol_if_undefined denv result_sym K.value
-      in
+      let denv = DE.define_symbol denv result_sym K.value in
       DE.add_equation_on_symbol denv result_sym typ)
   in
   match static_const with


### PR DESCRIPTION
This cleans up a few things discovered whilst working on #346, some of which were pieces of old code relating to the `Reify_continuation_param_types` pass, which is no longer used.