### PR TITLE
Add the implicit allocation when computing the cost_metrics of a set of closures

### DIFF
--- a/middle_end/flambda/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion_aux.ml
@@ -347,10 +347,12 @@ module Let_with_acc = struct
       | Named.Set_of_closures set_of_closures ->
         let code_mapping = Acc.code acc in
         Cost_metrics.set_of_closures
-          ~find_cost_characteristics:(fun code_id ->
+          ~find_code_characteristics:(fun code_id ->
             let code = Code_id.Map.find code_id code_mapping in
-            Code.cost_metrics code,
-            List.length (Code.result_arity code)
+            {
+              cost_metrics = Code.cost_metrics code;
+              params_arity = List.length (Code.params_arity code)
+            }
           )
           set_of_closures
     in

--- a/middle_end/flambda/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion_aux.ml
@@ -347,9 +347,11 @@ module Let_with_acc = struct
       | Named.Set_of_closures set_of_closures ->
         let code_mapping = Acc.code acc in
         Cost_metrics.set_of_closures
-          ~find_cost_metrics:(fun code_id ->
-            Code_id.Map.find code_id code_mapping
-            |> Code.cost_metrics)
+          ~find_cost_characteristics:(fun code_id ->
+            let code = Code_id.Map.find code_id code_mapping in
+            Code.cost_metrics code,
+            List.length (Code.result_arity code)
+          )
           set_of_closures
     in
     let acc =

--- a/middle_end/flambda/inlining/metrics/code_size.mli
+++ b/middle_end/flambda/inlining/metrics/code_size.mli
@@ -40,5 +40,5 @@ val apply : Apply_expr.t -> t
 val apply_cont : Apply_cont_expr.t -> t
 val switch : Switch_expr.t -> t
 val invalid : t
-
 val evaluate : round:int -> t -> float
+val alloc_size : t

--- a/middle_end/flambda/simplify/basic/simplified_named.ml
+++ b/middle_end/flambda/simplify/basic/simplified_named.ml
@@ -61,7 +61,8 @@ let reachable (named : Named.t) =
     free_names = Named.free_names named;
   }
 
-let reachable_with_known_free_names ~find_cost_metrics (named : Named.t) ~free_names =
+let reachable_with_known_free_names ~find_cost_characteristics
+      (named : Named.t) ~free_names =
   let (simplified_named : simplified_named), cost_metrics =
     match named with
     | Simple simple ->
@@ -72,7 +73,7 @@ let reachable_with_known_free_names ~find_cost_metrics (named : Named.t) ~free_n
        Cost_metrics.from_size (Code_size.prim prim)
     | Set_of_closures set ->
        Set_of_closures set,
-       Cost_metrics.set_of_closures ~find_cost_metrics set
+       Cost_metrics.set_of_closures ~find_cost_characteristics set
     | Static_consts _ ->
       Misc.fatal_errorf "Cannot create [Simplified_named] from \
           [Static_consts];@ use the lifted constant infrastructure instead:@ %a"

--- a/middle_end/flambda/simplify/basic/simplified_named.ml
+++ b/middle_end/flambda/simplify/basic/simplified_named.ml
@@ -61,7 +61,7 @@ let reachable (named : Named.t) =
     free_names = Named.free_names named;
   }
 
-let reachable_with_known_free_names ~find_cost_characteristics
+let reachable_with_known_free_names ~find_code_characteristics
       (named : Named.t) ~free_names =
   let (simplified_named : simplified_named), cost_metrics =
     match named with
@@ -73,7 +73,7 @@ let reachable_with_known_free_names ~find_cost_characteristics
        Cost_metrics.from_size (Code_size.prim prim)
     | Set_of_closures set ->
        Set_of_closures set,
-       Cost_metrics.set_of_closures ~find_cost_characteristics set
+       Cost_metrics.set_of_closures ~find_code_characteristics set
     | Static_consts _ ->
       Misc.fatal_errorf "Cannot create [Simplified_named] from \
           [Static_consts];@ use the lifted constant infrastructure instead:@ %a"

--- a/middle_end/flambda/simplify/basic/simplified_named.mli
+++ b/middle_end/flambda/simplify/basic/simplified_named.mli
@@ -43,7 +43,7 @@ val reachable : Named.t -> t
 
 (** It is an error to pass [Static_consts] to this function. *)
 val reachable_with_known_free_names
-  : find_cost_characteristics:(Code_id.t -> Cost_metrics.t * int)
+  : find_code_characteristics:(Code_id.t -> Cost_metrics.code_characteristics)
   -> Named.t
   -> free_names:Name_occurrences.t
   -> t

