### PR TITLE
Fix float comparison with nan

### DIFF
--- a/middle_end/flambda/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda/simplify/simplify_binary_primitive.ml
@@ -781,36 +781,28 @@ end = struct
       let has_nan = F.is_any_nan n1 || F.is_any_nan n2 in
       let bool b = Target_imm.bool b in
       begin match op with
-      | Eq ->
-        if has_nan then
-          Some (bool false)
-        else
-          Some (bool (F.IEEE_semantics.equal n1 n2))
-      | Neq ->
-        if has_nan then
-          Some (bool true)
-        else
-        Some (bool (not (F.IEEE_semantics.equal n1 n2)))
+      | Eq -> Some (bool (F.IEEE_semantics.equal n1 n2))
+      | Neq -> Some (bool (not (F.IEEE_semantics.equal n1 n2)))
       | Lt ->
         if has_nan then
           Some (bool false)
         else
-        Some (bool (F.IEEE_semantics.compare n1 n2 < 0))
+          Some (bool (F.IEEE_semantics.compare n1 n2 < 0))
       | Gt ->
         if has_nan then
           Some (bool false)
         else
-        Some (bool (F.IEEE_semantics.compare n1 n2 > 0))
+          Some (bool (F.IEEE_semantics.compare n1 n2 > 0))
       | Le ->
         if has_nan then
           Some (bool false)
         else
-        Some (bool (F.IEEE_semantics.compare n1 n2 <= 0))
+          Some (bool (F.IEEE_semantics.compare n1 n2 <= 0))
       | Ge ->
         if has_nan then
           Some (bool false)
         else
-        Some (bool (F.IEEE_semantics.compare n1 n2 >= 0))
+          Some (bool (F.IEEE_semantics.compare n1 n2 >= 0))
       end
     | Yielding_int_like_compare_functions ->
       let int i = Target_imm.int (Targetint.OCaml.of_int i) in
@@ -820,7 +812,6 @@ end = struct
       else Some (int 1)
 
   let result_of_comparison_with_nan (op : P.comparison) =
-    print_endline "OK";
     match op with
     | Neq -> Exactly Target_imm.bool_true
     | Eq | Lt | Gt | Le | Ge -> Exactly Target_imm.bool_false

--- a/middle_end/flambda/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda/simplify/simplify_binary_primitive.ml
@@ -778,14 +778,39 @@ end = struct
   let op (op : op) n1 n2 =
     match op with
     | Yielding_bool op ->
+      let has_nan = F.is_any_nan n1 || F.is_any_nan n2 in
       let bool b = Target_imm.bool b in
       begin match op with
-      | Eq -> Some (bool (F.IEEE_semantics.equal n1 n2))
-      | Neq -> Some (bool (not (F.IEEE_semantics.equal n1 n2)))
-      | Lt -> Some (bool (F.IEEE_semantics.compare n1 n2 < 0))
-      | Gt -> Some (bool (F.IEEE_semantics.compare n1 n2 > 0))
-      | Le -> Some (bool (F.IEEE_semantics.compare n1 n2 <= 0))
-      | Ge -> Some (bool (F.IEEE_semantics.compare n1 n2 >= 0))
+      | Eq ->
+        if has_nan then
+          Some (bool false)
+        else
+          Some (bool (F.IEEE_semantics.equal n1 n2))
+      | Neq ->
+        if has_nan then
+          Some (bool true)
+        else
+        Some (bool (not (F.IEEE_semantics.equal n1 n2)))
+      | Lt ->
+        if has_nan then
+          Some (bool false)
+        else
+        Some (bool (F.IEEE_semantics.compare n1 n2 < 0))
+      | Gt ->
+        if has_nan then
+          Some (bool false)
+        else
+        Some (bool (F.IEEE_semantics.compare n1 n2 > 0))
+      | Le ->
+        if has_nan then
+          Some (bool false)
+        else
+        Some (bool (F.IEEE_semantics.compare n1 n2 <= 0))
+      | Ge ->
+        if has_nan then
+          Some (bool false)
+        else
+        Some (bool (F.IEEE_semantics.compare n1 n2 >= 0))
       end
     | Yielding_int_like_compare_functions ->
       let int i = Target_imm.int (Targetint.OCaml.of_int i) in
