### PR TITLE
Direct conversion of lambda switches to ilambda

### DIFF
--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -467,7 +467,6 @@ and lambda_switch =
     sw_numblocks: int;
     sw_blocks: (lambda_switch_block_key * lambda) list;
     sw_failaction : lambda option;
-    sw_tags_to_sizes : Targetint.OCaml.t Tag.Scannable.Map.t;
   }
 
 and lambda_switch_block_key =
@@ -948,7 +947,6 @@ let shallow_map f = function
                  sw_numblocks = sw.sw_numblocks;
                  sw_blocks = List.map (fun (n, e) -> (n, f e)) sw.sw_blocks;
                  sw_failaction = Option.map f sw.sw_failaction;
-                 sw_tags_to_sizes = sw.sw_tags_to_sizes;
                },
                loc)
   | Lstringswitch (e, sw, default, loc) ->

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -339,7 +339,6 @@ and lambda_switch =
     sw_numblocks: int;                  (* Number of tag block cases *)
     sw_blocks: (lambda_switch_block_key * lambda) list;  (* Tag block cases *)
     sw_failaction : lambda option;      (* Action to take if failure *)
-    sw_tags_to_sizes : Targetint.OCaml.t Tag.Scannable.Map.t;
   }
 
 and lambda_switch_block_key =

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1999,7 +1999,6 @@ let inline_lazy_force_switch arg loc =
                         } )
                   ];
                 sw_failaction = Some varg;
-                sw_tags_to_sizes = Tag.Scannable.Map.empty;
               },
               loc ) ) )
 
@@ -2457,7 +2456,6 @@ module SArg = struct
           sw_numblocks = 0;
           sw_blocks = [];
           sw_failaction = None;
-          sw_tags_to_sizes = Tag.Scannable.Map.empty;
         },
         loc )
 
@@ -2959,7 +2957,6 @@ let combine_constructor loc arg pat_env cstr partial ctx def
                         sw_numblocks = cstr.cstr_nonconsts;
                         sw_blocks = nonconsts;
                         sw_failaction = fail_opt;
-                        sw_tags_to_sizes = Tag.Scannable.Map.empty;
                       }
                     in
                     let hs, sw = share_actions_sw sw in

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -59,7 +59,6 @@ let rec eliminate_ref id = function
             List.map (fun (n, e) -> (n, eliminate_ref id e)) sw.sw_blocks;
          sw_failaction =
             Option.map (eliminate_ref id) sw.sw_failaction;
-         sw_tags_to_sizes = sw.sw_tags_to_sizes;
         },
         loc)
   | Lstringswitch(e, sw, default, loc) ->

--- a/middle_end/flambda/from_lambda/cps_conversion.ml
+++ b/middle_end/flambda/from_lambda/cps_conversion.ml
@@ -1029,14 +1029,15 @@ and cps_switch (switch : L.lambda_switch) ~scrutinee (k : Continuation.t)
   let build_switch scrutinee wrappers =
     let const_switch = I.Switch (scrutinee, const_switch) in
     let scrutinee_tag = Ident.create_local "scrutinee_tag" in
-    let block_switch = I.Let ( scrutinee_tag,
-      Not_user_visible,
-      Pgenval,
-      Prim { prim = Pgettag;
-        args = [Var scrutinee];
-        loc = Loc_unknown;
-        exn_continuation = None; },
-      I.Switch(scrutinee_tag, block_switch))
+    let block_switch =
+      I.Let ( scrutinee_tag,
+        Not_user_visible,
+        Pintval,
+        Prim { prim = Pgettag;
+          args = [Var scrutinee];
+          loc = Loc_unknown;
+          exn_continuation = None; },
+        I.Switch(scrutinee_tag, block_switch))
     in
     if switch.sw_numblocks = 0 then const_switch, wrappers
     else if switch.sw_numconsts = 0 then block_switch, wrappers
@@ -1050,14 +1051,15 @@ and cps_switch (switch : L.lambda_switch) ~scrutinee (k : Continuation.t)
         }
       in
       let is_scrutinee_int = Ident.create_local "is_scrutinee_int" in
