### PR TITLE
Introduce tagging and not while going down on boolean switch

### DIFF
--- a/middle_end/flambda/simplify/simplify_expr.ml
+++ b/middle_end/flambda/simplify/simplify_expr.ml
@@ -37,6 +37,7 @@ let rec simplify_expr dacc expr ~down_to_up =
     Simplify_apply_cont_expr.simplify_apply_cont dacc apply_cont ~down_to_up
   | Switch switch ->
     Simplify_switch_expr.simplify_switch ~simplify_let dacc switch ~down_to_up
+      ~original_expr:expr
   | Invalid _ ->
     (* CR mshinwell: Make sure that a program can be simplified to just
        [Invalid].  [Un_cps] should translate any [Invalid] that it sees as if

--- a/middle_end/flambda/simplify/simplify_switch_expr.mli
+++ b/middle_end/flambda/simplify/simplify_switch_expr.mli
@@ -18,4 +18,5 @@
 
 val simplify_switch
    : simplify_let:Flambda.Let.t Simplify_common.expr_simplifier
+  -> original_expr:Flambda.Expr.t
   -> Flambda.Switch.t Simplify_common.expr_simplifier


### PR DESCRIPTION
To avoid the problem with variables created while going up, this creates the required tagging and boolean_not operations while going down.

It looks for the presence of those variables in the CSE env, and checks if the scrutinee is a constant.
If they are available, the variables are passed to the rebuild. Otherwise a lets are introduced around the switch and simplify is called on it. This means that simplify_switch can be entered up to 3 times for a given switch. I don't know if there is a better solution. If there is a bug in the CSE or something around that, it might turn into an infinite loop.

I might have made some mistakes around operation counting: I didn't record any 'introduced operation'. Should I do that ? It seems like it might be required maybe ?

This is not required as is, it is possible for data_flow to do without this patch, but this feels cleaner than the other version.