### PR TITLE
WIP: Poison constants

### DIFF
--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -262,6 +262,7 @@ MIDDLE_END_FLAMBDA_TYPES=\
   middle_end/flambda/types/basic/or_bottom.cmo \
   middle_end/flambda/types/basic/string_info.cmo \
   middle_end/flambda/types/basic/or_unknown_or_bottom.cmo \
+  middle_end/flambda/types/basic/or_unknown_or_bottom_or_poison.cmo \
   middle_end/flambda/types/structures/code_age_relation.cmo \
   middle_end/flambda/types/structures/type_structure_intf.cmo \
   middle_end/flambda/types/structures/product_intf.cmo \

--- a/flambdatest/mlexamples/unboxing_need_poison.ml
+++ b/flambdatest/mlexamples/unboxing_need_poison.ml
@@ -8,8 +8,8 @@ let[@inline] f b y z g =
       B (g z)
   in
   match v with
-  | A (_, a) -> a
-  | B c -> c
+  | A (_, a) -> a + 2
+  | B c -> c + 2
 
 let[@inline] g x = 12
 

--- a/flambdatest/mlexamples/unboxing_need_poison.ml
+++ b/flambdatest/mlexamples/unboxing_need_poison.ml
@@ -1,0 +1,17 @@
+type ('a, 'b) t = A of int * 'a | B of 'b
+
+let[@inline] f b y z g =
+  let v =
+    if b then
+      A (42, g y)
+    else
+      B (g z)
+  in
+  match v with
+  | A (_, a) -> a
+  | B c -> c
+
+let[@inline] g x = 12
+
+let test b y z =
+  f b y z g

--- a/middle_end/flambda/basic/reg_width_const.ml
+++ b/middle_end/flambda/basic/reg_width_const.ml
@@ -30,9 +30,15 @@ let kind t =
 
 let of_descr (descr : Descr.t) =
   match descr with
-  | Naked_immediate i -> naked_immediate i
-  | Tagged_immediate i -> tagged_immediate i
-  | Naked_float f -> naked_float f
-  | Naked_int32 i -> naked_int32 i
-  | Naked_int64 i -> naked_int64 i
-  | Naked_nativeint i -> naked_nativeint i
+  | Naked_immediate (Value, i) -> naked_immediate i
+  | Tagged_immediate (Value, i) -> tagged_immediate i
+  | Naked_float (Value, f) -> naked_float f
+  | Naked_int32 (Value, i) -> naked_int32 i
+  | Naked_int64 (Value, i) -> naked_int64 i
+  | Naked_nativeint (Value, i) -> naked_nativeint i
+  | Naked_immediate (Poison, _) -> naked_immediate_poison
+  | Tagged_immediate (Poison, _) -> tagged_immediate_poison
+  | Naked_float (Poison, _) -> naked_float_poison
+  | Naked_int32 (Poison, _) -> naked_int32_poison
+  | Naked_int64 (Poison, _) -> naked_int64_poison
+  | Naked_nativeint (Poison, _) -> naked_nativeint_poison

--- a/middle_end/flambda/basic/reg_width_const.ml
+++ b/middle_end/flambda/basic/reg_width_const.ml
@@ -27,18 +27,27 @@ let kind t =
   | Naked_int32 _ -> K.naked_int32
   | Naked_int64 _ -> K.naked_int64
   | Naked_nativeint _ -> K.naked_nativeint
+  | Poison k -> begin
+      match k with
+      | Naked_immediate -> K.naked_immediate
+      | Value -> K.value
+      | Naked_float -> K.naked_float
+      | Naked_int32 -> K.naked_int32
+      | Naked_int64 -> K.naked_int64
+      | Naked_nativeint -> K.naked_nativeint
+    end
 
 let of_descr (descr : Descr.t) =
   match descr with
-  | Naked_immediate (Value, i) -> naked_immediate i
-  | Tagged_immediate (Value, i) -> tagged_immediate i
-  | Naked_float (Value, f) -> naked_float f
-  | Naked_int32 (Value, i) -> naked_int32 i
-  | Naked_int64 (Value, i) -> naked_int64 i
-  | Naked_nativeint (Value, i) -> naked_nativeint i
-  | Naked_immediate (Poison, _) -> naked_immediate_poison
-  | Tagged_immediate (Poison, _) -> tagged_immediate_poison
-  | Naked_float (Poison, _) -> naked_float_poison
-  | Naked_int32 (Poison, _) -> naked_int32_poison
-  | Naked_int64 (Poison, _) -> naked_int64_poison
-  | Naked_nativeint (Poison, _) -> naked_nativeint_poison
+  | Naked_immediate i -> naked_immediate i
+  | Tagged_immediate i -> tagged_immediate i
+  | Naked_float f -> naked_float f
+  | Naked_int32 i -> naked_int32 i
+  | Naked_int64 i -> naked_int64 i
+  | Naked_nativeint i -> naked_nativeint i
+  | Poison Naked_immediate -> naked_immediate_poison
+  | Poison Value -> value_poison
+  | Poison Naked_float -> naked_float_poison
+  | Poison Naked_int32 -> naked_int32_poison
+  | Poison Naked_int64 -> naked_int64_poison
+  | Poison Naked_nativeint -> naked_nativeint_poison

--- a/middle_end/flambda/compilenv_deps/reg_width_things.ml
+++ b/middle_end/flambda/compilenv_deps/reg_width_things.ml
@@ -49,7 +49,7 @@ module Const_data = struct
           Target_imm.print i
           (Flambda_colours.normal ())
       | Naked_immediate (Poison, i) ->
-        Format.fprintf ppf "@<0>%s#Poison %a@<0>%s"
+        Format.fprintf ppf "@<0>%s#Poison_%a@<0>%s"
           (Flambda_colours.naked_number ())
           Target_imm.print i
           (Flambda_colours.normal ())
@@ -59,7 +59,7 @@ module Const_data = struct
           Target_imm.print i
           (Flambda_colours.normal ())
       | Tagged_immediate (Poison, i) ->