-      let isint_switch = I.Let ( is_scrutinee_int,
-      Not_user_visible,
-      Pgenval,
-      Prim { prim = Pflambda_isint;
-        args = [Var scrutinee];
-        loc = Loc_unknown;
-        exn_continuation = None; },
-      I.Switch(is_scrutinee_int, isint_switch))
+      let isint_switch =
+        I.Let ( is_scrutinee_int,
+          Not_user_visible,
+          Pintval,
+          Prim { prim = Pflambda_isint;
+            args = [Var scrutinee];
+            loc = Loc_unknown;
+            exn_continuation = None; },
+          I.Switch(is_scrutinee_int, isint_switch))
       in
       isint_switch,
       ((const_cont, const_switch)::(block_cont, block_switch)::wrappers)

--- a/middle_end/flambda/from_lambda/cps_conversion.ml
+++ b/middle_end/flambda/from_lambda/cps_conversion.ml
@@ -455,8 +455,9 @@ let rec cps_non_tail (lam : L.lambda) (k : Ident.t -> Ilambda.t)
       body;
       handler = after;
     }
-  | Lstringswitch _ ->
-    Misc.fatal_error "Lstringswitch must be expanded prior to CPS conversion"
+  | Lstringswitch (scrutinee, cases, default, loc) ->
+    cps_non_tail (Matching.expand_stringswitch loc scrutinee cases default)
+      k k_exn
   | Lstaticraise (static_exn, args) ->
     let continuation =
       match Numbers.Int.Map.find static_exn !static_exn_env with
@@ -766,8 +767,8 @@ and cps_tail (lam : L.lambda) (k : Continuation.t) (k_exn : Continuation.t)
     end
   | Lswitch (scrutinee,switch, _loc) ->
     cps_switch switch ~scrutinee k k_exn
-  | Lstringswitch _ ->
-    Misc.fatal_error "Lstringswitch must be expanded prior to CPS conversion"
+  | Lstringswitch (scrutinee, cases, default, loc) ->
+    cps_tail (Matching.expand_stringswitch loc scrutinee cases default) k k_exn
   | Lstaticraise (static_exn, args) ->
     let continuation =
       match Numbers.Int.Map.find static_exn !static_exn_env with

--- a/middle_end/flambda/from_lambda/cps_conversion.ml
+++ b/middle_end/flambda/from_lambda/cps_conversion.ml
@@ -133,7 +133,6 @@ let switch_for_if_then_else ~cond ~ifso ~ifnot =
       sw_numblocks = 0;
       sw_blocks = [];
       sw_failaction = None;
-      sw_tags_to_sizes = Tag.Scannable.Map.empty;
     }
   in
   L.Lswitch (cond, switch, Loc_unknown)
@@ -450,8 +449,8 @@ let rec cps_non_tail (lam : L.lambda) (k : Ident.t -> Ilambda.t)
     | Transformed lam -> cps_non_tail lam k k_exn
     end
   | Lswitch (scrutinee,
-      { sw_numconsts; sw_consts; sw_numblocks = _; sw_blocks; sw_failaction;
-        sw_tags_to_sizes = _; }, _loc) ->
+      { sw_numconsts; sw_consts; sw_numblocks = _; sw_blocks; sw_failaction; },
+      _loc) ->
     begin match sw_blocks with
     | [] -> ()
     | _ -> Misc.fatal_error "Lswitch `block' cases are forbidden"
@@ -784,8 +783,8 @@ and cps_tail (lam : L.lambda) (k : Continuation.t) (k_exn : Continuation.t)
     | Transformed lam -> cps_tail lam k k_exn
     end
   | Lswitch (scrutinee,
-      { sw_numconsts; sw_consts; sw_numblocks = _; sw_blocks; sw_failaction;
-        sw_tags_to_sizes = _; }, _loc) ->
+      { sw_numconsts; sw_consts; sw_numblocks = _; sw_blocks; sw_failaction;},
+      _loc) ->
     begin match sw_blocks with
     | [] -> ()
     | _ -> Misc.fatal_error "Lswitch `block' cases are forbidden"

--- a/middle_end/flambda/from_lambda/cps_conversion.ml
+++ b/middle_end/flambda/from_lambda/cps_conversion.ml
@@ -999,9 +999,8 @@ and cps_switch (switch : L.lambda_switch) ~scrutinee (k : Continuation.t)
       cases
   in
   let consts_rev, wrappers = convert_arms_rev switch.sw_consts [] in
-  let blocks_rev, wrappers = convert_arms_rev
-    (List.combine block_nums sw_blocks)
-    wrappers
+  let blocks_rev, wrappers =
+    convert_arms_rev (List.combine block_nums sw_blocks) wrappers
   in
   let consts = List.rev consts_rev in
   let blocks = List.rev blocks_rev in