--- a/middle_end/flambda/simplify/basic/simplified_named.mli
+++ b/middle_end/flambda/simplify/basic/simplified_named.mli
@@ -43,7 +43,7 @@ val reachable : Named.t -> t
 
 (** It is an error to pass [Static_consts] to this function. *)
 val reachable_with_known_free_names
-  : find_cost_metrics:(Code_id.t -> Cost_metrics.t)
+  : find_cost_characteristics:(Code_id.t -> Cost_metrics.t * int)
   -> Named.t
   -> free_names:Name_occurrences.t
   -> t

--- a/middle_end/flambda/simplify/simplify_named.ml
+++ b/middle_end/flambda/simplify/simplify_named.ml
@@ -313,7 +313,7 @@ let removed_operations (named : Named.t) result =
   | Set_of_closures _ -> begin
       match descr with
       | Multiple_bindings_to_symbols _ ->
-          Removed_operations.alloc
+        Removed_operations.alloc
       | Single_term { simplified_defining_expr; _ } -> begin
           match simplified_defining_expr with
           | Reachable { named = Set_of_closures _; _ } ->

--- a/middle_end/flambda/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda/simplify/simplify_set_of_closures.ml
@@ -772,13 +772,14 @@ let simplify_non_lifted_set_of_closures0 dacc bound_vars ~closure_bound_vars
   let dacc = introduce_code dacc code in
   let defining_expr =
     let named = Named.create_set_of_closures set_of_closures in
-    let find_cost_metrics code_id =
+    let find_cost_characteristics code_id =
       let env = Downwards_acc.denv dacc in
-      Downwards_env.find_code env code_id
-      |> Code.cost_metrics
+      let code = Downwards_env.find_code env code_id in
+      Code.cost_metrics code,
+      List.length (Code.result_arity code)
     in
     Simplified_named.reachable_with_known_free_names
-      ~find_cost_metrics
+      ~find_cost_characteristics
       (Named.create_set_of_closures set_of_closures)
       ~free_names:(Named.free_names named)
   in

--- a/middle_end/flambda/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda/simplify/simplify_set_of_closures.ml
@@ -772,14 +772,16 @@ let simplify_non_lifted_set_of_closures0 dacc bound_vars ~closure_bound_vars
   let dacc = introduce_code dacc code in
   let defining_expr =
     let named = Named.create_set_of_closures set_of_closures in
-    let find_cost_characteristics code_id =
+    let find_code_characteristics code_id =
       let env = Downwards_acc.denv dacc in
       let code = Downwards_env.find_code env code_id in
-      Code.cost_metrics code,
-      List.length (Code.result_arity code)
+      Cost_metrics.{
+        cost_metrics = Code.cost_metrics code;
+        params_arity = List.length (Code.params_arity code)
+      }
     in
     Simplified_named.reachable_with_known_free_names
-      ~find_cost_characteristics
+      ~find_code_characteristics
       (Named.create_set_of_closures set_of_closures)
       ~free_names:(Named.free_names named)
   in

--- a/middle_end/flambda/terms/cost_metrics.rec.ml
+++ b/middle_end/flambda/terms/cost_metrics.rec.ml
@@ -70,21 +70,24 @@ and named_size ~find_code (named : Named.t) size =
       Set_of_closures.closure_elements set_of_closures
       |> Var_within_closure.Map.cardinal
     in
-    Closure_id.Map.fold (fun _ func_decl size ->
-      let code_id = Function_declaration.code_id func_decl in
-      let code = find_code code_id in
-      let arity = List.length (Code.params_arity code) in
-      let size =
-        match Code.params_and_body code with
-        | Present params_and_body ->
-          Function_params_and_body.pattern_match params_and_body
-            ~f:(fun ~return_continuation:_ _exn_continuation _params
-                 ~body ~my_closure:_ ~is_my_closure_used:_ ->
-                 expr_size ~find_code body size)
-        | Deleted -> size
-      in
-      size + (if arity = 1 then 2 else 3))
-      funs (Code_size.to_int Code_size.alloc_size + num_clos_vars + size)
+    Closure_id.Map.fold
+      (fun _ func_decl size ->
+         let code_id = Function_declaration.code_id func_decl in
+         let code = find_code code_id in
+         let arity = List.length (Code.params_arity code) in
+         let size =
+           match Code.params_and_body code with
+           | Present params_and_body ->
+             Function_params_and_body.pattern_match params_and_body
+               ~f:(fun ~return_continuation:_ _exn_continuation _params
+                    ~body ~my_closure:_ ~is_my_closure_used:_ ->
+                    expr_size ~find_code body size)
+           | Deleted -> size
+         in
+         size + (if arity <= 1 then 2 else 3)
+      )
+      funs
+      (Code_size.to_int Code_size.alloc_size + num_clos_vars + size)
   | Prim (prim, _dbg) ->
     size + (Code_size.prim prim |> Code_size.to_int)
   | Static_consts _ -> size
