### PR TITLE
Deprecate support of 32 bits platforms

### DIFF
--- a/middle_end/flambda/to_cmm/un_cps.ml
+++ b/middle_end/flambda/to_cmm/un_cps.ml
@@ -29,9 +29,6 @@ module R = Un_cps_result
      on 32-bits integers that may have a result outside of the range.
 *)
 
-(* TODO: remove all uses of this, ^^ *)
-let todo () = failwith "Not yet implemented"
-
 (* Cmm helpers *)
 module C = struct
   include Cmm_helpers
@@ -91,7 +88,7 @@ let default_of_kind (k : Flambda_kind.t) =
   | Naked_number Naked_immediate -> C.int 0
   | Naked_number Naked_float -> C.float 0.
   | Naked_number Naked_int32 -> C.int 0
-  | Naked_number Naked_int64 when C.arch32 -> todo ()
+  | Naked_number Naked_int64 when C.arch32 -> C.unsupported_32_bits ()
   | Naked_number Naked_int64 -> C.int 0
   | Naked_number Naked_nativeint -> C.int 0
   | Fabricated -> Misc.fatal_error "Fabricated_kind have no default value"
@@ -139,7 +136,7 @@ let unary_int_arith_primitive _env dbg kind op arg =
   | Naked_immediate, Swap_byte_endianness -> C.bswap16 arg dbg
   (* Special case for manipulating int64 on 32-bit hosts *)
   | Naked_int64, Neg when C.arch32 ->
-    C.extcall ~alloc:false ~returns:true "caml_int64_neg_native" typ_int64 [arg]
+    C.unsupported_32_bits ()
   (* General case (including byte swap for 64-bit on 32-bit archi) *)
   | _, Neg -> C.sub_int (C.int 0) arg dbg
   | _, Swap_byte_endianness ->
@@ -155,26 +152,15 @@ let arithmetic_conversion dbg src dst arg =
   let open Flambda_kind.Standard_int_or_float in
   match src, dst with
   (* 64-bit on 32-bit host specific cases *)
-  | Naked_int64, Tagged_immediate when C.arch32 ->
-    None, C.extcall ~alloc:false ~returns:true "caml_int64_to_int" typ_int [arg]
-  | Naked_int64, Naked_int32 when C.arch32 ->
-    None, C.extcall ~alloc:false ~returns:true "caml_int64_to_int32" typ_int [arg]
-  | Naked_int64, (Naked_nativeint | Naked_immediate) when C.arch32 ->
-    None, C.extcall ~alloc:false ~returns:true "caml_int64_to_nativeint" typ_int [arg]
-  | Naked_int64, Naked_float when C.arch32 ->
-    None, C.extcall ~alloc:false ~returns:true "caml_int64_to_float_unboxed" typ_float [arg]
-  | Tagged_immediate, Naked_int64 when C.arch32 ->
-    None, C.extcall ~alloc:true ~returns:true "caml_int64_of_int" typ_val [arg]
-          |> C.unbox_number ~dbg Flambda_kind.Boxable_number.Naked_int64
-  | Naked_int32, Naked_int64 when C.arch32 ->
-    None, C.extcall ~alloc:true ~returns:true "caml_int64_of_int32" typ_val [arg]
-          |> C.unbox_number ~dbg Flambda_kind.Boxable_number.Naked_int64
-  | (Naked_nativeint | Naked_immediate), Naked_int64 when C.arch32 ->
-    None, C.extcall ~alloc:true ~returns:true "caml_int64_of_nativeint" typ_val [arg]
-          |> C.unbox_number ~dbg Flambda_kind.Boxable_number.Naked_int64
+  | Naked_int64, Tagged_immediate
+  | Naked_int64, Naked_int32
+  | Naked_int64, (Naked_nativeint | Naked_immediate)
+  | Naked_int64, Naked_float
+  | Tagged_immediate, Naked_int64
+  | Naked_int32, Naked_int64
+  | (Naked_nativeint | Naked_immediate), Naked_int64
   | Naked_float, Naked_int64 when C.arch32 ->
-    None, C.extcall ~alloc:true ~returns:true "caml_int64_of_float_unboxed" typ_val [arg]
-          |> C.unbox_number ~dbg Flambda_kind.Boxable_number.Naked_int64
+    C.unsupported_32_bits ()
   (* Identity on floats *)
   | Naked_float, Naked_float -> None, arg
   (* Conversions to and from tagged ints  *)
@@ -213,16 +199,9 @@ let binary_phys_comparison _env dbg kind op x y =
   match (kind : Flambda_kind.t),
         (op : Flambda_primitive.equality_comparison) with
   (* int64 special case *)
-  | Naked_number Naked_int64, Eq when C.arch32 ->
-    C.untag_int
-      (C.extcall ~alloc:true ~returns:true "caml_equal" typ_int
-         [C.box_int64 ~dbg x; C.box_int64 ~dbg y])
-      dbg
+  | Naked_number Naked_int64, Eq
   | Naked_number Naked_int64, Neq when C.arch32 ->
-    C.untag_int
-      (C.extcall ~alloc:true ~returns:true "caml_notequal" typ_int
-         [C.box_int64 ~dbg x; C.box_int64 ~dbg y])
-      dbg
+    C.unsupported_32_bits ()
   (* General case *)
   | _, Eq -> C.eq ~dbg x y
   | _, Neq -> C.neq ~dbg x y