@@ -1030,7 +1029,7 @@ and cps_switch (switch : L.lambda_switch) ~scrutinee (k : Continuation.t)
     let const_switch = I.Switch (scrutinee, const_switch) in
     let scrutinee_tag = Ident.create_local "scrutinee_tag" in
     let block_switch =
-      I.Let ( scrutinee_tag,
+      I.Let (scrutinee_tag,
         Not_user_visible,
         Pintval,
         Prim { prim = Pgettag;
@@ -1052,7 +1051,7 @@ and cps_switch (switch : L.lambda_switch) ~scrutinee (k : Continuation.t)
       in
       let is_scrutinee_int = Ident.create_local "is_scrutinee_int" in
       let isint_switch =
-        I.Let ( is_scrutinee_int,
+        I.Let (is_scrutinee_int,
           Not_user_visible,
           Pintval,
           Prim { prim = Pflambda_isint;

--- a/middle_end/flambda/from_lambda/prepare_lambda.ml
+++ b/middle_end/flambda/from_lambda/prepare_lambda.ml
@@ -225,7 +225,12 @@ let rec prepare env (lam : L.lambda) (k : L.lambda -> L.lambda) =
             in
             k (Lswitch (scrutinee, switch, loc))))))
   | Lstringswitch (scrutinee, cases, default, loc) ->
-    prepare env (Matching.expand_stringswitch loc scrutinee cases default) k
+    prepare env scrutinee (fun scrutinee ->
+      let patterns, actions = List.split cases in
+      prepare_list env actions (fun actions ->
+        prepare_option env default (fun default ->
+          let cases = List.combine patterns actions in
+          k (L.Lstringswitch (scrutinee, cases, default, loc)))))
   | Lstaticraise (cont, args) ->
     prepare_list env args (fun args ->
       k (L.Lstaticraise (cont, args)))

--- a/middle_end/flambda/from_lambda/prepare_lambda.ml
+++ b/middle_end/flambda/from_lambda/prepare_lambda.ml
@@ -231,33 +231,27 @@ let rec prepare env (lam : L.lambda) (k : L.lambda -> L.lambda) =
                 sw_numblocks = 0;
                 sw_blocks = [];
                 sw_failaction;
-                sw_tags_to_sizes = Tag.Scannable.Map.empty;
               }
             in
             (* CR mshinwell: Merge this file into Cps_conversion then delete
                [sw_tags_to_sizes]. *)
-            let tags_to_sizes =
-              List.fold_left (fun tags_to_sizes
-                        ({ sw_tag; sw_size; } : L.lambda_switch_block_key) ->
+            begin
+              List.iter (fun ({ sw_tag; _ } : L.lambda_switch_block_key) ->
                   match Tag.Scannable.create sw_tag with
                   | Some tag ->
                     let tag' = Tag.Scannable.to_tag tag in
-                    if Tag.is_structured_block_but_not_a_variant tag' then begin
+                    if Tag.is_structured_block_but_not_a_variant tag' then
                       Misc.fatal_errorf "Bad tag %a in [Lswitch] (tag is that \
                           of a scannable block, but not one treated like a \
                           variant; [Lswitch] can only be used for variant \
                           matching)"
                         Tag.print tag'
-                    end;
-                    let size = Targetint.OCaml.of_int sw_size in
-                    Tag.Scannable.Map.add tag size tags_to_sizes
                   | None ->
                     Misc.fatal_errorf "Bad tag %d in [Lswitch] (not the tag \
                         of a GC-scannable block)"
                       sw_tag)
-                Tag.Scannable.Map.empty
                 block_nums
-            in
+            end;
             let block_nums =
               List.map (fun ({ sw_tag; _} : L.lambda_switch_block_key) ->
                   sw_tag)
@@ -278,7 +272,6 @@ let rec prepare env (lam : L.lambda) (k : L.lambda -> L.lambda) =
                 sw_blocks = [];
                 sw_failaction;
                 (* XXX What about the size for the failaction? ... *)
-                sw_tags_to_sizes = tags_to_sizes;
               }
             in
             let consts_switch : L.lambda =
@@ -295,7 +288,6 @@ let rec prepare env (lam : L.lambda) (k : L.lambda -> L.lambda) =
                 sw_numblocks = 0;
                 sw_blocks = [];
                 sw_failaction = None;
-                sw_tags_to_sizes = Tag.Scannable.Map.empty;
               }
             in
             let switch =

