### PR TITLE
Fix double counting of cost metrics for linearly used continuations

### DIFF
--- a/middle_end/flambda/simplify/simplify_apply_cont_expr.ml
+++ b/middle_end/flambda/simplify/simplify_apply_cont_expr.ml
@@ -56,7 +56,7 @@ let inline_linearly_used_continuation uacc ~create_apply_cont ~params ~handler
     let expr, uacc =
       let uacc =
         UA.with_name_occurrences uacc ~name_occurrences:free_names_of_handler
-        |> UA.add_cost_metrics cost_metrics_of_handler
+        |> UA.with_cost_metrics cost_metrics_of_handler
       in
       EB.make_new_let_bindings uacc ~bindings_outermost_first ~body:handler
     in

--- a/middle_end/flambda/terms/cost_metrics.rec.ml
+++ b/middle_end/flambda/terms/cost_metrics.rec.ml
@@ -128,7 +128,7 @@ let notify_removed ~operation t =
 
 let expr_size ~find_code e = Code_size.of_int (expr_size ~find_code e 0)
 
-let (+) a b ={
+let (+) a b = {
     size = Code_size.(+) a.size b.size;
     removed = Removed_operations.(+) a.removed b.removed
   }


### PR DESCRIPTION
The cost metrics for a continuation that is linearly used were double-counted in the uacc. The bug was two-fold:
- Firstly cost metric of the handler was being incorrectly passed through the uacc in simplify_let_cont_expr
- Secondly, in simplify_apply_cont, the cost metrics of a linearly used continuation was computed as (`UA.cost_metrics uacc + cost_metrics_of_handle`) and later on added on uacc.