### PR TITLE
Correctly import simples

### DIFF
--- a/flambdatest/api_tests/Makefile
+++ b/flambdatest/api_tests/Makefile
@@ -60,7 +60,7 @@ CAMLDEP=$(CAMLRUN) $(ROOTDIR)/boot/ocamlc -depend
 DEPFLAGS=-slash
 DEPINCLUDES=$(INCLUDES)
 
-SOURCES=extension_meet.ml
+SOURCES=extension_meet.ml import_test.ml
 
 COMPILERLIBS=\
   $(ROOTDIR)/compilerlibs/ocamlcommon.cma \

--- a/flambdatest/api_tests/import_test.ml
+++ b/flambdatest/api_tests/import_test.ml
@@ -1,0 +1,102 @@
+let test () =
+  (* This test checks that importing Simples work correctly. *)
+  (* All the simples we're importing will have var_ext as their
+     base variable. However, importing will map var to var_bad
+     so if for some reason importing is done twice then one of
+     the output simples will be printed as "bad" instead of "ok". *)
+  let var_ext = Variable.create "ext" in
+  let var_ok = Variable.create "ok" in
+  let var_bad = Variable.create "bad" in
+  let variables =
+    Variable.Map.add var_ok var_bad
+      (Variable.Map.singleton var_ext var_ok)
+  in
+  let renaming =
+    Renaming.create_import_map
+      ~symbols:Symbol.Map.empty
+      ~variables
+      ~simples:Simple.Map.empty
+      ~consts:Reg_width_things.Const.Map.empty
+      ~code_ids:Code_id.Map.empty
+      ~continuations:Continuation.Map.empty
+      ~used_closure_vars:Var_within_closure.Set.empty
+  in
+  (* Now create the simples. simple0 is the raw variable,
+     simple1 has some rec info with depth 1, and simple2 has rec info
+     with depth 2. *)
+  let simple0 = Simple.var var_ext in
+  let rec_info1 = Rec_info.create ~depth:1 ~unroll_to:None in
+  let simple1 = Simple.with_rec_info simple0 rec_info1 in
+  let rec_info2 = Rec_info.create ~depth:2 ~unroll_to:None in
+  let simple1_ok = Simple.with_rec_info simple0 rec_info2 in
+  (* Map simple1 to simple1_ok. Normally import preserves the rec info,
+     but here we're trying to detect application of the renaming so
+     we whose a rec_info that's noticeably distinct. *)
+  let simples =
+    Simple.Map.singleton simple1 simple1_ok
+  in
+  let renaming2 =
+    Renaming.create_import_map
+      ~symbols:Symbol.Map.empty
+      ~variables
+      ~simples
+      ~consts:Reg_width_things.Const.Map.empty
+      ~code_ids:Code_id.Map.empty
+      ~continuations:Continuation.Map.empty
+      ~used_closure_vars:Var_within_closure.Set.empty
+  in
+  (* Now the bad case, if importing simples was also
+     importing the underlying variable (as it used to do) *)
+  let simple1_bad = Simple.with_rec_info (Simple.var var_ok) rec_info2 in
+  let simples_bad = Simple.Map.singleton simple1 simple1_bad in
+  let renaming2_bad =
+    Renaming.create_import_map
+      ~symbols:Symbol.Map.empty
+      ~variables
+      ~simples:simples_bad
+      ~consts:Reg_width_things.Const.Map.empty
+      ~code_ids:Code_id.Map.empty
+      ~continuations:Continuation.Map.empty
+      ~used_closure_vars:Var_within_closure.Set.empty
+  in
+  let check renaming msg =
+    let simple0' = Renaming.apply_simple renaming simple0 in
+    let simple1' = Renaming.apply_simple renaming simple1 in
+    Format.printf
+      "%s:@.%a -> %a@.%a -> %a@."
+      msg
+      Simple.print simple0
+      Simple.print simple0'
+      Simple.print simple1
+      Simple.print simple1'
+  in
+  check renaming "Simple renaming, vars only";
+  check renaming2 "Simple renaming, with simples";
+  check renaming2_bad "Simple renaming, with recursive import";
+  (* As reference, here is what output is expected at the time of writing
+     this test:
+
+Simple renaming, vars only:
+ext/0 -> ok/1
+(simple ext/0) (rec_info ((depth 1) (unroll_to None))) -> 
+(simple ok/1) (rec_info ((depth 1) (unroll_to None)))
+Simple renaming, with simples:
+ext/0 -> ok/1
+(simple ext/0) (rec_info ((depth 1) (unroll_to None))) -> 
+(simple ok/1) (rec_info ((depth 2) (unroll_to None)))
+Simple renaming, with recursive import:
+ext/0 -> ok/1
+(simple ext/0) (rec_info ((depth 1) (unroll_to None))) -> 
+(simple bad/2) (rec_info ((depth 2) (unroll_to None)))
+
+  *)
+  ()
+
+let _ =
+  let comp_unit =
+    let id = Ident.create_persistent "Test" in
+    let linkage_name = Linkage_name.create "camlTest" in
+    Compilation_unit.create id linkage_name
+  in
+  Compilation_unit.set_current comp_unit;
+  test ()

--- a/flambdatest/api_tests/import_test.ml
+++ b/flambdatest/api_tests/import_test.ml
@@ -31,7 +31,7 @@ let test () =
   let simple1_ok = Simple.with_rec_info simple0 rec_info2 in
   (* Map simple1 to simple1_ok. Normally import preserves the rec info,
      but here we're trying to detect application of the renaming so
-     we whose a rec_info that's noticeably distinct. *)
+     we use a rec_info that's noticeably distinct. *)
   let simples =
     Simple.Map.singleton simple1 simple1_ok
   in

--- a/middle_end/flambda/cmx/flambda_cmx_format.ml
+++ b/middle_end/flambda/cmx/flambda_cmx_format.ml
@@ -117,6 +117,9 @@ let import_typing_env_and_code0 t =
   let variables =
     Variable.Map.filter_map (filter Variable.import) t.table_data.variables
   in
+  let simples =
+    Simple.Map.filter_map (filter Simple.import) t.table_data.simples
+  in
   let consts =
     Const.Map.filter_map (filter Const.import) t.table_data.consts
   in
@@ -128,35 +131,6 @@ let import_typing_env_and_code0 t =
       t.table_data.continuations
   in
   let used_closure_vars = t.used_closure_vars in
-  (* Build a simple to simple converter from this *)
-  let renaming =
-    Renaming.create_import_map
-      ~symbols
-      ~variables
-      ~simples:Simple.Map.empty
-      ~consts
-      ~code_ids
-      ~continuations
-      ~used_closure_vars
-  in
-  let import_simple_without_rec_info simple =
-    (* [simple] will never have [Rec_info] since it is the [Simple] component
-       of a [Simple_data.t].  See [Reg_width_things.Simple_data]. *)
-    assert (not (Simple.has_rec_info simple));
-    Simple.pattern_match simple
-      ~const:(fun c ->
-        Simple.const (Renaming.apply_const renaming c))
-      ~name:(fun n ->
-        Simple.name (Renaming.apply_name renaming n))
-  in
-  (* Then convert the [Simple]s (only those that have Rec_info).  Inside such
-     [Simple]s are further [Simple]s, all without [Rec_info]; these will be
-     imported using the renaming constructed above. *)
-  let simples =
-    Simple.Map.filter_map
-      (filter (Simple.import import_simple_without_rec_info))
-      t.table_data.simples
-  in
   let renaming =
     Renaming.create_import_map
       ~symbols

--- a/middle_end/flambda/compilenv_deps/reg_width_things.ml
+++ b/middle_end/flambda/compilenv_deps/reg_width_things.ml
@@ -607,20 +607,13 @@ module Simple = struct
 
   let export t = find_data t
 
-  let import map (data : exported) =
-    (* The grand table of [Simple]s only holds those with [Rec_info]. *)
-    let old_simple = data.simple in
-    (* [old_simple] never has [Rec_info].  See [Simple_data], above. *)
-    assert (Id.flags old_simple <> simple_flags);
-    let t = map old_simple in
-    (* The import converter should never affect the flags. *)
-    assert (Id.flags t <> simple_flags);
-    let rec_info = data.rec_info in
-    if Rec_info.is_initial rec_info then t
-    else begin
-      let data : Simple_data.t = { simple = t; rec_info; } in
-      Table.add !grand_table_of_simples data
-    end
+  let import (data : exported) =
+    (* Note: We do not import the underlying name or const.
+       This is done on purpose, to make the import process simpler
+       and well-defined, but means that the real import functions
+       (in Renaming) are responsible for importing the underlying
+       name/const. *)
+    Table.add !grand_table_of_simples data
 
   let map_compilation_unit _f data =
     (* The compilation unit is not associated with the simple directly,

--- a/middle_end/flambda/compilenv_deps/reg_width_things.mli
+++ b/middle_end/flambda/compilenv_deps/reg_width_things.mli
@@ -173,7 +173,7 @@ module Simple : sig
 
   val export : t -> exported
 
-  val import : (t -> t) -> exported -> t
+  val import : exported -> t
 
   val map_compilation_unit :
     (Compilation_unit.t -> Compilation_unit.t) -> exported -> exported

--- a/middle_end/flambda/naming/renaming.ml
+++ b/middle_end/flambda/naming/renaming.ml
@@ -337,7 +337,9 @@ let apply_simple t simple =
   (* Constants are never permuted, only freshened upon import. *)
   Simple.pattern_match simple
     ~name
-    ~const:(fun cst -> Simple.const (apply_const t cst))
+    ~const:(fun cst ->
+      assert (not (Simple.has_rec_info simple));
+      Simple.const (apply_const t cst))
 
 let closure_var_is_used t closure_var =
   match t.import_map with


### PR DESCRIPTION
This fixes the code for importing simples (for good, I hope) by making the import mechanism easier to specify.
In particular, importing a simple is meaningless for simples without rec info, and for the ones with rec info it only brings back the same structure in the table and doesn't try to magically import the underlying name or const too. This fits the current code in `renaming.ml` so no change has been made there apart for adding a small assertion.

I've added a test that shows what happens in various problematic cases, so if import problems show up again running the test should help with debugging.
The test can be run with `make -C flambdatest/api_tests allopt && flambdatest/api_tests/import_test.native` (if you've built ocamlopt.opt with the Makefiles) or `make -C flambdatest/api_tests all && boot/ocamlrun flambdatest/api_tests/import_test.byte` (if you've only built ocamlopt). You can check the test's source to see the expected output.