@@ -231,22 +210,15 @@ let binary_int_arith_primitive _env dbg kind op x y =
   match (kind : Flambda_kind.Standard_int.t),
         (op : Flambda_primitive.binary_int_arith_op) with
   (* Int64 bits ints on 32-bit archs *)
-  | Naked_int64, Add when C.arch32 ->
-    C.extcall ~alloc:false ~returns:true "caml_int64_add_native" typ_int64 [x; y]
-  | Naked_int64, Sub when C.arch32 ->
-    C.extcall ~alloc:false ~returns:true "caml_int64_sub_native" typ_int64 [x; y]
-  | Naked_int64, Mul when C.arch32 ->
-    C.extcall ~alloc:false ~returns:true "caml_int64_mul_native" typ_int64 [x; y]
-  | Naked_int64, Div when C.arch32 ->
-    C.extcall ~alloc:true ~returns:true "caml_int64_div_native" typ_int64 [x; y]
-  | Naked_int64, Mod when C.arch32 ->
-    C.extcall ~alloc:true ~returns:true "caml_int64_mod_native" typ_int64 [x; y]
-  | Naked_int64, And when C.arch32 ->
-    C.extcall ~alloc:false ~returns:true "caml_int64_and_native" typ_int64 [x; y]
-  | Naked_int64, Or when C.arch32 ->
-    C.extcall ~alloc:false ~returns:true "caml_int64_or_native" typ_int64 [x; y]
+  | Naked_int64, Add
+  | Naked_int64, Sub
+  | Naked_int64, Mul
+  | Naked_int64, Div
+  | Naked_int64, Mod
+  | Naked_int64, And
+  | Naked_int64, Or
   | Naked_int64, Xor when C.arch32 ->
-    C.extcall ~alloc:false ~returns:true "caml_int64_xor_native" typ_int64 [x; y]
+    C.unsupported_32_bits ()
   (* Tagged integers *)
   | Tagged_immediate, Add -> C.add_int_caml x y dbg
   | Tagged_immediate, Sub -> C.sub_int_caml x y dbg
@@ -302,11 +274,11 @@ let binary_int_shift_primitive _env dbg kind op x y =
         (op : Flambda_primitive.int_shift_op) with
   (* Int64 special case *)
   | Naked_int64, Lsl when C.arch32 ->
-    todo() (* caml primitives for these have no native/unboxed version *)
+    C.unsupported_32_bits () (* caml primitives for these have no native/unboxed version *)
   | Naked_int64, Lsr when C.arch32 ->
-    todo() (* caml primitives for these have no native/unboxed version *)
+    C.unsupported_32_bits () (* caml primitives for these have no native/unboxed version *)
   | Naked_int64, Asr when C.arch32 ->
-    todo() (* caml primitives for these have no native/unboxed version *)
+    C.unsupported_32_bits () (* caml primitives for these have no native/unboxed version *)
   (* Tagged integers *)
   | Tagged_immediate, Lsl -> C.lsl_int_caml_raw ~dbg x y
   | Tagged_immediate, Lsr -> C.lsr_int_caml_raw ~dbg x y
@@ -333,20 +305,12 @@ let binary_int_comp_primitive _env dbg kind signed cmp x y =
         (signed : Flambda_primitive.signed_or_unsigned),
         (cmp : Flambda_primitive.ordered_comparison) with
   (* XXX arch32 cases need [untag_int] now. *)
-  | Naked_int64, Signed, Lt when C.arch32 ->
-    C.extcall ~alloc:true ~returns:true "caml_lessthan" typ_int
-      [C.box_int64 ~dbg x; C.box_int64 ~dbg y]
-  | Naked_int64, Signed, Le when C.arch32 ->
-    C.extcall ~alloc:true ~returns:true "caml_lessequal" typ_int
-      [C.box_int64 ~dbg x; C.box_int64 ~dbg y]
-  | Naked_int64, Signed, Gt when C.arch32 ->
-    C.extcall ~alloc:true ~returns:true "caml_greaterthan" typ_int
-      [C.box_int64 ~dbg x; C.box_int64 ~dbg y]
-  | Naked_int64, Signed, Ge when C.arch32 ->
-    C.extcall ~alloc:true ~returns:true "caml_greaterequal" typ_int
-      [C.box_int64 ~dbg x; C.box_int64 ~dbg y]
+  | Naked_int64, Signed, Lt
+  | Naked_int64, Signed, Le
+  | Naked_int64, Signed, Gt
+  | Naked_int64, Signed, Ge
   | Naked_int64, Unsigned, (Lt | Le | Gt | Ge) when C.arch32 ->
-    todo() (* There are no runtime C functions to do that afaict *)
+    C.unsupported_32_bits () (* There are no runtime C functions to do that afaict *)
   (* Tagged integers *)
   (* When comparing tagged integers, there is always one number for which
      the last bit is irrelevant.

--- a/middle_end/flambda/to_cmm/un_cps_helper.mli
+++ b/middle_end/flambda/to_cmm/un_cps_helper.mli
@@ -16,6 +16,8 @@
 
 (** {2 Useful misc values} *)
 
+val unsupported_32_bits : unit -> 'a
+
 val arch32 : bool
 (** [arch32] is [true] iff we are compiling for a 32-bit target. *)
 


### PR DESCRIPTION
We are suspecting some of this code to be incorrect and we prefer to discard it temporarily and to work on it more thoroughly later on.