### PR TITLE
Use binding times as scope markers for cheaper closure environments

### DIFF
--- a/middle_end/flambda/types/env/aliases.ml
+++ b/middle_end/flambda/types/env/aliases.ml
@@ -192,9 +192,14 @@ let defined_earlier t alias ~than =
     (Binding_time.With_name_mode.binding_time info1)
     ~than:(Binding_time.With_name_mode.binding_time info2)
 
-let name_mode t elt =
+let name_mode_unscoped t elt =
   Binding_time.With_name_mode.name_mode
     (Simple.Map.find elt t.binding_times_and_modes)
+
+let name_mode t elt ~min_binding_time =
+  Binding_time.With_name_mode.scoped_name_mode
+    (Simple.Map.find elt t.binding_times_and_modes)
+    ~min_binding_time
 
 let invariant t =
   if !Clflags.flambda_invariant_checks then begin
@@ -284,7 +289,7 @@ let add_alias_between_canonical_elements t ~canonical_element ~to_be_demoted =
       Aliases_of_canonical_element.add
         (Aliases_of_canonical_element.union aliases_of_to_be_demoted
           aliases_of_canonical_element)
-        to_be_demoted (name_mode t to_be_demoted)
+        to_be_demoted (name_mode_unscoped t to_be_demoted)
     in
     let aliases_of_canonical_elements =
       t.aliases_of_canonical_elements
@@ -493,7 +498,7 @@ Format.eprintf "looking for canonical for %a, candidate canonical %a, min order 
     in
     match
       Name_mode.compare_partial_order
-        (name_mode t canonical_element)
+        (name_mode t canonical_element ~min_binding_time)
         min_name_mode
     with
     | None -> find_earliest ()

--- a/middle_end/flambda/types/env/aliases.mli
+++ b/middle_end/flambda/types/env/aliases.mli
@@ -51,6 +51,7 @@ val get_canonical_element_exn
   -> Simple.t
   -> Name_mode.t
   -> min_name_mode:Name_mode.t
+  -> min_binding_time:Binding_time.t
   -> Simple.t
 
 (** [get_aliases] always returns the supplied element in the result set. *)

--- a/middle_end/flambda/types/env/binding_time.ml
+++ b/middle_end/flambda/types/env/binding_time.ml
@@ -37,6 +37,7 @@ let consts_and_discriminants = 0
 let symbols = 1
 let imported_variables = 2
 let earliest_var = 3
+let before_earliest_var = 2
 
 let succ (t : t) =
   if t < earliest_var then
@@ -67,6 +68,14 @@ module With_name_mode = struct
     | 1 -> Name_mode.in_types
     | 2 -> Name_mode.phantom
     | _ -> assert false
+
+  let scoped_name_mode t ~min_binding_time =
+    if strictly_earlier (binding_time t) ~than:earliest_var
+    || strictly_earlier min_binding_time ~than:(binding_time t)
+    then (* Constant, symbol, or variable in the allowed scope *)
+      name_mode t
+    else (* Variable out of the allowed scope *)
+      Name_mode.in_types
 
   let print ppf t =
     Format.fprintf ppf "(bound at time %d %a)" (binding_time t)

--- a/middle_end/flambda/types/env/binding_time.ml
+++ b/middle_end/flambda/types/env/binding_time.ml
@@ -37,7 +37,6 @@ let consts_and_discriminants = 0
 let symbols = 1
 let imported_variables = 2
 let earliest_var = 3
-let before_earliest_var = 2
 
 let succ (t : t) =
   if t < earliest_var then
@@ -70,8 +69,10 @@ module With_name_mode = struct
     | _ -> assert false
 
   let scoped_name_mode t ~min_binding_time =
-    if strictly_earlier (binding_time t) ~than:earliest_var
-    || strictly_earlier min_binding_time ~than:(binding_time t)
+    (* Strictly before [min_binding_time] means out of scope,
+       at [min_binding_time] or later is in scope. *)
+    if (binding_time t) < earliest_var
+    || min_binding_time <= binding_time t
     then (* Constant, symbol, or variable in the allowed scope *)
       name_mode t
     else (* Variable out of the allowed scope *)

