### PR TITLE
Remove redundant max_inline depth clflag

### DIFF
--- a/Makefile.common.in
+++ b/Makefile.common.in
@@ -68,7 +68,7 @@ endif
 
 # CR mshinwell: We should be able to remove this inlining depth setting
 # once the new inliner has been merged.
-OPTCOMPFLAGS=-flambda-expert-max-inlining-depth 3
+OPTCOMPFLAGS=-inline-max-depth 3
 ifeq "$(FUNCTION_SECTIONS)" "true"
 OPTCOMPFLAGS += -function-sections
 endif

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -1004,11 +1004,6 @@ let mk_no_flambda_expert_phantom_lets f =
   " Do not generate phantom lets even when -g is specified"
 ;;
 
-let mk_flambda_expert_max_inlining_depth f =
-  "-flambda-expert-max-inlining-depth", Arg.Int f,
-  " Set maximum inlining depth"
-;;
-
 let mk_flambda_expert_max_block_size_for_projections f =
   "-flambda-expert-max-block-size-for-projections", Arg.Int f,
   " Do not simplify projections from blocks if the block size exceeds \
@@ -1280,7 +1275,6 @@ module type Optcommon_options = sig
   val _no_flambda_expert_inline_effects_in_cmm : unit -> unit
   val _flambda_expert_phantom_lets : unit -> unit
   val _no_flambda_expert_phantom_lets : unit -> unit
-  val _flambda_expert_max_inlining_depth : int -> unit
   val _flambda_expert_max_block_size_for_projections : int -> unit
   val _flambda_expert_max_unboxing_depth : int -> unit
   val _flambda_debug_permute_every_name : unit -> unit
@@ -1649,8 +1643,6 @@ struct
       F._flambda_expert_phantom_lets;
     mk_no_flambda_expert_phantom_lets
       F._no_flambda_expert_phantom_lets;
-    mk_flambda_expert_max_inlining_depth
-      F._flambda_expert_max_inlining_depth;
     mk_flambda_expert_max_block_size_for_projections
       F._flambda_expert_max_block_size_for_projections;
     mk_flambda_expert_max_unboxing_depth
@@ -1818,8 +1810,6 @@ module Make_opttop_options (F : Opttop_options) = struct
       F._flambda_expert_phantom_lets;
     mk_no_flambda_expert_phantom_lets
       F._no_flambda_expert_phantom_lets;
-    mk_flambda_expert_max_inlining_depth
-      F._flambda_expert_max_inlining_depth;
     mk_flambda_expert_max_block_size_for_projections
       F._flambda_expert_max_block_size_for_projections;
     mk_flambda_expert_max_unboxing_depth
@@ -2147,8 +2137,6 @@ module Default = struct
       set Flambda.Expert.phantom_lets
     let _no_flambda_expert_phantom_lets =
       clear Flambda.Expert.phantom_lets
-    let _flambda_expert_max_inlining_depth depth =
-      Flambda.Expert.max_inlining_depth := depth
     let _flambda_expert_max_block_size_for_projections size =
       Flambda.Expert.max_block_size_for_projections := Some size
     let _flambda_expert_max_unboxing_depth depth =

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -245,7 +245,6 @@ module type Optcommon_options = sig
   val _no_flambda_expert_inline_effects_in_cmm : unit -> unit
   val _flambda_expert_phantom_lets : unit -> unit
   val _no_flambda_expert_phantom_lets : unit -> unit
-  val _flambda_expert_max_inlining_depth : int -> unit
   val _flambda_expert_max_block_size_for_projections : int -> unit
   val _flambda_expert_max_unboxing_depth : int -> unit
   val _flambda_debug_permute_every_name : unit -> unit

--- a/middle_end/flambda/inlining/inlining_arguments.ml
+++ b/middle_end/flambda/inlining/inlining_arguments.ml
@@ -191,7 +191,7 @@ module Args = struct
     Clflags.Float_arg_helper.get ~key:round flag
 
   let create ~round = {
-    max_inlining_depth = !Clflags.Flambda.Expert.max_inlining_depth;
+    max_inlining_depth = cost_i !Clflags.inline_max_depth ~round;
     call_cost = cost_f !Clflags.inline_call_cost ~round;
     alloc_cost = cost_f !Clflags.inline_alloc_cost ~round;
     prim_cost = cost_f !Clflags.inline_prim_cost ~round;

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -475,7 +475,6 @@ module Flambda = struct
     let fallback_inlining_heuristic = ref false
     let inline_effects_in_cmm = ref false
     let phantom_lets = ref true
-    let max_inlining_depth = ref 1
     let max_block_size_for_projections = ref None
     let max_unboxing_depth = ref 3
   end

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -266,7 +266,6 @@ module Flambda : sig
     val fallback_inlining_heuristic : bool ref
     val inline_effects_in_cmm : bool ref
     val phantom_lets : bool ref
-    val max_inlining_depth : int ref
     val max_block_size_for_projections : int option ref
     val max_unboxing_depth : int ref
   end


### PR DESCRIPTION
The `Flambda.Expert.max_inlining_depth` is not needed anymore, since we can now use the proper values that are available in the information for each round. 