### PR TITLE
Provide a skeleton type for function decl when not rebuilding terms

### DIFF
--- a/middle_end/flambda/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda/simplify/simplify_set_of_closures.ml
@@ -472,13 +472,14 @@ let simplify_function context ~used_closure_vars ~shareable_constants
     in
     let function_decl = FD.update_code_id function_decl new_code_id in
     let function_type =
-      (* When not rebuilding terms we cannot infer function types.  However
-         this shouldn't matter too much since inlining will typically be
-         disabled during such traversals. *)
+      (* When not rebuilding terms we only give a skeleton function type so
+         that we can distinguish between direct and indirect calls. *)
       if Are_rebuilding_terms.do_not_rebuild_terms
            (DA.are_rebuilding_terms dacc_after_body)
       then
-        Or_unknown_or_bottom.Unknown
+	T.create_non_inlinable_function_declaration
+	   ~code_id:new_code_id
+	   ~is_tupled:(FD.is_tupled function_decl)
       else
         (* We need to manually specify the cost metrics to use to ensure that
            they are the one of the body after simplification. *)

--- a/middle_end/flambda/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda/simplify/simplify_set_of_closures.ml
@@ -472,8 +472,9 @@ let simplify_function context ~used_closure_vars ~shareable_constants
     in
     let function_decl = FD.update_code_id function_decl new_code_id in
     let function_type =
-      (* When not rebuilding terms we only give a skeleton function type so
-         that we can distinguish between direct and indirect calls. *)
+      (* When not rebuilding terms we always give a non-inlinable function type,
+         since the body is not available for inlining, but we would still like
+         to generate direct calls to the function *)
       if Are_rebuilding_terms.do_not_rebuild_terms
            (DA.are_rebuilding_terms dacc_after_body)
       then


### PR DESCRIPTION
Creates a skeleton type for function declaration when simplifying while not rebuilding terms. This allow to distinguish between direct and indirect functions.