--- a/middle_end/flambda/types/env/binding_time.mli
+++ b/middle_end/flambda/types/env/binding_time.mli
@@ -24,7 +24,6 @@ val symbols : t
 val imported_variables : t
 
 val earliest_var : t
-val before_earliest_var : t
 val succ : t -> t
 
 val strictly_earlier : t -> than:t -> bool

--- a/middle_end/flambda/types/env/binding_time.mli
+++ b/middle_end/flambda/types/env/binding_time.mli
@@ -24,6 +24,7 @@ val symbols : t
 val imported_variables : t
 
 val earliest_var : t
+val before_earliest_var : t
 val succ : t -> t
 
 val strictly_earlier : t -> than:t -> bool
@@ -37,6 +38,8 @@ module With_name_mode : sig
   val binding_time : t -> binding_time
 
   val name_mode : t -> Name_mode.t
+
+  val scoped_name_mode : t -> min_binding_time:binding_time -> Name_mode.t
 
   val print : Format.formatter -> t -> unit
 

--- a/middle_end/flambda/types/env/typing_env.rec.ml
+++ b/middle_end/flambda/types/env/typing_env.rec.ml
@@ -24,6 +24,7 @@ module Cached : sig
 
   val print_name_modes
      : restrict_to:Name.Set.t
+    -> min_binding_time:Binding_time.t
     -> Format.formatter
     -> t
     -> unit
@@ -71,14 +72,19 @@ end = struct
     symbol_projections : Symbol_projection.t Variable.Map.t;
   }
 
-  let print_kind_and_mode ppf (ty, _, mode) =
+  let print_kind_and_mode ~min_binding_time ppf (ty, binding_time, mode) =
     let kind = Type_grammar.kind ty in
+    let mode =
+      Binding_time.With_name_mode.scoped_name_mode
+        (Binding_time.With_name_mode.create binding_time mode)
+        ~min_binding_time
+    in
     Format.fprintf ppf ":: %a %a"
       Flambda_kind.print kind
       Name_mode.print mode
 
-  let print_name_modes ~restrict_to ppf t =
-    Name.Map.print print_kind_and_mode ppf
+  let print_name_modes ~restrict_to ~min_binding_time ppf t =
+    Name.Map.print (print_kind_and_mode ~min_binding_time) ppf
       (Name.Map.filter (fun name _ -> Name.Set.mem name restrict_to)
         t.names_to_types)
 
@@ -156,24 +162,14 @@ end = struct
     | proj -> Some proj
 
   let clean_for_export t ~reachable_names =
-    (* Two things happen:
-       - All variables are existentialized (mode is switched to in_types)
-       - Names coming from other compilation units or unreachable are removed
-    *)
-    let names_to_types =
-      Name.Map.mapi (fun name ((ty, binding_time, _mode) as info) ->
-          Name.pattern_match name
-          ~var:(fun _ -> ty, binding_time, Name_mode.in_types)
-          ~symbol:(fun _ -> info))
-        t.names_to_types
-    in
+    (* Names coming from other compilation units or unreachable are removed *)
     let current_compilation_unit = Compilation_unit.get_current_exn () in
     let names_to_types =
       Name.Map.filter (fun name _info ->
           Name_occurrences.mem_name reachable_names name
           && Compilation_unit.equal (Name.compilation_unit name)
                current_compilation_unit)
-        names_to_types
+        t.names_to_types
     in
     let aliases = Aliases.clean_for_export t.aliases in
     { t with
@@ -232,7 +228,7 @@ module One_level = struct
     just_after_level : Cached.t;
   }
 
-  let print_with_cache ~cache:_ ppf
+  let print_with_cache ~min_binding_time ~cache:_ ppf
         { scope = _; level; just_after_level; } =
     let restrict_to = Typing_env_level.defined_names level in
     if Name.Set.is_empty restrict_to then
@@ -245,7 +241,7 @@ module One_level = struct
           @[<hov 1>(defined_vars@ %a)@]@ \
           %a\
           @]"