-        Format.fprintf ppf "@<0>%sPoison %a@<0>%s"
+        Format.fprintf ppf "@<0>%sPoison_%a@<0>%s"
           (Flambda_colours.tagged_immediate ())
           Target_imm.print i
           (Flambda_colours.normal ())
@@ -69,7 +69,7 @@ module Const_data = struct
           Numbers.Float_by_bit_pattern.print f
           (Flambda_colours.normal ())
       | Naked_float (Poison, f) ->
-        Format.fprintf ppf "@<0>%s#Poison %a@<0>%s"
+        Format.fprintf ppf "@<0>%s#Poison_%a@<0>%s"
           (Flambda_colours.naked_number ())
           Numbers.Float_by_bit_pattern.print f
           (Flambda_colours.normal ())
@@ -79,7 +79,7 @@ module Const_data = struct
           n
           (Flambda_colours.normal ())
       | Naked_int32 (Poison, n) ->
-        Format.fprintf ppf "@<0>%s#Poison %ldl@<0>%s"
+        Format.fprintf ppf "@<0>%s#Poison_%ldl@<0>%s"
           (Flambda_colours.naked_number ())
           n
           (Flambda_colours.normal ())
@@ -89,7 +89,7 @@ module Const_data = struct
           n
           (Flambda_colours.normal ())
       | Naked_int64 (Poison, n) ->
-        Format.fprintf ppf "@<0>%s#Poison %LdL@<0>%s"
+        Format.fprintf ppf "@<0>%s#Poison_%LdL@<0>%s"
           (Flambda_colours.naked_number ())
           n
           (Flambda_colours.normal ())
@@ -99,7 +99,7 @@ module Const_data = struct
           Targetint.print n
           (Flambda_colours.normal ())
       | Naked_nativeint (Poison, n) ->
-        Format.fprintf ppf "@<0>%s#Poison %an@<0>%s"
+        Format.fprintf ppf "@<0>%s#Poison_%an@<0>%s"
           (Flambda_colours.naked_number ())
           Targetint.print n
           (Flambda_colours.normal ())

--- a/middle_end/flambda/compilenv_deps/reg_width_things.mli
+++ b/middle_end/flambda/compilenv_deps/reg_width_things.mli
@@ -52,19 +52,30 @@ module Const : sig
   val naked_int64 : Int64.t -> t
   val naked_nativeint : Targetint.t -> t
 
+  val naked_immediate_poison : t
+  val tagged_immediate_poison : t
+  val naked_float_poison : t
+  val naked_int32_poison : t
+  val naked_int64_poison : t
+  val naked_nativeint_poison : t
+
   module Descr : sig
+    type is_poison = private Value | Poison
+
     type t = private
-      | Naked_immediate of Target_imm.t
-      | Tagged_immediate of Target_imm.t
-      | Naked_float of Numbers.Float_by_bit_pattern.t
-      | Naked_int32 of Int32.t
-      | Naked_int64 of Int64.t
-      | Naked_nativeint of Targetint.t
+      | Naked_immediate of is_poison * Target_imm.t
+      | Tagged_immediate of is_poison * Target_imm.t
+      | Naked_float of is_poison * Numbers.Float_by_bit_pattern.t
+      | Naked_int32 of is_poison * Int32.t
+      | Naked_int64 of is_poison * Int64.t
+      | Naked_nativeint of is_poison * Targetint.t
 
     include Identifiable.S with type t := t
   end
 
   val descr : t -> Descr.t
+
+  val is_poison : t -> Descr.is_poison
 
   val export : t -> exported
 

--- a/middle_end/flambda/compilenv_deps/reg_width_things.mli
+++ b/middle_end/flambda/compilenv_deps/reg_width_things.mli
@@ -53,29 +53,36 @@ module Const : sig
   val naked_nativeint : Targetint.t -> t
 
   val naked_immediate_poison : t
-  val tagged_immediate_poison : t
+  val value_poison : t
   val naked_float_poison : t
   val naked_int32_poison : t
   val naked_int64_poison : t
   val naked_nativeint_poison : t
 
   module Descr : sig
-    type is_poison = private Value | Poison
+    module Kind : sig
+      type t = private
+        | Value
+        | Naked_immediate
+        | Naked_float
+        | Naked_int32
+        | Naked_int64
+        | Naked_nativeint
+    end
 
-    type t = private
-      | Naked_immediate of is_poison * Target_imm.t
-      | Tagged_immediate of is_poison * Target_imm.t
-      | Naked_float of is_poison * Numbers.Float_by_bit_pattern.t
-      | Naked_int32 of is_poison * Int32.t
-      | Naked_int64 of is_poison * Int64.t
-      | Naked_nativeint of is_poison * Targetint.t
+  type t = private
+    | Naked_immediate of Target_imm.t
+    | Tagged_immediate of Target_imm.t
+    | Naked_float of Numbers.Float_by_bit_pattern.t
+    | Naked_int32 of Int32.t
+    | Naked_int64 of Int64.t
+    | Naked_nativeint of Targetint.t
+    | Poison of Kind.t
 
     include Identifiable.S with type t := t
   end
 
   val descr : t -> Descr.t
-
-  val is_poison : t -> Descr.is_poison
 
   val export : t -> exported
 

--- a/middle_end/flambda/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda/parser/flambda_to_fexpr.ml
@@ -260,24 +260,24 @@ let name env n =
 
 let const c : Fexpr.const =
   match Reg_width_things.Const.descr c with