@@ -795,6 +820,7 @@ end = struct
       else Some (int 1)
 
   let result_of_comparison_with_nan (op : P.comparison) =
+    print_endline "OK";
     match op with
     | Neq -> Exactly Target_imm.bool_true
     | Eq | Lt | Gt | Le | Ge -> Exactly Target_imm.bool_false

--- a/testsuite/tests/basic/equality.ml
+++ b/testsuite/tests/basic/equality.ml
@@ -73,8 +73,8 @@ let _ =
   test 37 eqm1 (compare (0.0, nan) (0.0, neg_infinity));
   test 38 eq0 (compare (nan, 0.0) (nan, 0.0));
 
-  (* Force inline these functions to ensures that the simplifier will
-     simplify the comparisons. *)
+  (* Force inline these functions to allow evaluation of the comparisons at
+     compile time by the middle end. *)
   let [@inline always] cmpgen x y =
     (x=y, x<>y, x<y, x<=y, x>y, x>=y)
   in
@@ -112,7 +112,8 @@ let _ =
   test 54 eqtrue (testcmpfloat 1.0 0.0);
   test 55 eqtrue (testcmpfloat 0.0 1.0);
 
-  (* Check the equality at run time. *)
+  (* Prevent inlining of these functions to force evaluation of the comparisons
+     at runtime and test the corresponding code generation. *)
   let [@inline never] cmpgen x y =
     (x=y, x<>y, x<y, x<=y, x>y, x>=y)
   in

--- a/testsuite/tests/basic/equality.ml
+++ b/testsuite/tests/basic/equality.ml
@@ -72,8 +72,15 @@ let _ =
   test 36 eqm1 (compare (0.0, nan) (0.0, 0.0));
   test 37 eqm1 (compare (0.0, nan) (0.0, neg_infinity));
   test 38 eq0 (compare (nan, 0.0) (nan, 0.0));
-  let cmpgen x y = (x=y, x<>y, x<y, x<=y, x>y, x>=y) in
-  let cmpfloat (x:float) (y:float) = (x=y, x<>y, x<y, x<=y, x>y, x>=y) in
+
+  (* Force inline these functions to ensures that the simplifier will
+     simplify the comparisons. *)
+  let [@inline always] cmpgen x y =
+    (x=y, x<>y, x<y, x<=y, x>y, x>=y)
+  in
+  let [@inline always] cmpfloat (x:float) (y:float) =
+    (x=y, x<>y, x<y, x<=y, x>y, x>=y)
+  in
   test 39 eqftffff (cmpgen nan nan);
   test 40 eqftffff (cmpgen nan 0.0);
   test 41 eqftffff (cmpfloat nan nan);
@@ -81,21 +88,21 @@ let _ =
   test 43 eqtrue ([||] = [||]);
   (* Convoluted forms to test both the "positive" and "negative" cases
      of float tests *)
-  let cmpfloatpos (x:float) (y:float) =
+  let [@inline always] cmpfloatpos (x:float) (y:float) =
     ((let r = ref false in (if x = y then r := true); !r),
      (let r = ref false in (if x <> y then r := true); !r),
      (let r = ref false in (if x < y then r := true); !r),
      (let r = ref false in (if x <= y then r := true); !r),
      (let r = ref false in (if x > y then r := true); !r),
      (let r = ref false in (if x >= y then r := true); !r))
-  and cmpfloatneg (x:float) (y:float) =
+  and [@inline always] cmpfloatneg (x:float) (y:float) =
     ((let r = ref true in (if not (x = y) then r := false); !r),
      (let r = ref true in (if not (x <> y) then r := false); !r),
      (let r = ref true in (if not (x < y) then r := false); !r),
      (let r = ref true in (if not (x <= y) then r := false); !r),
      (let r = ref true in (if not (x > y) then r := false); !r),
      (let r = ref true in (if not (x >= y) then r := false); !r)) in