-        (Cached.print_name_modes ~restrict_to) just_after_level
+        (Cached.print_name_modes ~restrict_to ~min_binding_time) just_after_level
         Typing_env_level.print level
 
   let create scope level ~just_after_level =
@@ -286,7 +282,7 @@ type t = {
   prev_levels : One_level.t Scope.Map.t;
   current_level : One_level.t;
   next_binding_time : Binding_time.t;
-  closure_env : t option;
+  min_binding_time : Binding_time.t; (* Earlier variables have mode In_types *)
 }
 
 module Serializable : sig
@@ -315,6 +311,7 @@ end = struct
     defined_symbols : Symbol.Set.t;
     code_age_relation : Code_age_relation.t;
     just_after_level : Cached.t;
+    next_binding_time : Binding_time.t
   }
 
   let create ({ resolver = _;
@@ -323,16 +320,18 @@ end = struct
                 code_age_relation;
                 prev_levels = _;
                 current_level;
-                next_binding_time = _;
-                closure_env = _; } : typing_env) =
+                next_binding_time;
+                min_binding_time = _; } : typing_env) =
     { defined_symbols;
       code_age_relation;
       just_after_level = One_level.just_after_level current_level;
+      next_binding_time;
     }
 
   let print ppf { defined_symbols;
                   code_age_relation;
                   just_after_level;
+                  next_binding_time = _;
                 } =
     Format.fprintf ppf
       "@[<hov 1>(\
@@ -350,6 +349,7 @@ end = struct
   let to_typing_env { defined_symbols;
                       code_age_relation;
                       just_after_level;
+                      next_binding_time;
                     }
         ~resolver ~get_imported_names =
     { resolver;
@@ -360,24 +360,19 @@ end = struct
       current_level =
         One_level.create Scope.initial (Typing_env_level.empty ())
           ~just_after_level;
-      next_binding_time = Binding_time.earliest_var;
-      closure_env = Some {
-        resolver;
-        get_imported_names;
-        prev_levels = Scope.Map.empty;
-        current_level = One_level.create_empty Scope.initial;
-        next_binding_time = Binding_time.earliest_var;
-        defined_symbols = Symbol.Set.empty;
-        code_age_relation = Code_age_relation.empty;
-        closure_env = None;
-      };
+      (* Note: the field [next_binding_time] of the new env will not be used,
+         but setting [min_binding_time] to the value of [next_binding_time]
+         from the serialized env marks all variables as having mode In_types. *)
+      next_binding_time;
+      min_binding_time = next_binding_time;
     }
 
   (* CR mshinwell for vlaviron: Shouldn't some of this be in
      [Cached.all_ids_for_export]? *)
   let all_ids_for_export { defined_symbols;
                            code_age_relation;
-                           just_after_level; } =
+                           just_after_level;
+                           next_binding_time = _; } =
     let symbols = defined_symbols in
     let code_ids = Code_age_relation.all_code_ids_for_export code_age_relation in
     let ids = Ids_for_export.create ~symbols ~code_ids () in
@@ -405,7 +400,10 @@ end = struct
     in
     ids
 
-  let apply_renaming { defined_symbols; code_age_relation; just_after_level; }
+  let apply_renaming { defined_symbols;
+                       code_age_relation;
+                       just_after_level;
+                       next_binding_time; }
         renaming =
     let defined_symbols =
       Symbol.Set.fold (fun sym symbols ->
@@ -418,7 +416,7 @@ end = struct
       Code_age_relation.apply_renaming code_age_relation renaming
     in
     let just_after_level = Cached.apply_renaming just_after_level renaming in
-    { defined_symbols; code_age_relation; just_after_level; }
+    { defined_symbols; code_age_relation; just_after_level; next_binding_time; }
 
   let merge t1 t2 =
     let defined_symbols =
@@ -430,7 +428,14 @@ end = struct
     let just_after_level =
       Cached.merge t1.just_after_level t2.just_after_level
     in
-    { defined_symbols; code_age_relation; just_after_level; }
+    let next_binding_time =
+      (* Take the latest one *)
+      if Binding_time.strictly_earlier t1.next_binding_time
+           ~than:t2.next_binding_time
+      then t2.next_binding_time
+      else t1.next_binding_time
+    in
+    { defined_symbols; code_age_relation; just_after_level; next_binding_time; }
 end
 
 let is_empty t =
@@ -443,7 +448,7 @@ let is_empty t =
 let print_with_cache ~cache ppf
       ({ resolver = _; get_imported_names = _;
          prev_levels; current_level; next_binding_time = _;
-         defined_symbols; code_age_relation; closure_env = _;
+         defined_symbols; code_age_relation; min_binding_time;
        } as t) =
   if is_empty t then
     Format.pp_print_string ppf "Empty"
@@ -464,7 +469,8 @@ let print_with_cache ~cache ppf
             )@]"
         Symbol.Set.print defined_symbols
         Code_age_relation.print code_age_relation