@@ -101,6 +104,11 @@ and continuation_handler_size ~find_code handler size =
 type t = {
   size: Code_size.t;
   removed: Removed_operations.t;
+}
+
+type code_characteristics = {
+  cost_metrics : t;
+  params_arity : int;
 }
 
 let zero = { size = Code_size.zero; removed = Removed_operations.zero }
@@ -135,20 +143,20 @@ let (+) a b ={
      total number of closure variables + sum of s(arity) for each closure
    where s(a) = if a = 1 then 2 else 3
 *)
-let set_of_closures ~find_cost_characteristics set_of_closures =
+let set_of_closures ~find_code_characteristics set_of_closures =
   let func_decls = Set_of_closures.function_decls set_of_closures in
   let funs = Function_declarations.funs func_decls in
   let num_clos_vars =
     Set_of_closures.closure_elements set_of_closures
     |> Var_within_closure.Map.cardinal
   in
-  let cost_metrics, num_blocks =
-    Closure_id.Map.fold (fun _ func_decl (metrics, num_blocks) ->
+  let cost_metrics, num_words =
+    Closure_id.Map.fold (fun _ func_decl (metrics, num_words) ->
       let code_id = Function_declaration.code_id func_decl in
-      let code_metrics, code_arity = find_cost_characteristics code_id in
-      metrics + code_metrics,
-      (* CR poechsel: valid until OCaml 4.13 *)
-      Stdlib.(+) num_blocks (if code_arity = 1 then 2 else 3)
+      let { cost_metrics; params_arity } = find_code_characteristics code_id in
+      metrics + cost_metrics,
+      (* CR poechsel: valid until OCaml 4.13, as for named_size *)
+      Stdlib.(+) num_words (if params_arity <= 1 then 2 else 3)
     )
       funs
       (zero, num_clos_vars)
@@ -156,7 +164,7 @@ let set_of_closures ~find_cost_characteristics set_of_closures =
   let alloc_size =
     Code_size.(+)
       Code_size.alloc_size
-      (Code_size.of_int num_blocks)
+      (Code_size.of_int num_words)
   in
   cost_metrics + (from_size alloc_size)
 

--- a/middle_end/flambda/terms/cost_metrics.rec.mli
+++ b/middle_end/flambda/terms/cost_metrics.rec.mli
@@ -33,7 +33,10 @@ val size : t -> Code_size.t
 val print : Format.formatter -> t -> unit
 val (+) : t -> t -> t
 
-val set_of_closures : find_cost_metrics:(Code_id.t -> t) -> Set_of_closures.t -> t
+val set_of_closures
+  : find_cost_characteristics:(Code_id.t -> t * int)
+  -> Set_of_closures.t
+  -> t
 
 val increase_due_to_let_expr : is_phantom:bool -> cost_metrics_of_defining_expr:t -> t
 val increase_due_to_let_cont_non_recursive : cost_metrics_of_handler:t -> t

--- a/middle_end/flambda/terms/cost_metrics.rec.mli
+++ b/middle_end/flambda/terms/cost_metrics.rec.mli
@@ -33,8 +33,12 @@ val size : t -> Code_size.t
 val print : Format.formatter -> t -> unit
 val (+) : t -> t -> t
 
+type code_characteristics = {
+  cost_metrics : t;
+  params_arity : int;
+}
 val set_of_closures
-  : find_cost_characteristics:(Code_id.t -> t * int)
+  : find_code_characteristics:(Code_id.t -> code_characteristics)
   -> Set_of_closures.t
   -> t
 

--- a/middle_end/flambda/terms/flambda.mli
+++ b/middle_end/flambda/terms/flambda.mli
@@ -657,7 +657,7 @@ end and Cost_metrics : sig
   val (+) : t -> t -> t
 
   val set_of_closures
-     : find_cost_metrics:(Code_id.t -> t)
+     : find_cost_characteristics:(Code_id.t -> t * int)
     -> Set_of_closures.t
     -> t
 

--- a/middle_end/flambda/terms/flambda.mli
+++ b/middle_end/flambda/terms/flambda.mli
@@ -656,8 +656,12 @@ end and Cost_metrics : sig
   val print : Format.formatter -> t -> unit
   val (+) : t -> t -> t
 
+  type code_characteristics = {
+    cost_metrics : t;
+    params_arity : int;
+  }
   val set_of_closures
-     : find_cost_characteristics:(Code_id.t -> t * int)
+    : find_code_characteristics:(Code_id.t -> code_characteristics)
     -> Set_of_closures.t
     -> t
 


### PR DESCRIPTION
A set of closures implicitly allocates -- the size of this allocation should be accounted for in the code_size.