### PR TITLE
Add script to compile coq

### DIFF
--- a/scripts/compile_coq.sh
+++ b/scripts/compile_coq.sh
@@ -9,7 +9,8 @@ help() {
   echo "                    this directory, including deleting it."
   echo "                    Omitting this entry will result in using a temp dir."
   echo "[-c|--compile-opam] Compile and use the latest version of opam."
-  echo "[--opam opam]       Use a specific version of opam."
+  echo "[--opam opam]       [opam] will be used as the opam command to execute."
+  echo "                    Usefull to specify a specific opam binary."
   echo "[-r|--remove]       Remove the destination directory after coq is compiled."
 }
 

--- a/scripts/compile_coq.sh
+++ b/scripts/compile_coq.sh
@@ -1,0 +1,71 @@
+#!/bin/sh -e
+
+help() {
+  echo "./compile-coq [compiler path] [path to directory]"
+  echo "[compiler path] is the path to the ocaml compiler"
+  echo "[path to directory] is the path to the drectory where eveything will be build." 
+  echo "                    This script considers that it is free to do anything from"
+  echo "                    this directory, including deleting it."
+  echo "                    Omitting this entry will result in using a temp dir."
+}
+
+if [ "$#" -le 0 ]
+then
+  help
+  exit 0
+elif [ "$#" -le 1 ]
+then
+  echo "1"
+  COMPILER_TO_TEST=$(realpath $1)
+  CWD=$(mktemp -d)
+else
+  echo "2"
+  COMPILER_TO_TEST=$(realpath $1)
+  CWD=$(realpath $2)
+fi
+echo $COMPILER_TO_TEST
+echo $CWD
+
+mkdir -p $CWD
+
+OCAML_PATH=$CWD/ocaml
+OPAM_PATH=$CWD/opam
+OPAM_INSTALL=$OPAM_PATH/_install
+OPAM_ROOT=$OPAM_PATH/.opam
+OPAM_EXE=$OPAM_INSTALL/bin/opam
+
+echo $OCAML_PATH
+echo $OPAM_PATH
+echo $OPAM_INSTALL
+echo $OPAM_ROOT
+echo $OPAM_EXE
+
+
+install_compiler () {
+  rm -rdf $OCAML_PATH
+  cp -r $COMPILER_TO_TEST $OCAML_PATH
+}
+
+install_and_build_opam () {
+  git clone https://github.com/ocaml/opam $OPAM_PATH
+  pushd $OPAM_PATH
+
+  ./configure --prefix=$OPAM_INSTALL
+  make lib-ext
+  make
+  make install
+  popd
+
+  rm -rdf $OPAM_ROOT
+  $OPAM_EXE init --root=$OPAM_ROOT -n --disable-sandboxing --bare
+}
+
+
+install_compiler
+install_and_build_opam
+
+pushd $OCAML_PATH
+$OPAM_EXE switch --root=$OPAM_ROOT create . --empty --repositories=default,beta=git+https://github.com/ocaml/ocaml-beta-repository.git
+$OPAM_EXE install --root=$OPAM_ROOT  . --inplace-build -y
+$OPAM_EXE pin add --root=$OPAM_ROOT  coq git+https://github.com/ocaml-flambda/coq.git#flambda2-patches -y
+

--- a/scripts/compile_coq.sh
+++ b/scripts/compile_coq.sh
@@ -1,9 +1,10 @@
 #!/bin/sh -e
 
 help() {
-  echo "./compile-coq <compiler path> <path to directory> [--opam opam] [-c|--compile-opam] [-r|--remove]"
-  echo "[compiler path]     is the path to the ocaml compiler"
-  echo "[path to directory] is the path to the drectory where eveything will be build." 
+  echo "./compile-coq <compiler_path> <path_to_directory> [--opam opam] [-c|--compile-opam] [-r|--remove]"
+  echo "[compiler_path]     is the path to the repository to test. It uses the files
+                            as in and does not the head of the git branch."
+  echo "[path_to_directory] is the path to the drectory where eveything will be build."
   echo "                    This script considers that it is free to do anything from"
   echo "                    this directory, including deleting it."
   echo "                    Omitting this entry will result in using a temp dir."
@@ -31,6 +32,10 @@ case $key in
     OPAM="$2"
     shift # past argument
     shift # past value
+    ;;
+  -h|--help)
+    help
+    exit 1
     ;;
   -r|--remove)
     REMOVE=true
@@ -101,6 +106,9 @@ cp -r $COMPILER_TO_TEST $OCAML_PATH
 $OPAM init -n --disable-sandboxing --bare
 
 pushd $OCAML_PATH
+# Remove pre-existing compilation artifacts
+make clean
+
 $OPAM switch create . --empty --repositories=default,beta=git+https://github.com/ocaml/ocaml-beta-repository.git
 
 # Once the switch is set try to compile coq. On failure remove the switch.

--- a/scripts/compile_coq.sh
+++ b/scripts/compile_coq.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 help() {
   echo "./compile-coq <compiler_path> <path_to_directory> [--opam opam] [-c|--compile-opam] [-r|--remove]"
@@ -10,7 +10,7 @@ help() {
   echo "                    Omitting this entry will result in using a temp dir."
   echo "[-c|--compile-opam] Compile and use the latest version of opam."
   echo "[--opam opam]       [opam] will be used as the opam command to execute."
-  echo "                    Usefull to specify a specific opam binary."
+  echo "                    Useful to specify a specific opam binary."
   echo "[-r|--remove]       Remove the destination directory after coq is compiled."
 }
 
@@ -66,6 +66,9 @@ fi
 # Setup the working environment
 mkdir -p $CWD
 OCAML_PATH=$CWD/ocaml
+# Export a custom OPAMROOT not to interfer with the user's existing opam
+# environment. All subsequent opam invocations will be done from an environment
+# setup in $CWD/.opam.
 export OPAMROOT=$CWD/.opam
 rm -rdf $OPAMROOT
 


### PR DESCRIPTION
Adds a small script that compiles coq with some Ocaml compiler.

To use it you can either do:
```
scripts/compile_coq <path to the ocaml directory> <path to somewhere where the artifacts are gonna be build>
```
Or
```
scripts/compile_coq <path to the ocaml directory>
```
In the second case coq will be build from a temp folder.
In the first case the script assumes that it is allow to do anything it wants from the artifact folder.

Basically this script does 3 things:
- Copy the current ocaml directory to some folder
- Build the latest opam from scratch
- Create a local swith & use it to build coq