-        (Scope.Map.print (One_level.print_with_cache ~cache)) levels)
+        (Scope.Map.print (One_level.print_with_cache ~min_binding_time ~cache))
+        levels)
 
 let print ppf t =
   print_with_cache ~cache:(Printing_cache.create ()) ppf t
@@ -520,6 +526,9 @@ let names_to_types t =
 let aliases t =
   Cached.aliases (One_level.just_after_level t.current_level)
 
+let aliases_with_min_binding_time t =
+  aliases t, t.min_binding_time
+
 let create ~resolver ~get_imported_names =
   { resolver;
     get_imported_names;
@@ -528,16 +537,7 @@ let create ~resolver ~get_imported_names =
     next_binding_time = Binding_time.earliest_var;
     defined_symbols = Symbol.Set.empty;
     code_age_relation = Code_age_relation.empty;
-    closure_env = Some {
-      resolver;
-      get_imported_names;
-      prev_levels = Scope.Map.empty;
-      current_level = One_level.create_empty Scope.initial;
-      next_binding_time = Binding_time.earliest_var;
-      defined_symbols = Symbol.Set.empty;
-      code_age_relation = Code_age_relation.empty;
-      closure_env = None;
-    };
+    min_binding_time = Binding_time.before_earliest_var;
   }
 
 let increment_scope t =
@@ -648,18 +648,21 @@ let find_with_binding_time_and_mode' t name kind =
                   environment (maybe the wrong .cmx file is present?):@ %a"
                 Variable.print var
                 print t)
-        | ty, _binding_time, name_mode ->
+        | ty, _binding_time, _name_mode ->
           check_optional_kind_matches name ty kind;
           (* Binding times for imported units are meaningless at present.
              Also see [Alias.defined_earlier]. *)
-          ty, Binding_time.imported_variables, name_mode
+          ty, Binding_time.imported_variables, Name_mode.in_types
       end
   | found ->
     let ty, _, _ = found in
     check_optional_kind_matches name ty kind;
     found
 
-let find_with_binding_time_and_mode t name kind =
+(* This version doesn't check min_binding_time.
+   This ensures that no allocation occurs when we're not interested
+   in the name mode. *)
+let find_with_binding_time_and_mode_unscoped t name kind =
   try find_with_binding_time_and_mode' t name kind
   with
   | Missing_cmx_and_kind ->
@@ -669,9 +672,22 @@ let find_with_binding_time_and_mode t name kind =
 
 let find t name kind =
   let ty, _binding_time, _name_mode =
-    find_with_binding_time_and_mode t name kind
+    find_with_binding_time_and_mode_unscoped t name kind
   in
   ty
+
+let find_with_binding_time_and_mode t name kind =
+  let ((ty, binding_time, mode) as found) =
+    find_with_binding_time_and_mode_unscoped t name kind
+  in
+  let scoped_mode =
+    Binding_time.With_name_mode.scoped_name_mode
+      (Binding_time.With_name_mode.create binding_time mode)
+      ~min_binding_time:t.min_binding_time
+  in
+  if Name_mode.equal mode scoped_mode then found
+  else (ty, binding_time, scoped_mode)
+
 
 let find_or_missing t name =
   match find_with_binding_time_and_mode' t name None with
