### PR TITLE
Remove remaining uses of Expr.free_names (except in test code)

### DIFF
--- a/middle_end/flambda/simplify/expr_builder.mli
+++ b/middle_end/flambda/simplify/expr_builder.mli
@@ -83,7 +83,8 @@ val rebuild_invalid
 
 type add_wrapper_for_switch_arm_result = private
   | Apply_cont of Apply_cont.t
-  | New_wrapper of Continuation.t * Continuation_handler.t * Cost_metrics.t
+  | New_wrapper of Continuation.t * Continuation_handler.t
+      * Name_occurrences.t * Cost_metrics.t
 
 val add_wrapper_for_switch_arm
    : Upwards_acc.t


### PR DESCRIPTION
(I still need to review this again myself next week.)

This removes the last few occurrences of `Expr.free_names` from the compiler, with the exception of `compare.ml` and `fexpr_to_flambda.ml`, both of which are only used for tests.  It's unfortunate that those files need to use the function as otherwise we could remove a fair amount of code.  Perhaps in due course we could investigate how to fix this -- we shouldn't block this PR as this is part of #346.  One thing that seems to be needed is the substitution action in `Compare` on `Name_occurrences.t`.  The parser translation code is more complicated; I think this would need to keep track of free symbols and code IDs in the bodies of functions, like `Closure_conversion` does.  (There is no need to keep track of variables or continuations since all we are concerned with is the free names of pieces of `Code`, which are closed with respect to those two varieties of name.)

cc @lukemaurer 