-  let testcmpfloat x y =
+  let [@inline always] testcmpfloat x y =
     cmpfloatpos x y = cmpgen x y &&
     cmpfloatneg x y = cmpgen x y in
   test 50 eqtrue (testcmpfloat nan nan);
@@ -103,4 +110,40 @@ let _ =
   test 52 eqtrue (testcmpfloat 0.0 nan);
   test 53 eqtrue (testcmpfloat 0.0 0.0);
   test 54 eqtrue (testcmpfloat 1.0 0.0);
-  test 55 eqtrue (testcmpfloat 0.0 1.0)
+  test 55 eqtrue (testcmpfloat 0.0 1.0);
+
+  (* Check the equality at run time. *)
+  let [@inline never] cmpgen x y =
+    (x=y, x<>y, x<y, x<=y, x>y, x>=y)
+  in
+  let [@inline never] cmpfloat (x:float) (y:float) =
+    (x=y, x<>y, x<y, x<=y, x>y, x>=y)
+  in
+  test 56 eqftffff (cmpgen nan nan);
+  test 57 eqftffff (cmpgen nan 0.0);
+  test 58 eqftffff (cmpfloat nan nan);
+  test 59 eqftffff (cmpfloat nan 0.0);
+  test 60 eqtrue ([||] = [||]);
+  let [@inline never] cmpfloatpos (x:float) (y:float) =
+    ((let r = ref false in (if x = y then r := true); !r),
+     (let r = ref false in (if x <> y then r := true); !r),
+     (let r = ref false in (if x < y then r := true); !r),
+     (let r = ref false in (if x <= y then r := true); !r),
+     (let r = ref false in (if x > y then r := true); !r),
+     (let r = ref false in (if x >= y then r := true); !r))
+  and [@inline never] cmpfloatneg (x:float) (y:float) =
+    ((let r = ref true in (if not (x = y) then r := false); !r),
+     (let r = ref true in (if not (x <> y) then r := false); !r),
+     (let r = ref true in (if not (x < y) then r := false); !r),
+     (let r = ref true in (if not (x <= y) then r := false); !r),
+     (let r = ref true in (if not (x > y) then r := false); !r),
+     (let r = ref true in (if not (x >= y) then r := false); !r)) in
+  let [@inline never] testcmpfloat x y =
+    cmpfloatpos x y = cmpgen x y &&
+    cmpfloatneg x y = cmpgen x y in
+  test 61 eqtrue (testcmpfloat nan nan);
+  test 62 eqtrue (testcmpfloat nan 0.0);
+  test 63 eqtrue (testcmpfloat 0.0 nan);
+  test 64 eqtrue (testcmpfloat 0.0 0.0);
+  test 65 eqtrue (testcmpfloat 1.0 0.0);
+  test 66 eqtrue (testcmpfloat 0.0 1.0)

--- a/testsuite/tests/basic/equality.reference
+++ b/testsuite/tests/basic/equality.reference
@@ -47,3 +47,14 @@ Test 52 passed.
 Test 53 passed.
 Test 54 passed.
 Test 55 passed.
+Test 56 passed.
+Test 57 passed.
+Test 58 passed.
+Test 59 passed.
+Test 60 passed.
+Test 61 passed.
+Test 62 passed.
+Test 63 passed.
+Test 64 passed.
+Test 65 passed.
+Test 66 passed.


### PR DESCRIPTION
Float comparisons with both operands known and at least a nan in one of them were miss-simplified by the simplifier.

Updated the test basic/equality.ml to check these comparisons twice:
- once where the functions building these comparisons is forced inlined, which should be checking the output of the simplifier
- once where these functions are never inlined to check the correctness of runtime executing float comparisons.