@@ -716,8 +732,13 @@ let mem ?min_name_mode t name =
           if Name.Set.mem name (t.get_imported_names ())
           then Some Name_mode.in_types
           else None
-        | _ty, _binding_time, name_mode ->
-          Some name_mode
+        | _ty, binding_time, name_mode ->
+          let scoped_name_mode =
+            Binding_time.With_name_mode.scoped_name_mode
+              (Binding_time.With_name_mode.create binding_time name_mode)
+              ~min_binding_time:t.min_binding_time
+          in
+          Some scoped_name_mode
       in
       match name_mode, min_name_mode with
       | None, _ -> false
@@ -742,11 +763,6 @@ let mem_simple ?min_name_mode t simple =
 
 let with_current_level t ~current_level =
   let t = { t with current_level; } in
-  invariant t;
-  t
-
-let with_current_level_and_closure_env t ~current_level ~closure_env =
-  let t = { t with current_level; closure_env; } in
   invariant t;
   t
 
@@ -793,7 +809,7 @@ let add_variable_definition t var kind name_mode =
   with_current_level_and_next_binding_time t ~current_level
     (Binding_time.succ t.next_binding_time)
 
-let rec add_symbol_definition t sym =
+let add_symbol_definition t sym =
   (* CR mshinwell: check for redefinition when invariants enabled? *)
   let comp_unit = Symbol.compilation_unit sym in
   let this_comp_unit = Compilation_unit.get_current_exn () in
@@ -806,25 +822,13 @@ let rec add_symbol_definition t sym =
       (Compilation_unit.equal comp_unit this_comp_unit)
       print t
   end;
-  let closure_env =
-    match t.closure_env with
-    | None -> None
-    | Some closure_env -> Some (add_symbol_definition closure_env sym)
-  in
   { t with
     defined_symbols = Symbol.Set.add sym t.defined_symbols;
-    closure_env;
   }
 
-let rec add_symbol_definitions t syms =
-  let closure_env =
-    match t.closure_env with
-    | None -> None
-    | Some closure_env -> Some (add_symbol_definitions closure_env syms)
-  in
+let add_symbol_definitions t syms =
   { t with
     defined_symbols = Symbol.Set.union syms t.defined_symbols;
-    closure_env;
   }
 
 let add_symbol_projection t var proj =
@@ -898,7 +902,7 @@ let rec add_equation0 t aliases name ty =
     Typing_env_level.add_or_replace_equation
       (One_level.level t.current_level) name ty
   in
-  let just_after_level, closure_env =
+  let just_after_level =
     Name.pattern_match name
       ~var:(fun var ->
         let just_after_level =
@@ -914,7 +918,7 @@ let rec add_equation0 t aliases name ty =
               name ty Binding_time.imported_variables Name_mode.in_types
               ~new_aliases:aliases
         in
-        just_after_level, t.closure_env)
+        just_after_level)
       ~symbol:(fun _ ->
         let just_after_level =
           Cached.add_or_replace_binding
@@ -922,28 +926,12 @@ let rec add_equation0 t aliases name ty =
             name ty Binding_time.symbols Name_mode.normal
             ~new_aliases:aliases
         in
-        let closure_env =
-          match t.closure_env with
-          | None -> None
-          | Some closure_env ->
-            let extension, ty =
-              Type_grammar.make_suitable_for_environment0 ty t
-                ~suitable_for:closure_env
-                (Typing_env_extension.With_extra_variables.empty ())
-            in
-            let closure_env =
-              add_equation
-                (add_env_extension_with_extra_variables closure_env extension)
-                name ty
-            in
-            Some closure_env
-        in
-        just_after_level, closure_env)
+        just_after_level)
   in
   let current_level =
     One_level.create (current_scope t) level ~just_after_level
   in
-  with_current_level_and_closure_env t ~current_level ~closure_env
+  with_current_level t ~current_level
 
 and add_equation t name ty =
   if !Clflags.flambda_invariant_checks then begin
