### PR TITLE
Some more type creation functions

### DIFF
--- a/middle_end/flambda/types/flambda_type.mli
+++ b/middle_end/flambda/types/flambda_type.mli
@@ -157,6 +157,14 @@ module Typing_env : sig
     -> Simple.t
     -> flambda_type
 
+  (** Raises [Not_found] if no canonical [Simple] was found. *)
+  val get_alias_then_canonical_simple_exn
+     : t
+    -> ?min_name_mode:Name_mode.t
+    -> ?name_mode_of_existing_simple:Name_mode.t
+    -> flambda_type
+    -> Simple.t
+
   val add_to_code_age_relation : t -> newer:Code_id.t -> older:Code_id.t -> t
 
   val code_age_relation : t -> Code_age_relation.t
@@ -431,6 +439,11 @@ val closure_with_at_least_this_closure_var
    : this_closure:Closure_id.t
   -> Var_within_closure.t
   -> closure_element_var:Variable.t
+  -> flambda_type
+
+val closure_with_at_least_these_closure_vars
+   : this_closure:Closure_id.t
+  -> Variable.t Var_within_closure.Map.t
   -> flambda_type
 
 val array_of_length : length:flambda_type -> flambda_type

--- a/middle_end/flambda/types/type_grammar.rec.ml
+++ b/middle_end/flambda/types/type_grammar.rec.ml
@@ -670,15 +670,11 @@ let at_least_the_closures_with_ids ~this_closure closure_ids_and_bindings =
   in
   Value (T_V.create (Closures { by_closure_id; }))
 
-let closure_with_at_least_this_closure_var ~this_closure
-    closure_var ~closure_element_var : t =
+let closure_with_at_least_these_closure_vars ~this_closure closure_vars : t =
   let closure_var_types =
-    let closure_var_type =
-      alias_type_of K.value (Simple.var closure_element_var)
-    in
-    Product.Var_within_closure_indexed.create
-      Flambda_kind.value
-      (Var_within_closure.Map.singleton closure_var closure_var_type)
+    let type_of_var v = alias_type_of K.value (Simple.var v) in
+    let map = Var_within_closure.Map.map type_of_var closure_vars in
+    Product.Var_within_closure_indexed.create Flambda_kind.value map
   in
   let closures_entry =
     Closures_entry.create ~function_decls:Closure_id.Map.empty
@@ -689,7 +685,7 @@ let closure_with_at_least_this_closure_var ~this_closure
     let set_of_closures_contents =
       Set_of_closures_contents.create
         Closure_id.Set.empty
-        (Var_within_closure.Set.singleton closure_var)
+        (Var_within_closure.Map.keys closure_vars)
     in
     Row_like.For_closures_entry_by_set_of_closures_contents.
       create_at_least
@@ -698,6 +694,11 @@ let closure_with_at_least_this_closure_var ~this_closure
       closures_entry
   in
   Value (T_V.create (Closures { by_closure_id; }))
+
+let closure_with_at_least_this_closure_var ~this_closure
+      closure_var ~closure_element_var : t =
+  closure_with_at_least_these_closure_vars ~this_closure
+    (Var_within_closure.Map.singleton closure_var closure_element_var)
 
 let array_of_length ~length =
   Value (T_V.create (Array { length; }))

--- a/middle_end/flambda/types/type_grammar.rec.mli
+++ b/middle_end/flambda/types/type_grammar.rec.mli
@@ -189,6 +189,11 @@ val closure_with_at_least_this_closure_var
   -> closure_element_var:Variable.t
   -> t
 
+val closure_with_at_least_these_closure_vars
+   : this_closure:Closure_id.t
+  -> Variable.t Var_within_closure.Map.t
+  -> t
+
 val array_of_length : length:t -> t
 
 val make_suitable_for_environment


### PR DESCRIPTION
Required for the unboxing work.

This PR does two things:
- expose `get_alias_then_canonical_simple_exn` in `flambda_type.mli`
- slightly refactor `closure_with_at_least_this_closure_var` to expose a version of this function that does the same thing but with more than one closure var.