### PR TITLE
Replace tuple by proper record for arg_types_by_use_id

### DIFF
--- a/middle_end/flambda/simplify/env/continuation_env_and_param_types.ml
+++ b/middle_end/flambda/simplify/env/continuation_env_and_param_types.ml
@@ -19,11 +19,16 @@
 module T = Flambda_type
 module TE = Flambda_type.Typing_env
 
+type arg_at_use = {
+  arg_type : T.t;
+  typing_env : TE.t;
+}
+
 type t =
   | No_uses
   | Uses of {
       handler_env : Downwards_env.t;
-      arg_types_by_use_id : (TE.t * T.t) Apply_cont_rewrite_id.Map.t list;
+      arg_types_by_use_id : arg_at_use Apply_cont_rewrite_id.Map.t list;
       extra_params_and_args : Continuation_extra_params_and_args.t;
       is_single_inlinable_use : bool;
     }

--- a/middle_end/flambda/simplify/env/continuation_env_and_param_types.mli
+++ b/middle_end/flambda/simplify/env/continuation_env_and_param_types.mli
@@ -16,13 +16,16 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
+type arg_at_use = {
+  arg_type : Flambda_type.t;
+  typing_env : Flambda_type.Typing_env.t;
+}
+
 type t =
   | No_uses
   | Uses of {
       handler_env : Downwards_env.t;
-      arg_types_by_use_id :
-        (Flambda_type.Typing_env.t * Flambda_type.t)
-          Apply_cont_rewrite_id.Map.t list;
+      arg_types_by_use_id : arg_at_use Apply_cont_rewrite_id.Map.t list;
       extra_params_and_args : Continuation_extra_params_and_args.t;
       is_single_inlinable_use : bool;
     }

--- a/middle_end/flambda/simplify/typing_helpers/continuation_uses.ml
+++ b/middle_end/flambda/simplify/typing_helpers/continuation_uses.ml
@@ -281,12 +281,15 @@ Format.eprintf "The extra params and args are:@ %a\n%!"
     in
     let arg_types_by_use_id =
       List.fold_left (fun args use ->
-          List.map2 (fun arg_map arg_type ->
-              Apply_cont_rewrite_id.Map.add (U.id use)
-                (DE.typing_env (U.env_at_use use), arg_type)
-                arg_map)
-            args
-            (U.arg_types use))
+        List.map2 (fun arg_map arg_type ->
+          let env_at_use = U.env_at_use use in
+          let typing_env = DE.typing_env env_at_use in
+          let arg_at_use : Continuation_env_and_param_types.arg_at_use =
+            { arg_type; typing_env; }
+          in
+          Apply_cont_rewrite_id.Map.add (U.id use) arg_at_use arg_map)
+          args
+          (U.arg_types use))
         (List.map (fun _ -> Apply_cont_rewrite_id.Map.empty) t.arity)
         uses
     in

--- a/middle_end/flambda/unboxing/unbox_continuation_params.ml
+++ b/middle_end/flambda/unboxing/unbox_continuation_params.ml
@@ -1120,7 +1120,6 @@ let rec make_unboxing_decision denv ~depth ~arg_types_by_use_id
 let make_unboxing_decisions0 denv ~arg_types_by_use_id ~params
       ~param_types extra_params_and_args =
   assert (List.compare_lengths params param_types = 0);
-
   let denv, param_types_rev, extra_params_and_args =
     List.fold_left (fun (denv, param_types_rev, extra_params_and_args)
               (arg_types_by_use_id, (param, param_type)) ->

--- a/middle_end/flambda/unboxing/unbox_continuation_params.ml
+++ b/middle_end/flambda/unboxing/unbox_continuation_params.ml
@@ -1120,9 +1120,17 @@ let rec make_unboxing_decision denv ~depth ~arg_types_by_use_id
 let make_unboxing_decisions0 denv ~arg_types_by_use_id ~params
       ~param_types extra_params_and_args =
   assert (List.compare_lengths params param_types = 0);
+
   let denv, param_types_rev, extra_params_and_args =
     List.fold_left (fun (denv, param_types_rev, extra_params_and_args)
               (arg_types_by_use_id, (param, param_type)) ->
+        (* Temporary hack before the merge of the split unboxing work *)
+        let arg_types_by_use_id =
+          Apply_cont_rewrite_id.Map.map
+            (fun { Continuation_env_and_param_types.arg_type; typing_env; } ->
+              typing_env, arg_type
+            ) arg_types_by_use_id
+        in
         let denv, param_type, extra_params_and_args =
           make_unboxing_decision denv ~depth:1 ~arg_types_by_use_id
             ~param_being_unboxed:param ~param_type extra_params_and_args

--- a/middle_end/flambda/unboxing/unbox_continuation_params.mli
+++ b/middle_end/flambda/unboxing/unbox_continuation_params.mli
@@ -20,7 +20,8 @@ open! Simplify_import
 
 val make_unboxing_decisions
    : DE.t
-  -> arg_types_by_use_id:(TE.t * T.t) Apply_cont_rewrite_id.Map.t list
+  -> arg_types_by_use_id:
+       Continuation_env_and_param_types.arg_at_use Apply_cont_rewrite_id.Map.t list
   -> params:KP.t list
   -> param_types:T.t list
   -> Continuation_extra_params_and_args.t


### PR DESCRIPTION
This is a small cleanup/refactoring to avoid using a tuple, and instead use a record for the arg types by use id.

The change to the unboxing code was kept minimal (and thus a bit inefficient) as it didn't seem really useful to make a lot of modifications to code that will be replaced once #394 is merged.