@@ -1224,28 +1212,28 @@ let type_simple_in_term_exn t ?min_name_mode simple =
             | Some rec_info ->
               Some (Rec_info.merge rec_info ~newer:newer_rec_info))
   in
-  let aliases_for_simple =
-    if Aliases.mem (aliases t) simple then aliases t
+  let aliases_for_simple, min_binding_time =
+    if Aliases.mem (aliases t) simple then aliases_with_min_binding_time t
     else
     Simple.pattern_match simple
-      ~const:(fun _ -> aliases t)
+      ~const:(fun _ -> aliases_with_min_binding_time t)
       ~name:(fun name ->
         Name.pattern_match name
           ~var:(fun var ->
             let comp_unit = Variable.compilation_unit var in
             if Compilation_unit.equal comp_unit
                  (Compilation_unit.get_current_exn ())
-            then aliases t
+            then aliases_with_min_binding_time t
             else
               match (resolver t) comp_unit with
-              | Some env -> aliases env
+              | Some env -> aliases_with_min_binding_time env
               | None ->
                 Misc.fatal_errorf "Error while looking up variable %a:@ \
                                    No corresponding .cmx file was found"
                   Variable.print var)
           ~symbol:(fun _sym ->
             (* Symbols can't alias, so lookup in the current aliases is fine *)
-            aliases t))
+            aliases_with_min_binding_time t))
   in
   let min_name_mode =
     match min_name_mode with
@@ -1254,7 +1242,7 @@ let type_simple_in_term_exn t ?min_name_mode simple =
   in
   match
     Aliases.get_canonical_element_exn aliases_for_simple simple name_mode_simple
-      ~min_name_mode
+      ~min_name_mode ~min_binding_time
   with
   | exception Misc.Fatal_error ->
     if !Clflags.flambda_context_on_error then begin
@@ -1292,21 +1280,21 @@ let get_canonical_simple_exn t ?min_name_mode ?name_mode_of_existing_simple
               | Some rec_info ->
                 Some (Rec_info.merge rec_info ~newer:newer_rec_info))
   in
-  let aliases_for_simple =
-    if Aliases.mem (aliases t) simple then aliases t
+  let aliases_for_simple, min_binding_time =
+    if Aliases.mem (aliases t) simple then aliases_with_min_binding_time t
     else
     Simple.pattern_match simple
-      ~const:(fun _ -> aliases t)
+      ~const:(fun _ -> aliases_with_min_binding_time t)
       ~name:(fun name ->
         Name.pattern_match name
           ~var:(fun var ->
             let comp_unit = Variable.compilation_unit var in
             if Compilation_unit.equal comp_unit
                  (Compilation_unit.get_current_exn ())
-            then aliases t
+            then aliases_with_min_binding_time t
             else
               match (resolver t) comp_unit with
-              | Some env -> aliases env
+              | Some env -> aliases_with_min_binding_time env
               | None ->
                 (* Transcript of Slack conversation relating to the next line:
 
@@ -1334,10 +1322,10 @@ let get_canonical_simple_exn t ?min_name_mode ?name_mode_of_existing_simple
                    if we had a way to learn later that the variable is
                    actually an alias, but that would only happen if for some
                    reason we later successfully load the missing cmx. *)
-                  aliases t)
+                aliases_with_min_binding_time t)
           ~symbol:(fun _sym ->
             (* Symbols can't alias, so lookup in the current aliases is fine *)
-            aliases t))
+            aliases_with_min_binding_time t))
   in
   let name_mode_simple =
     let in_types =
@@ -1360,7 +1348,7 @@ let get_canonical_simple_exn t ?min_name_mode ?name_mode_of_existing_simple
   in
   match
     Aliases.get_canonical_element_exn aliases_for_simple simple name_mode_simple
-      ~min_name_mode
+      ~min_name_mode ~min_binding_time
   with
   | exception Misc.Fatal_error ->
     if !Clflags.flambda_context_on_error then begin
@@ -1411,17 +1399,10 @@ let aliases_of_simple_allowable_in_types t simple =
   aliases_of_simple t ~min_name_mode:Name_mode.in_types simple
 
 let closure_env t =
