### PR TITLE
Always rebuild the term inside a function

### DIFF
--- a/middle_end/flambda/simplify/env/downwards_env.ml
+++ b/middle_end/flambda/simplify/env/downwards_env.ml
@@ -585,6 +585,8 @@ let set_do_not_rebuild_terms_and_disable_inlining t =
     can_inline = false;
   }
 
+let set_rebuild_terms t = { t with do_not_rebuild_terms = false }
+
 type are_rebuilding_terms = bool
 
 let are_rebuilding_terms t = not t.do_not_rebuild_terms
@@ -598,4 +600,3 @@ let enter_closure code_id return_continuation exn_continuation t =
   }
 
 let closure_info t = t.closure_info
-

--- a/middle_end/flambda/simplify/env/downwards_env.mli
+++ b/middle_end/flambda/simplify/env/downwards_env.mli
@@ -221,6 +221,8 @@ val without_closure_var_uses : t -> t
 
 val set_do_not_rebuild_terms_and_disable_inlining : t -> t
 
+val set_rebuild_terms : t -> t
+
 type are_rebuilding_terms
 
 val are_rebuilding_terms : t -> are_rebuilding_terms
@@ -234,4 +236,3 @@ val enter_closure
  -> t -> t
 
 val closure_info : t -> Closure_info.t
-

--- a/middle_end/flambda/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda/simplify/simplify_set_of_closures.ml
@@ -251,8 +251,9 @@ end = struct
       denv
       |> DE.enter_set_of_closures
       |> DE.increment_continuation_scope_level_twice
-      (* Even if we are not rebuilding terms we should always rebuild it
-         for local functions. *)
+      (* Even if we are not rebuilding terms we should always rebuild them
+         for local functions. The type of a function is dependent on its
+	 term and not knowing it prohibits us from inlining it.*)
       |> DE.set_rebuild_terms
     in
     let env_inside_functions,

--- a/middle_end/flambda/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda/simplify/simplify_set_of_closures.ml
@@ -251,6 +251,9 @@ end = struct
       denv
       |> DE.enter_set_of_closures
       |> DE.increment_continuation_scope_level_twice
+      (* Even if we are not rebuilding terms we should always rebuild it
+         for local functions. *)
+      |> DE.set_rebuild_terms
     in
     let env_inside_functions,
         closure_element_types_all_sets_inside_functions_rev =


### PR DESCRIPTION
While comparing the cost metrics computed between simplifying with rebuilding terms and simplifying it without rebuilding terms we found out that not building the terms for sub-functions would prohibit certain small functions from being inlined.

This pr always rebuilds the term for sub-functions and fixes this discrepancy.