### PR TITLE
Moving all lambda primitive transformations to cps_conversion

### DIFF
--- a/middle_end/flambda/from_lambda/cps_conversion.ml
+++ b/middle_end/flambda/from_lambda/cps_conversion.ml
@@ -30,6 +30,8 @@ type proto_switch = {
   failaction : L.lambda option;
 }
 
+type primitive_transform = No_transformation | Transformed of L.lambda
+
 let check_let_rec_bindings bindings =
   List.map (fun (binding : Lambda.lambda) ->
       match binding with
@@ -193,7 +195,7 @@ let transform_primitive (prim : L.primitive) args loc =
   | Psequor, [arg1; arg2] ->
     let const_true = Ident.create_local "const_true" in
     let cond = Ident.create_local "cond_sequor" in
-    Some
+    Transformed
       (L.Llet (Strict, Pgenval, const_true, Lconst (Const_base (Const_int 1)),
         (L.Llet (Strict, Pgenval, cond, arg1,
           switch_for_if_then_else
@@ -204,7 +206,7 @@ let transform_primitive (prim : L.primitive) args loc =
   | Psequand, [arg1; arg2] ->
     let const_false = Ident.create_local "const_false" in
     let cond = Ident.create_local "cond_sequand" in
-    Some
+    Transformed
       (L.Llet (Strict, Pgenval, const_false, Lconst (Const_base (Const_int 0)),
         (L.Llet (Strict, Pgenval, cond, arg1,
           switch_for_if_then_else
@@ -218,17 +220,17 @@ let transform_primitive (prim : L.primitive) args loc =
   | Pflambda_isint, _ ->
     Misc.fatal_error "[Pflambda_isint] should not exist at this stage" *)
   | Pisint, [arg] ->
-    Some
+    Transformed
       (switch_for_if_then_else
         ~cond:(L.Lprim (Pflambda_isint, [arg], loc))
         ~ifso:(L.Lconst (Const_base (Const_int 1)))
         ~ifnot:(L.Lconst (Const_base (Const_int 0)))
         (fun lam -> lam))
-  | (Pidentity | Pbytes_to_string | Pbytes_of_string), [arg] -> Some arg
+  | (Pidentity | Pbytes_to_string | Pbytes_of_string), [arg] -> Transformed arg
   | Pignore, [arg] ->
     let ident = Ident.create_local "ignore" in
     let result = L.Lconst (Const_base (Const_int 0)) in
-    Some (L.Llet (Strict, Pgenval, ident, arg, result))
+    Transformed (L.Llet (Strict, Pgenval, ident, arg, result))
   | Pdirapply, [funct; arg]
   | Prevapply, [arg; funct] ->
     let apply : L.lambda_apply =
@@ -243,8 +245,8 @@ let transform_primitive (prim : L.primitive) args loc =
         ap_specialised = Default_specialise;
       }
     in
-    Some (L.Lapply apply)
-  | _, _ -> None
+    Transformed (L.Lapply apply)
+  | _, _ -> No_transformation
 
 let rec cps_non_tail (lam : L.lambda) (k : Ident.t -> Ilambda.t)
           (k_exn : Continuation.t) : Ilambda.t =
@@ -325,7 +327,7 @@ let rec cps_non_tail (lam : L.lambda) (k : Ident.t -> Ilambda.t)
     I.Let (id, User_visible, value_kind, Simple (Const const), body)
   | Llet (let_kind, value_kind, id, Lprim (prim, args, loc), body) ->
     begin match transform_primitive prim args loc with
-    | None ->
+    | No_transformation ->
       (* This case avoids extraneous continuations. *)
       let prim, args, loc = simplify_primitive prim args loc in
       let exn_continuation : I.exn_continuation option =
@@ -342,7 +344,7 @@ let rec cps_non_tail (lam : L.lambda) (k : Ident.t -> Ilambda.t)
             Prim { prim; args; loc; exn_continuation; },
             body))
         k_exn
-    | Some lam ->
+    | Transformed lam ->
       cps_non_tail (L.Llet (let_kind, value_kind, id, lam, body)) k k_exn
     end
   | Llet (_let_kind, value_kind, id, defining_expr, body) ->
@@ -364,7 +366,7 @@ let rec cps_non_tail (lam : L.lambda) (k : Ident.t -> Ilambda.t)
     Let_rec (List.combine idents bindings, body)
   | Lprim (prim, args, loc) ->
     begin match transform_primitive prim args loc with
-    | None ->
+    | No_transformation ->
       let prim, args, loc = simplify_primitive prim args loc in
       let name = Printlambda.name_of_primitive prim in
       let result_var = Ident.create_local name in
@@ -383,7 +385,7 @@ let rec cps_non_tail (lam : L.lambda) (k : Ident.t -> Ilambda.t)
             Prim { prim; args; loc; exn_continuation; },
             k result_var))
         k_exn
-    | Some lam -> cps_non_tail lam k k_exn
+    | Transformed lam -> cps_non_tail lam k k_exn
     end
   | Lswitch (scrutinee,
       { sw_numconsts; sw_consts; sw_numblocks = _; sw_blocks; sw_failaction;
@@ -641,7 +643,7 @@ and cps_tail (lam : L.lambda) (k : Continuation.t) (k_exn : Continuation.t)
     I.Let (id, User_visible, value_kind, Simple (Const const), body)
   | Llet (let_kind, value_kind, id, Lprim (prim, args, loc), body) ->
     begin match transform_primitive prim args loc with
-    | None ->
+    | No_transformation ->
       (* This case avoids extraneous continuations. *)
       let prim, args, loc = simplify_primitive prim args loc in
       let exn_continuation : I.exn_continuation option =
@@ -658,7 +660,7 @@ and cps_tail (lam : L.lambda) (k : Continuation.t) (k_exn : Continuation.t)
             Prim { prim; args; loc; exn_continuation; },
             body))
         k_exn
-    | Some lam ->
+    | Transformed lam ->
        cps_tail (L.Llet (let_kind, value_kind, id, lam, body)) k k_exn
     end
   | Llet (_let_kind, _value_kind, id, Lassign (being_assigned, new_value),
@@ -690,7 +692,7 @@ and cps_tail (lam : L.lambda) (k : Continuation.t) (k_exn : Continuation.t)
     Let_rec (List.combine idents bindings, body)
   | Lprim (prim, args, loc) ->
     begin match transform_primitive prim args loc with
-    | None ->
+    | No_transformation ->
       (* CR mshinwell: Arrange for "args" to be named. *)
       let prim, args, loc = simplify_primitive prim args loc in
       let name = Printlambda.name_of_primitive prim in
@@ -707,7 +709,7 @@ and cps_tail (lam : L.lambda) (k : Continuation.t) (k_exn : Continuation.t)
           I.Let (result_var, Not_user_visible, Pgenval,
             Prim { prim; args; loc; exn_continuation; },
             Apply_cont (k, None, [Ilambda.Var result_var]))) k_exn
-    | Some lam -> cps_tail lam k k_exn
+    | Transformed lam -> cps_tail lam k k_exn
     end
   | Lswitch (scrutinee,
       { sw_numconsts; sw_consts; sw_numblocks = _; sw_blocks; sw_failaction;

--- a/middle_end/flambda/from_lambda/cps_conversion.ml
+++ b/middle_end/flambda/from_lambda/cps_conversion.ml
@@ -30,7 +30,7 @@ type proto_switch = {
   failaction : L.lambda option;
 }
 
-type primitive_transform =
+type primitive_transform_result =
   | Primitive of L.primitive * L.lambda list * L.scoped_location
   | Transformed of L.lambda
 

--- a/middle_end/flambda/from_lambda/cps_conversion.ml
+++ b/middle_end/flambda/from_lambda/cps_conversion.ml
@@ -157,6 +157,7 @@ let transform_primitive (prim : L.primitive) args loc =
   | (Psequand | Psequor), _ ->
     Misc.fatal_error "Psequand / Psequor must have exactly two arguments"
   (* Removed. Should be safe, but will no longer catch misuses.
+     CR keryan: do we still need this primitive ?
   | Pflambda_isint, _ ->
     Misc.fatal_error "[Pflambda_isint] should not exist at this stage" *)
   | Pisint, [arg] ->
@@ -244,28 +245,7 @@ let transform_primitive (prim : L.primitive) args loc =
            dimensions between 1 and 3 (see translprim)."
       end
     end
-  | (Pfloatcomp _ | Psetfield _ | Prevapply | Pdirapply | Pignore | Pidentity
-  | Pbytes_to_string | Pbytes_of_string | Pisint | Pnot | Pnegint | Paddint
-  | Psubint | Pmulint | Pandint | Porint | Pxorint | Plslint | Plsrint | Pasrint
-  | Pcompare_ints | Pcompare_floats | Pintoffloat | Pfloatofint | Pnegfloat
-  | Pabsfloat | Paddfloat | Psubfloat | Pmulfloat | Pdivfloat | Pstringlength
-  | Pstringrefu | Pstringrefs | Pbyteslength | Pbytesrefu | Pbytessetu
-  | Pbytesrefs | Pbytessets | Pflambda_isint | Pgettag | Pisout | Pbswap16
-  | Pint_as_pointer | Popaque | Pgetglobal _ | Psetglobal _ | Pmakeblock _
-  | Pmakefloatblock _ | Pfield _ | Pfield_computed _ | Psetfield_computed _
-  | Pfloatfield _ | Psetfloatfield _ | Pduprecord _ | Pccall _ | Praise _
-  | Pdivint _ | Pmodint _ | Pintcomp _ | Pcompare_bints _ | Poffsetint _
-  | Poffsetref _ | Pmakearray _ | Pduparray _ | Parraylength _ | Parrayrefu _
-  | Parraysetu _ | Parrayrefs _ | Parraysets _ | Pbintofint _ | Pintofbint _
-  | Pcvtbint _ | Pnegbint _ | Paddbint _ | Psubbint _ | Pmulbint _ | Pdivbint _
-  | Pmodbint _ | Pandbint _ | Porbint _ | Pxorbint _ | Plslbint _ | Plsrbint _
-  | Pasrbint _ | Pbintcomp _ | Pbigarraydim _ | Pstring_load_16 _
-  | Pstring_load_32 _ | Pstring_load_64 _ | Pbytes_load_16 _ | Pbytes_load_32 _
-  | Pbytes_load_64 _ | Pbytes_set_16 _ | Pbytes_set_32 _ | Pbytes_set_64 _
-  | Pbigstring_load_16 _ | Pbigstring_load_32 _ | Pbigstring_load_64 _
-  | Pbigstring_set_16 _ | Pbigstring_set_32 _ | Pbigstring_set_64 _ | Pctconst _
-  | Pbbswap _), _ ->
-     Primitive (prim, args, loc)
+  | _, _ -> Primitive (prim, args, loc)
 
 let rec cps_non_tail (lam : L.lambda) (k : Ident.t -> Ilambda.t)
           (k_exn : Continuation.t) : Ilambda.t =

--- a/middle_end/flambda/from_lambda/prepare_lambda.mli
+++ b/middle_end/flambda/from_lambda/prepare_lambda.mli
@@ -23,5 +23,3 @@
 val run
    : Lambda.lambda
   -> Lambda.lambda * Numbers.Int.Set.t
-
-val stub_hack_prim_name : string


### PR DESCRIPTION
Follow-up to #416.

This PR finish the job for primitives. 

EDIT: As @lthls summed up for me below, the patch moves `Prepare_lambda.simplify_primitive` in cps_conversion.ml. 
The issues I discussed in the initial comment are now resolved in a way I am confortable with.

--------

Although, the solution is not entirely satisfactory.

cps_conversion does some optimizations on constructs containing primitives. With the elimination of the preliminary pass, some cases may be voided by a transformation from a primitive to something else, leading to code duplication, and impaired readability IMO.
To avoid this, I chose to filter out those cases with a test that tell if a primitive will remain one after being processed. This simplifies the readability, reduce changes to existing code and avoid useless computations.
There are two issues with this:
- transforming primitives through a complete function to call back the main function recursively on the "same" object may lead to infinite loops if we're not careful.
- the test function is tightly linked to the fonction doing actual transformations, but can be easily overlooked in the future, leading to the first issue.

The alternative would be to simply test the returned value of the transformation to decide to loop or not, but we'd have to duplicate this at every case with a `Lprim` pattern.
There is still a lot to merge from prepare_lambda and duplication will not always be avoidable, but I would rather refrain to do so if there is another way. 