--- a/middle_end/flambda/from_lambda/prepare_lambda.ml
+++ b/middle_end/flambda/from_lambda/prepare_lambda.ml
@@ -215,89 +215,15 @@ let rec prepare env (lam : L.lambda) (k : L.lambda -> L.lambda) =
       prepare_option env switch.sw_failaction (fun sw_failaction ->
         prepare_list env sw_consts (fun sw_consts ->
           prepare_list env sw_blocks (fun sw_blocks ->
-            let sw_failaction, wrap_switch =
-              match sw_failaction with
-              | None -> None, (fun lam -> lam)
-              | Some failaction ->
-                let failaction_cont = L.next_raise_count () in
-                let wrap_switch lam : L.lambda =
-                  Lstaticcatch (lam, (failaction_cont, []), failaction)
-                in
-                Some (L.Lstaticraise (failaction_cont, [])), wrap_switch
-            in
-            let consts_switch : L.lambda_switch =
+            let switch : L.lambda_switch =
               { sw_numconsts = switch.sw_numconsts;
                 sw_consts = List.combine const_nums sw_consts;
-                sw_numblocks = 0;
-                sw_blocks = [];
+                sw_numblocks = switch.sw_numblocks;
+                sw_blocks = List.combine block_nums sw_blocks;
                 sw_failaction;
               }
             in
-            (* CR mshinwell: Merge this file into Cps_conversion then delete
-               [sw_tags_to_sizes]. *)
-            begin
-              List.iter (fun ({ sw_tag; _ } : L.lambda_switch_block_key) ->
-                  match Tag.Scannable.create sw_tag with
-                  | Some tag ->
-                    let tag' = Tag.Scannable.to_tag tag in
-                    if Tag.is_structured_block_but_not_a_variant tag' then
-                      Misc.fatal_errorf "Bad tag %a in [Lswitch] (tag is that \
-                          of a scannable block, but not one treated like a \
-                          variant; [Lswitch] can only be used for variant \
-                          matching)"
-                        Tag.print tag'
-                  | None ->
-                    Misc.fatal_errorf "Bad tag %d in [Lswitch] (not the tag \
-                        of a GC-scannable block)"
-                      sw_tag)
-                block_nums
-            end;
-            let block_nums =
-              List.map (fun ({ sw_tag; _} : L.lambda_switch_block_key) ->
-                  sw_tag)
-                block_nums
-            in
-            if switch.sw_numblocks > Obj.last_non_constant_constructor_tag + 1
-            then begin
-              Misc.fatal_errorf "Too many blocks (%d) in [Lswitch], would \
-                  overlap into tag space for blocks that are not treated \
-                  like variants; [Lswitch] can only be used for variant \
-                  matching"
-                switch.sw_numblocks
-            end;
-            let blocks_switch : L.lambda_switch =
-              { sw_numconsts = switch.sw_numblocks;
-                sw_consts = List.combine block_nums sw_blocks;
-                sw_numblocks = 0;
-                sw_blocks = [];
-                sw_failaction;
-                (* XXX What about the size for the failaction? ... *)
-              }
-            in
-            let consts_switch : L.lambda =
-              L.Lswitch (scrutinee, consts_switch, loc)
-            in
-            let blocks_switch : L.lambda =
-              L.Lswitch (
-               Lprim (Pgettag, [scrutinee], Loc_unknown),
-               blocks_switch, loc)
-            in
-            let isint_switch : L.lambda_switch =
-              { sw_numconsts = 2;
-                sw_consts = [0, blocks_switch; 1, consts_switch];
-                sw_numblocks = 0;
-                sw_blocks = [];
-                sw_failaction = None;
-              }
-            in
-            let switch =
-              if switch.sw_numconsts = 0 then blocks_switch
-              else if switch.sw_numblocks = 0 then consts_switch
-              else
-                L.Lswitch (L.Lprim (Pflambda_isint, [scrutinee], Loc_unknown),
-                  isint_switch, loc)
-            in
-            k (wrap_switch switch)))))
+            k (Lswitch (scrutinee, switch, loc))))))
   | Lstringswitch (scrutinee, cases, default, loc) ->
     prepare env (Matching.expand_stringswitch loc scrutinee cases default) k
   | Lstaticraise (cont, args) ->


### PR DESCRIPTION
This moves Lswitch conversion to cps_conversion.
This is a bit more involved than previous PRs, as it skips almost entirely previous source to source transformation, but actually reduces code size for once.

The first commit is just relevant cleanup for an (already) unused record field.