-  match t.closure_env with
-  | None ->
-    create ~resolver:t.resolver ~get_imported_names:t.get_imported_names
-  | Some closure_env ->
-    assert (Option.is_none closure_env.closure_env);
-    { closure_env with
-      closure_env = Some {
-        closure_env with
-        closure_env = None;
-      };
-    }
+  { t with
+    min_binding_time = t.next_binding_time;
+    next_binding_time = Binding_time.succ t.next_binding_time;
+  }
 
 let rec free_names_transitive_of_type_of_name t name ~result =
   let result = Name_occurrences.add_name result name Name_mode.in_types in

--- a/middle_end/flambda/types/env/typing_env.rec.ml
+++ b/middle_end/flambda/types/env/typing_env.rec.ml
@@ -537,7 +537,7 @@ let create ~resolver ~get_imported_names =
     next_binding_time = Binding_time.earliest_var;
     defined_symbols = Symbol.Set.empty;
     code_age_relation = Code_age_relation.empty;
-    min_binding_time = Binding_time.before_earliest_var;
+    min_binding_time = Binding_time.earliest_var;
   }
 
 let increment_scope t =
@@ -654,8 +654,11 @@ let find_with_binding_time_and_mode' t name kind =
             ~symbol:(fun _ ->
               ty, Binding_time.symbols, Name_mode.normal)
             ~var:(fun _ ->
-              (* Binding times for imported units are meaningless at present.
-                 Also see [Alias.defined_earlier]. *)
+              (* Binding times for imported variables are meaningless outside
+                 their original environment.
+                 Variables from foreign compilation units are always out of
+                 scope, so their mode must be In_types (we cannot rely on the
+                 scoping by binding time). *)
               ty, Binding_time.imported_variables, Name_mode.in_types)
       end
   | found ->
@@ -1405,7 +1408,6 @@ let aliases_of_simple_allowable_in_types t simple =
 let closure_env t =
   { t with
     min_binding_time = t.next_binding_time;
-    next_binding_time = Binding_time.succ t.next_binding_time;
   }
 
 let rec free_names_transitive_of_type_of_name t name ~result =

--- a/middle_end/flambda/types/env/typing_env.rec.ml
+++ b/middle_end/flambda/types/env/typing_env.rec.ml
@@ -650,9 +650,13 @@ let find_with_binding_time_and_mode' t name kind =
                 print t)
         | ty, _binding_time, _name_mode ->
           check_optional_kind_matches name ty kind;
-          (* Binding times for imported units are meaningless at present.
-             Also see [Alias.defined_earlier]. *)
-          ty, Binding_time.imported_variables, Name_mode.in_types
+          Name.pattern_match name
+            ~symbol:(fun _ ->
+              ty, Binding_time.symbols, Name_mode.normal)
+            ~var:(fun _ ->
+              (* Binding times for imported units are meaningless at present.
+                 Also see [Alias.defined_earlier]. *)
+              ty, Binding_time.imported_variables, Name_mode.in_types)
       end
   | found ->
     let ty, _, _ = found in

--- a/middle_end/flambda/types/type_grammar.rec.mli
+++ b/middle_end/flambda/types/type_grammar.rec.mli
@@ -191,13 +191,6 @@ val closure_with_at_least_this_closure_var
 
 val array_of_length : length:t -> t
 
-val make_suitable_for_environment0
-   : t
-  -> Typing_env.t
-  -> suitable_for:Typing_env.t
-  -> Typing_env_extension.With_extra_variables.t
-  -> Typing_env_extension.With_extra_variables.t * t
-
 val make_suitable_for_environment
    : t
   -> Typing_env.t


### PR DESCRIPTION
Comparing the compilation of `typecore.ml` with and without this patch shows that this patch reduces allocations by roughly 15%.
The effect on compilation time is less impressive. This patch does seem to have a small positive effect (it compiles faster), but it is harder to measure precisely and since the environments used inside closures are bigger then it's expected that the lookup times will be slightly slower too.