-  | Naked_immediate (Value, imm) ->
+  | Naked_immediate imm ->
     Naked_immediate (imm |> Target_imm.to_targetint' |> Targetint.to_string)
-  | Tagged_immediate (Value, imm) ->
+  | Tagged_immediate imm ->
     Tagged_immediate (imm |> Target_imm.to_targetint' |> Targetint.to_string)
-  | Naked_float (Value, f) ->
+  | Naked_float f ->
     Naked_float (f |> Numbers.Float_by_bit_pattern.to_float)
-  | Naked_int32 (Value, i) ->
+  | Naked_int32 i ->
     Naked_int32 i
-  | Naked_int64 (Value, i) ->
+  | Naked_int64 i ->
     Naked_int64 i
-  | Naked_nativeint (Value, i) ->
+  | Naked_nativeint i ->
     Naked_nativeint (i |> Targetint.to_int64)
-  | Naked_immediate (Poison, _)
-  | Tagged_immediate (Poison, _)
-  | Naked_float (Poison, _)
-  | Naked_int32 (Poison, _)
-  | Naked_int64 (Poison, _)
-  | Naked_nativeint (Poison, _) ->
+  | Poison Naked_immediate
+  | Poison Value
+  | Poison Naked_float
+  | Poison Naked_int32
+  | Poison Naked_int64
+  | Poison Naked_nativeint ->
     Misc.fatal_errorf "TODO: Poison constants"
 
 let simple env s =

--- a/middle_end/flambda/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda/parser/flambda_to_fexpr.ml
@@ -260,18 +260,25 @@ let name env n =
 
 let const c : Fexpr.const =
   match Reg_width_things.Const.descr c with
-  | Naked_immediate imm ->
+  | Naked_immediate (Value, imm) ->
     Naked_immediate (imm |> Target_imm.to_targetint' |> Targetint.to_string)
-  | Tagged_immediate imm ->
+  | Tagged_immediate (Value, imm) ->
     Tagged_immediate (imm |> Target_imm.to_targetint' |> Targetint.to_string)
-  | Naked_float f ->
+  | Naked_float (Value, f) ->
     Naked_float (f |> Numbers.Float_by_bit_pattern.to_float)
-  | Naked_int32 i ->
+  | Naked_int32 (Value, i) ->
     Naked_int32 i
-  | Naked_int64 i ->
+  | Naked_int64 (Value, i) ->
     Naked_int64 i
-  | Naked_nativeint i ->
+  | Naked_nativeint (Value, i) ->
     Naked_nativeint (i |> Targetint.to_int64)
+  | Naked_immediate (Poison, _)
+  | Tagged_immediate (Poison, _)
+  | Naked_float (Poison, _)
+  | Naked_int32 (Poison, _)
+  | Naked_int64 (Poison, _)
+  | Naked_nativeint (Poison, _) ->
+    Misc.fatal_errorf "TODO: Poison constants"
 
 let simple env s =
   Simple.pattern_match s

--- a/middle_end/flambda/simplify/simplify_named.ml
+++ b/middle_end/flambda/simplify/simplify_named.ml
@@ -71,7 +71,8 @@ let record_any_symbol_projection dacc (defining_expr : Simplified_named.t)
         Simple.pattern_match index
           ~const:(fun const ->
             match Reg_width_const.descr const with
-            | Tagged_immediate (_, imm) ->
+            | Poison Value -> None
+            | Tagged_immediate imm ->
               Simple.pattern_match' block
                 ~const:(fun _ -> None)
                 ~symbol:(fun symbol_projected_from ->
@@ -80,7 +81,9 @@ let record_any_symbol_projection dacc (defining_expr : Simplified_named.t)
                     (SP.Projection.block_load ~index)))
                 ~var:(fun _ -> None)
             | Naked_immediate _ | Naked_float _
-            | Naked_int32 _ | Naked_int64 _ | Naked_nativeint _ ->
+            | Naked_int32 _ | Naked_int64 _ | Naked_nativeint _
+            | Poison ( Naked_immediate | Naked_float | Naked_int32
+              | Naked_int64 | Naked_nativeint )->
               Misc.fatal_errorf "Kind error for [Block_load] index:@ \
                   %a@ =@ %a"
                 Bindable_let_bound.print bindable_let_bound

--- a/middle_end/flambda/simplify/simplify_named.ml
+++ b/middle_end/flambda/simplify/simplify_named.ml
@@ -71,7 +71,7 @@ let record_any_symbol_projection dacc (defining_expr : Simplified_named.t)
         Simple.pattern_match index
           ~const:(fun const ->
             match Reg_width_const.descr const with
-            | Tagged_immediate imm ->
+            | Tagged_immediate (_, imm) ->
               Simple.pattern_match' block
                 ~const:(fun _ -> None)
                 ~symbol:(fun symbol_projected_from ->

--- a/middle_end/flambda/simplify/simplify_static_const.ml
+++ b/middle_end/flambda/simplify/simplify_static_const.ml
@@ -41,12 +41,14 @@ let simplify_field_of_block dacc (field : Field_of_block.t) =
             ~symbol:(fun sym -> Field_of_block.Symbol sym, ty))
         ~const:(fun const ->
           match Reg_width_const.descr const with
-          | Tagged_immediate (Value, imm) -> Field_of_block.Tagged_immediate imm, ty
-          | Tagged_immediate (Poison, _) ->
+          | Tagged_immediate imm -> Field_of_block.Tagged_immediate imm, ty
+          | Poison Value ->
             (* CR pchambart: This should be "invalid" and propagate up *)
             field, T.bottom K.value
           | Naked_immediate _ | Naked_float _ | Naked_int32 _
-              | Naked_int64 _ | Naked_nativeint _ ->
+              | Naked_int64 _ | Naked_nativeint _
+              | Poison ( Naked_immediate | Naked_float | Naked_int32
+                | Naked_int64 | Naked_nativeint ) ->
             (* CR mshinwell: This should be "invalid" and propagate up *)
             field, ty)
 

--- a/middle_end/flambda/simplify/simplify_static_const.ml
+++ b/middle_end/flambda/simplify/simplify_static_const.ml
@@ -41,7 +41,10 @@ let simplify_field_of_block dacc (field : Field_of_block.t) =
             ~symbol:(fun sym -> Field_of_block.Symbol sym, ty))
         ~const:(fun const ->
           match Reg_width_const.descr const with
-          | Tagged_immediate imm -> Field_of_block.Tagged_immediate imm, ty
+          | Tagged_immediate (Value, imm) -> Field_of_block.Tagged_immediate imm, ty
+          | Tagged_immediate (Poison, _) ->
+            (* CR pchambart: This should be "invalid" and propagate up *)
+            field, T.bottom K.value
           | Naked_immediate _ | Naked_float _ | Naked_int32 _
               | Naked_int64 _ | Naked_nativeint _ ->
             (* CR mshinwell: This should be "invalid" and propagate up *)

--- a/middle_end/flambda/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda/simplify/simplify_switch_expr.ml
@@ -82,7 +82,7 @@ let rebuild_switch ~simplify_let dacc ~arms ~scrutinee ~scrutinee_ty uacc
               *)
               let [@inline always] const arg =
                 match Reg_width_const.descr arg with
-                | Tagged_immediate (_, arg) ->
+                | Tagged_immediate arg ->
                   if Target_imm.equal arm arg then
                     let identity_arms =
                       Target_imm.Map.add arm action identity_arms
@@ -99,6 +99,7 @@ let rebuild_switch ~simplify_let dacc ~arms ~scrutinee ~scrutinee_ty uacc
                     normal_case ~identity_arms ~not_arms
                   else
                     normal_case ~identity_arms ~not_arms
+                | Poison _
                 | Naked_immediate _ | Naked_float _ | Naked_int32 _
                 | Naked_int64 _ | Naked_nativeint _ ->
                   normal_case ~identity_arms ~not_arms

--- a/middle_end/flambda/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda/simplify/simplify_switch_expr.ml
@@ -82,7 +82,7 @@ let rebuild_switch ~simplify_let dacc ~arms ~scrutinee ~scrutinee_ty uacc
               *)
               let [@inline always] const arg =
                 match Reg_width_const.descr arg with
-                | Tagged_immediate arg ->
+                | Tagged_immediate (_, arg) ->
                   if Target_imm.equal arm arg then
                     let identity_arms =
                       Target_imm.Map.add arm action identity_arms

--- a/middle_end/flambda/to_cmm/un_cps.ml
+++ b/middle_end/flambda/to_cmm/un_cps.ml
@@ -75,15 +75,24 @@ let targetint_of_imm i = Targetint.OCaml.to_targetint i.Target_imm.value
 
 let const _env cst =
   match Reg_width_const.descr cst with
-  | Naked_immediate (_, i) ->
+  | Naked_immediate i ->
     C.targetint (targetint_of_imm i)
-  | Tagged_immediate (_, i) ->
+  | Poison Naked_immediate ->
+    C.targetint (targetint_of_imm Target_imm.zero)
+  | Tagged_immediate i ->
     C.targetint (tag_targetint (targetint_of_imm i))
-  | Naked_float (_, f) ->
+  | Poison Value ->
+    C.targetint (tag_targetint (targetint_of_imm Target_imm.zero))
+  | Naked_float f ->
     C.float (Numbers.Float_by_bit_pattern.to_float f)
-  | Naked_int32 (_, i) -> C.int32 i
-  | Naked_int64 (_, i) -> C.int64 i
-  | Naked_nativeint (_, t) -> C.targetint t
+  | Poison Naked_float ->
+    C.float 0.
+  | Naked_int32 i -> C.int32 i
+  | Poison Naked_int32 -> C.int32 0l
+  | Naked_int64 i -> C.int64 i
+  | Poison Naked_int64 -> C.int64 0L
+  | Naked_nativeint t -> C.targetint t
+  | Poison Naked_nativeint -> C.targetint Targetint.zero
 
 let default_of_kind (k : Flambda_kind.t) =
   match k with

--- a/middle_end/flambda/to_cmm/un_cps.ml
+++ b/middle_end/flambda/to_cmm/un_cps.ml
@@ -75,15 +75,15 @@ let targetint_of_imm i = Targetint.OCaml.to_targetint i.Target_imm.value
 
 let const _env cst =
   match Reg_width_const.descr cst with
-  | Naked_immediate i ->
+  | Naked_immediate (_, i) ->
     C.targetint (targetint_of_imm i)
-  | Tagged_immediate i ->
+  | Tagged_immediate (_, i) ->
     C.targetint (tag_targetint (targetint_of_imm i))
-  | Naked_float f ->
+  | Naked_float (_, f) ->
     C.float (Numbers.Float_by_bit_pattern.to_float f)
-  | Naked_int32 i -> C.int32 i
-  | Naked_int64 i -> C.int64 i
-  | Naked_nativeint t -> C.targetint t
+  | Naked_int32 (_, i) -> C.int32 i
+  | Naked_int64 (_, i) -> C.int64 i
+  | Naked_nativeint (_, t) -> C.targetint t
 
 let default_of_kind (k : Flambda_kind.t) =
   match k with

--- a/middle_end/flambda/to_cmm/un_cps_static.ml
+++ b/middle_end/flambda/to_cmm/un_cps_static.ml
@@ -55,18 +55,18 @@ let name_static env name =
 
 let const_static _env cst =
   match Reg_width_const.descr cst with
-  | Naked_immediate i ->
+  | Naked_immediate (_, i) ->
       [C.cint (nativeint_of_targetint (targetint_of_imm i))]
-  | Tagged_immediate i ->
+  | Tagged_immediate (_, i) ->
       [C.cint (nativeint_of_targetint (tag_targetint (targetint_of_imm i)))]
-  | Naked_float f ->
+  | Naked_float (_, f) ->
       [C.cfloat (Numbers.Float_by_bit_pattern.to_float f)]
-  | Naked_int32 i ->
+  | Naked_int32 (_, i) ->
       [C.cint (Nativeint.of_int32 i)]
-  | Naked_int64 i ->
+  | Naked_int64 (_, i) ->
       if C.arch32 then todo() (* split int64 on 32-bit archs *)
       else [C.cint (Int64.to_nativeint i)]
-  | Naked_nativeint t ->
+  | Naked_nativeint (_, t) ->
       [C.cint (nativeint_of_targetint t)]
 
 let simple_static env s =

--- a/middle_end/flambda/types/basic/or_unknown_or_bottom_or_poison.ml
+++ b/middle_end/flambda/types/basic/or_unknown_or_bottom_or_poison.ml
@@ -1,0 +1,64 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Pierre Chambart, OCamlPro                        *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2018 OCamlPro SAS                                          *)
+(*   Copyright 2018 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type 'a t =
+  | Unknown
+  | Ok of 'a
+  | Poison
+  | Bottom
+
+let print f ppf t =
+  match t with
+  | Unknown -> Format.pp_print_string ppf "Unknown"
+  | Ok contents -> Format.fprintf ppf "@[(Ok %a)@]" f contents
+  | Poison -> Format.pp_print_string ppf "Poison"
+  | Bottom -> Format.pp_print_string ppf "Bottom"
+
+let equal eq_contents t1 t2 =
+  match t1, t2 with
+  | Unknown, Unknown -> true
+  | Ok contents1, Ok contents2 -> eq_contents contents1 contents2
+  | Bottom, Bottom -> true
+  | Poison, Poison -> true
+  | (Unknown | Ok _ | Poison | Bottom), _ -> false
+
+let map t ~f =
+  match t with
+  | Unknown -> Unknown
+  | Bottom -> Bottom
+  | Poison -> Poison
+  | Ok contents -> Ok (f contents)
+
+let map_sharing t ~f =
+  match t with
+  | Unknown | Bottom | Poison -> t
+  | Ok contents ->
+    let contents' = f contents in
+    if contents == contents' then t
+    else Ok contents'
+
+let of_or_unknown (unk : _ Or_unknown.t) : _ t =
+  match unk with
+  | Known contents -> Ok contents
+  | Unknown -> Unknown
+
+let of_or_unknown_or_bottom (unk : _ Or_unknown_or_bottom.t) : _ t =
+  match unk with
+  | Ok contents -> Ok contents
+  | Unknown -> Unknown
+  | Bottom -> Bottom

--- a/middle_end/flambda/types/basic/or_unknown_or_bottom_or_poison.mli
+++ b/middle_end/flambda/types/basic/or_unknown_or_bottom_or_poison.mli
@@ -1,0 +1,39 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Pierre Chambart, OCamlPro                        *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2018 OCamlPro SAS                                          *)
+(*   Copyright 2018 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+type 'a t =
+  | Unknown
+  | Ok of 'a
+  | Poison
+  | Bottom
+
+val print
+   : (Format.formatter -> 'a -> unit)
+  -> Format.formatter
+  -> 'a t
+  -> unit
+
+val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+
+val map : 'a t -> f:('a -> 'b) -> 'b t
+
+val map_sharing : 'a t -> f:('a -> 'a) -> 'a t
+
+val of_or_unknown : 'a Or_unknown.t -> 'a t
+
+val of_or_unknown_or_bottom : 'a Or_unknown_or_bottom.t -> 'a t

--- a/middle_end/flambda/types/flambda_type.mli
+++ b/middle_end/flambda/types/flambda_type.mli
@@ -291,6 +291,12 @@ val bottom : Flambda_kind.t -> t
 (** Construct a top ("unknown") type of the given kind. *)
 val unknown : Flambda_kind.t -> t
 
+(** Construct a poison type of the given kind.
+    Poison behaves like bottom, but presence of a type poison
+    in an environment doesn't make the environment bottom.
+    expand_head on poison is bottom. *)
+val poison : Flambda_kind.t -> t
+
 val unknown_with_subkind : Flambda_kind.With_subkind.t -> t
 
 (** Create an bottom type with the same kind as the given type. *)

--- a/middle_end/flambda/types/template/flambda_type.templ.ml
+++ b/middle_end/flambda/types/template/flambda_type.templ.ml
@@ -132,7 +132,7 @@ let prove_equals_to_var_or_symbol_or_tagged_immediate env t
     Simple.pattern_match simple
       ~const:(fun cst : _ proof ->
         match Reg_width_const.descr cst with
-        | Tagged_immediate imm -> Proved (Tagged_immediate imm)
+        | Tagged_immediate (_, imm) -> Proved (Tagged_immediate imm)
         | _ ->
           Misc.fatal_errorf "[Simple] %a in the [Equals] field has a kind \
               different from that returned by [kind] (%a):@ %a"
@@ -152,7 +152,7 @@ let prove_equals_to_var_or_symbol_or_tagged_immediate env t
           Simple.pattern_match simple
             ~const:(fun cst : _ proof ->
               match Reg_width_const.descr cst with
-              | Tagged_immediate imm -> Proved (Tagged_immediate imm)
+              | Tagged_immediate (_, imm) -> Proved (Tagged_immediate imm)
               | _ ->
                 let kind = kind t in
                 Misc.fatal_errorf "Kind returned by [get_canonical_simple] (%a) \
@@ -213,7 +213,8 @@ let prove_naked_floats env t : _ proof =
     Misc.fatal_errorf "Kind error: expected [Naked_float]:@ %a" print t
   in
   match expand_head t env with
-  | Const (Naked_float f) -> Proved (Float.Set.singleton f)
+  | Const (Naked_float (Value, f)) -> Proved (Float.Set.singleton f)
+  | Const (Naked_float (Poison, _)) -> Invalid
   | Const (Naked_immediate _ | Tagged_immediate _ | Naked_int32 _
     | Naked_int64 _ | Naked_nativeint _) -> wrong_kind ()
   | Naked_float (Ok fs) ->
@@ -232,7 +233,8 @@ let prove_naked_int32s env t : _ proof =
     Misc.fatal_errorf "Kind error: expected [Naked_int32]:@ %a" print t
   in
   match expand_head t env with
-  | Const (Naked_int32 i) -> Proved (Int32.Set.singleton i)
+  | Const (Naked_int32 (Value, i)) -> Proved (Int32.Set.singleton i)
+  | Const (Naked_int32 (Poison, _)) -> Invalid
   | Const (Naked_immediate _ | Tagged_immediate _ | Naked_float _
     | Naked_int64 _ | Naked_nativeint _) -> wrong_kind ()
   | Naked_int32 (Ok is) ->
@@ -251,7 +253,8 @@ let prove_naked_int64s env t : _ proof =
     Misc.fatal_errorf "Kind error: expected [Naked_int64]:@ %a" print t
   in
   match expand_head t env with
-  | Const (Naked_int64 i) -> Proved (Int64.Set.singleton i)
+  | Const (Naked_int64 (Value, i)) -> Proved (Int64.Set.singleton i)
+  | Const (Naked_int64 (Poison, _)) -> Invalid
   | Const (Naked_immediate _ | Tagged_immediate _ | Naked_float _
     | Naked_int32 _ | Naked_nativeint _) -> wrong_kind ()
   | Naked_int64 (Ok is) ->
@@ -270,7 +273,8 @@ let prove_naked_nativeints env t : _ proof =
     Misc.fatal_errorf "Kind error: expected [Naked_nativeint]:@ %a" print t
   in
   match expand_head t env with
-  | Const (Naked_nativeint i) -> Proved (Targetint.Set.singleton i)
+  | Const (Naked_nativeint (Value, i)) -> Proved (Targetint.Set.singleton i)
+  | Const (Naked_nativeint (Poison, _)) -> Invalid
   | Const (Naked_immediate _ | Tagged_immediate _ | Naked_float _
     | Naked_int32 _ | Naked_int64 _) -> wrong_kind ()
   | Naked_nativeint (Ok is) ->
@@ -373,7 +377,8 @@ let prove_naked_immediates env t : Target_imm.Set.t proof =
     Misc.fatal_errorf "Kind error: expected [Naked_immediate]:@ %a" print t
   in
   match expand_head t env with
-  | Const (Naked_immediate i) -> Proved (Target_imm.Set.singleton i)
+  | Const (Naked_immediate (Value, i)) -> Proved (Target_imm.Set.singleton i)
+  | Const (Naked_immediate (Poison, _)) -> Invalid
   | Const (Tagged_immediate _ | Naked_float _ | Naked_int32 _
     | Naked_int64 _ | Naked_nativeint _) -> wrong_kind ()
   | Naked_immediate (Ok (Naked_immediates is)) ->
@@ -417,7 +422,8 @@ let prove_equals_tagged_immediates env t : Target_imm.Set.t proof =
     Misc.fatal_errorf "Kind error: expected [Value]:@ %a" print t
   in
   match expand_head t env with
-  | Const (Tagged_immediate imm) -> Proved (Target_imm.Set.singleton imm)
+  | Const (Tagged_immediate (Value, imm)) -> Proved (Target_imm.Set.singleton imm)
+  | Const (Tagged_immediate (Poison, _)) -> Invalid
   | Const (Naked_immediate _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
     | Naked_nativeint _) -> wrong_kind ()
   | Value (Ok (Variant blocks_imms)) ->

--- a/middle_end/flambda/types/template/flambda_type.templ.ml
+++ b/middle_end/flambda/types/template/flambda_type.templ.ml
@@ -293,7 +293,8 @@ let prove_is_int env t : bool proof =
     Misc.fatal_errorf "Kind error: expected [Value]:@ %a" print t
   in
   match expand_head t env with
-  | Const (Tagged_immediate _) -> Proved true
+  | Const (Tagged_immediate (Value, _)) -> Proved true
+  | Const (Tagged_immediate (Poison, _)) -> Invalid
   | Const _ -> wrong_kind ()
   | Value (Ok (Variant blocks_imms)) ->
     begin match blocks_imms.blocks, blocks_imms.immediates with
@@ -323,7 +324,8 @@ let prove_tags_must_be_a_block env t : Tag.Set.t proof =
     Misc.fatal_errorf "Kind error: expected [Value]:@ %a" print t
   in
   match expand_head t env with
-  | Const (Tagged_immediate _) -> Unknown
+  | Const (Tagged_immediate (Value, _)) -> Unknown
+  | Const (Tagged_immediate (Poison, _)) -> Invalid
   | Const _ -> wrong_kind ()
   | Value (Ok (Variant blocks_imms)) ->
     begin match blocks_imms.immediates with

--- a/middle_end/flambda/types/type_descr.rec.ml
+++ b/middle_end/flambda/types/type_descr.rec.ml
@@ -163,12 +163,12 @@ module Make (Head : Type_head_intf.S
         let [@inline always] const const =
           let typ =
             match Reg_width_const.descr const with
-            | Naked_immediate i -> T.this_naked_immediate_without_alias i
-            | Tagged_immediate i -> T.this_tagged_immediate_without_alias i
-            | Naked_float f -> T.this_naked_float_without_alias f
-            | Naked_int32 i -> T.this_naked_int32_without_alias i
-            | Naked_int64 i -> T.this_naked_int64_without_alias i
-            | Naked_nativeint i -> T.this_naked_nativeint_without_alias i
+            | Naked_immediate (_, i) -> T.this_naked_immediate_without_alias i
+            | Tagged_immediate (_, i) -> T.this_tagged_immediate_without_alias i
+            | Naked_float (_, f) -> T.this_naked_float_without_alias f
+            | Naked_int32 (_, i) -> T.this_naked_int32_without_alias i
+            | Naked_int64 (_, i) -> T.this_naked_int64_without_alias i
+            | Naked_nativeint (_, i) -> T.this_naked_nativeint_without_alias i
           in
           force_to_head ~force_to_kind typ
         in

--- a/middle_end/flambda/types/type_descr.rec.ml
+++ b/middle_end/flambda/types/type_descr.rec.ml
@@ -191,18 +191,18 @@ module Make (Head : Type_head_intf.S
         let [@inline always] const const : _ Or_unknown_or_bottom.t =
           let typ =
             match Reg_width_const.descr const with
-            | Naked_immediate (Poison, _) -> T.poison_naked_immediate ()
-            | Naked_immediate (Value, i) -> T.this_naked_immediate_without_alias i
-            | Tagged_immediate (Poison, _) -> T.poison_value ()
-            | Tagged_immediate (Value, i) -> T.this_tagged_immediate_without_alias i
-            | Naked_float (Poison, _) -> T.poison_naked_float ()
-            | Naked_float (Value, f) -> T.this_naked_float_without_alias f
-            | Naked_int32 (Poison, _) -> T.poison_naked_int32 ()
-            | Naked_int32 (Value, i) -> T.this_naked_int32_without_alias i
-            | Naked_int64 (Poison, _) -> T.poison_naked_int64 ()
-            | Naked_int64 (Value, i) -> T.this_naked_int64_without_alias i
-            | Naked_nativeint (Poison, _) -> T.poison_naked_nativeint ()
-            | Naked_nativeint (Value, i) -> T.this_naked_nativeint_without_alias i
+            | Naked_immediate i -> T.this_naked_immediate_without_alias i
+            | Tagged_immediate i -> T.this_tagged_immediate_without_alias i
+            | Naked_float f -> T.this_naked_float_without_alias f
+            | Naked_int32 i -> T.this_naked_int32_without_alias i
+            | Naked_int64 i -> T.this_naked_int64_without_alias i
+            | Naked_nativeint i -> T.this_naked_nativeint_without_alias i
+            | Poison Naked_immediate -> T.poison_naked_immediate ()
+            | Poison Value -> T.poison_value ()
+            | Poison Naked_float -> T.poison_naked_float ()
+            | Poison Naked_int32 -> T.poison_naked_int32 ()
+            | Poison Naked_int64 -> T.poison_naked_int64 ()
+            | Poison Naked_nativeint -> T.poison_naked_nativeint ()
           in
           force_to_head ~force_to_kind typ
         in

--- a/middle_end/flambda/types/type_descr_intf.ml
+++ b/middle_end/flambda/types/type_descr_intf.ml
@@ -27,7 +27,7 @@ module type S = sig
 
   module Descr : sig
     type t = private
-      | No_alias of head Or_unknown_or_bottom.t
+      | No_alias of head Or_unknown_or_bottom_or_poison.t
         (** For each kind there is a lattice of types.
             Unknown = "Any value can flow to this point": the top element.
             Bottom = "No value can flow to this point": the least element.
@@ -48,6 +48,7 @@ module type S = sig
 
   val unknown : unit -> t
   val bottom : unit -> t
+  val poison : unit -> t
 
   val descr : t -> Descr.t
 

--- a/middle_end/flambda/types/type_grammar.rec.ml
+++ b/middle_end/flambda/types/type_grammar.rec.ml
@@ -721,18 +721,18 @@ let array_of_length ~length =
 
 let type_for_const const =
   match Reg_width_const.descr const with
-  | Naked_immediate (Poison, _) -> poison_naked_immediate ()
-  | Naked_immediate (Value, i) -> this_naked_immediate i
-  | Tagged_immediate (Poison, _) -> poison_value ()
-  | Tagged_immediate (Value, i) -> this_tagged_immediate i
-  | Naked_float (Poison, _) -> poison_naked_float ()
-  | Naked_float (Value, f) -> this_naked_float f
-  | Naked_int32 (Poison, _) -> poison_naked_int32 ()
-  | Naked_int32 (Value, n) -> this_naked_int32 n
-  | Naked_int64 (Poison, _) -> poison_naked_int64 ()
-  | Naked_int64 (Value, n) -> this_naked_int64 n
-  | Naked_nativeint (Poison, _) -> poison_naked_nativeint ()
-  | Naked_nativeint (Value, n) -> this_naked_nativeint n
+  | Naked_immediate i -> this_naked_immediate i
+  | Tagged_immediate i -> this_tagged_immediate i
+  | Naked_float f -> this_naked_float f
+  | Naked_int32 n -> this_naked_int32 n
+  | Naked_int64 n -> this_naked_int64 n
+  | Naked_nativeint n -> this_naked_nativeint n
+  | Poison Naked_immediate -> poison_naked_immediate ()
+  | Poison Value -> poison_value ()
+  | Poison Naked_float -> poison_naked_float ()
+  | Poison Naked_int32 -> poison_naked_int32 ()
+  | Poison Naked_int64 -> poison_naked_int64 ()
+  | Poison Naked_nativeint -> poison_naked_nativeint ()
 
 let kind_for_const const = kind (type_for_const const)
 

--- a/middle_end/flambda/types/type_grammar.rec.ml
+++ b/middle_end/flambda/types/type_grammar.rec.ml
@@ -704,12 +704,12 @@ let array_of_length ~length =
 
 let type_for_const const =
   match Reg_width_const.descr const with
-  | Naked_immediate i -> this_naked_immediate i
-  | Tagged_immediate i -> this_tagged_immediate i
-  | Naked_float f -> this_naked_float f
-  | Naked_int32 n -> this_naked_int32 n
-  | Naked_int64 n -> this_naked_int64 n
-  | Naked_nativeint n -> this_naked_nativeint n
+  | Naked_immediate (_, i) -> this_naked_immediate i
+  | Tagged_immediate (_, i) -> this_tagged_immediate i
+  | Naked_float (_, f) -> this_naked_float f
+  | Naked_int32 (_, n) -> this_naked_int32 n
+  | Naked_int64 (_, n) -> this_naked_int64 n
+  | Naked_nativeint (_, n) -> this_naked_nativeint n
 
 let kind_for_const const = kind (type_for_const const)
 

--- a/middle_end/flambda/types/type_grammar.rec.mli
+++ b/middle_end/flambda/types/type_grammar.rec.mli
@@ -54,6 +54,8 @@ val bottom_like : t -> t
 val unknown : Flambda_kind.t -> t
 val unknown_like : t -> t
 
+val poison : Flambda_kind.t -> t
+
 val any_value : unit -> t
 
 val any_tagged_immediate : unit -> t
@@ -69,6 +71,13 @@ val any_naked_float : unit -> t
 val any_naked_int32 : unit -> t
 val any_naked_int64 : unit -> t
 val any_naked_nativeint : unit -> t
+
+val poison_value : unit -> t
+val poison_naked_immediate : unit -> t
+val poison_naked_float : unit -> t
+val poison_naked_int32 : unit -> t
+val poison_naked_int64 : unit -> t
+val poison_naked_nativeint : unit -> t
 
 val this_tagged_immediate : Target_imm.t -> t
 val this_boxed_float : Numbers.Float_by_bit_pattern.t -> t

--- a/middle_end/flambda/unboxing/unbox_continuation_params.ml
+++ b/middle_end/flambda/unboxing/unbox_continuation_params.ml
@@ -598,7 +598,7 @@ struct
     | Is_int
     | Tag ->
       (* These arguments are filled in later via [project_field]. *)
-      Some Simple.untagged_const_zero
+      Some (Simple.const Reg_width_const.naked_immediate_poison)
     | Const_ctor ->
       begin match use_info with
       | Const_ctor ->
@@ -609,7 +609,7 @@ struct
       | Block _ ->
         (* There are no constant constructors in the variant at the use site.
            We provide a dummy value. *)
-        Some Simple.untagged_const_zero
+        Some (Simple.const Reg_width_const.tagged_immediate_poison)
       end
     | Field { index; } ->
       begin match use_info with
@@ -622,12 +622,12 @@ struct
           (* If the argument at the use is known to be a block, but it has
              fewer fields than the maximum number of fields for the variant,
              then we provide a dummy value. *)
-          Some Simple.const_zero
+          Some (Simple.const Reg_width_const.tagged_immediate_poison)
         end
       | Const_ctor ->
         (* There are no blocks in the variant at the use site.  We again
            provide a dummy value. *)
-        Some Simple.const_zero
+        Some (Simple.const Reg_width_const.tagged_immediate_poison)
       end
 
   let make_boxed_value variant ~param_being_unboxed ~new_params ~fields =
@@ -735,10 +735,10 @@ struct
       end
     | Field { index; } ->
       match use_info with
-      | Const_ctor -> Simple Simple.const_zero
+      | Const_ctor -> Simple (Simple.const Reg_width_const.tagged_immediate_poison)
       | Block { tag = _; size = size_at_use; } ->
         if Targetint.OCaml.compare index size_at_use >= 0 then
-          Simple Simple.const_zero
+          Simple (Simple.const Reg_width_const.tagged_immediate_poison)
         else
           Default_behaviour No_untagging
 end

--- a/middle_end/flambda/unboxing/unbox_continuation_params.ml
+++ b/middle_end/flambda/unboxing/unbox_continuation_params.ml
@@ -609,7 +609,7 @@ struct
       | Block _ ->
         (* There are no constant constructors in the variant at the use site.
            We provide a dummy value. *)
-        Some (Simple.const Reg_width_const.tagged_immediate_poison)
+        Some (Simple.const Reg_width_const.value_poison)
       end
     | Field { index; } ->
       begin match use_info with
@@ -622,12 +622,12 @@ struct
           (* If the argument at the use is known to be a block, but it has
              fewer fields than the maximum number of fields for the variant,
              then we provide a dummy value. *)
-          Some (Simple.const Reg_width_const.tagged_immediate_poison)
+          Some (Simple.const Reg_width_const.value_poison)
         end
       | Const_ctor ->
         (* There are no blocks in the variant at the use site.  We again
            provide a dummy value. *)
-        Some (Simple.const Reg_width_const.tagged_immediate_poison)
+        Some (Simple.const Reg_width_const.value_poison)
       end
 
   let make_boxed_value variant ~param_being_unboxed ~new_params ~fields =
@@ -735,10 +735,10 @@ struct
       end
     | Field { index; } ->
       match use_info with
-      | Const_ctor -> Simple (Simple.const Reg_width_const.tagged_immediate_poison)
+      | Const_ctor -> Simple (Simple.const Reg_width_const.value_poison)
       | Block { tag = _; size = size_at_use; } ->
         if Targetint.OCaml.compare index size_at_use >= 0 then
-          Simple (Simple.const Reg_width_const.tagged_immediate_poison)
+          Simple (Simple.const Reg_width_const.value_poison)
         else
           Default_behaviour No_untagging
 end


### PR DESCRIPTION
This is a first attempt of adding poison constants to flambda to represent arguments present in a branch and not in an other. This can arise from unboxing. For instance an example where this matter is: (it has to be compiled with `-flambda-expert-max-inlining-depth 2`)
```OCaml
type ('a, 'b) t = A of int * 'a | B of 'b

let[@inline] f b y z g =
  let v =
    if b then
      A (42, g y)
    else
      B (g z)
  in
  match v with
  | A (_, a) -> a
  | B c -> c

let[@inline] g x = 12

let test b y z =
  f b y z g
```

The `f` function is analysed twice: once for definition, and a second time when inlining.
The first time the variant is correctly unboxed and all is well. And the branches of the switch ends in:
```
      k11: apply_cont k7 apply_result/214 42 #0)
      k9: apply_cont k7 0 apply_result/215 #1)
```

But the second time, the branches join the apply_result/214 and 0 and apply_result/215 and 42.
For the first round this was not a problem because the typing environment was 'hand built' by
unbox_continuation_param which didn't do that join. But the second round can't do that. Hence the
result can't be optimized when the `g` function is inlined

In that case the 0 is replaced by a Poison constant.

A Poison constant is a new kind of constants of type Poison that is somewhat
equivalent to bottom, but not really. It is ok to have a variable of type poison in the environment,
but using its value turns into bottom. This is done by `expand_head`.

That way the join of the poison and `12` here is `12` which allows to propagate things further.

It is not the case right now, but poison constants can also be used to track undefined variables during
Un_cps that would allow some parameter sharing. 