### PR TITLE
Rename rec_info to coercion in preparation for the coercion patch

### DIFF
--- a/middle_end/flambda/basic/simple.ml
+++ b/middle_end/flambda/basic/simple.ml
@@ -53,21 +53,21 @@ let pattern_match' t ~var ~symbol ~const =
 
 let const_from_descr descr = const (RWC.of_descr descr)
 
-let without_rec_info t = pattern_match t ~name ~const
+let without_coercion t = pattern_match t ~name ~const
 
-let merge_rec_info t ~newer_rec_info =
+let merge_coercion t ~newer_coercion =
   if is_const t then None
   else
-    match newer_rec_info with
+    match newer_coercion with
     | None -> Some t
-    | Some newer_rec_info ->
-      let rec_info =
-        match rec_info t with
-        | None -> newer_rec_info
-        | Some older_rec_info ->
-          Rec_info.merge older_rec_info ~newer:newer_rec_info
+    | Some newer_coercion ->
+      let coercion =
+        match coercion t with
+        | None -> newer_coercion
+        | Some older_coercion ->
+          Rec_info.merge older_coercion ~newer:newer_coercion
       in
-      Some (with_rec_info (without_rec_info t) rec_info)
+      Some (with_coercion (without_coercion t) coercion)
 
 (* CR mshinwell: Make naming consistent with [Name] re. the option type *)
 
@@ -86,7 +86,7 @@ let [@inline always] must_be_name t =
 let to_name t =
   match must_be_name t with
   | None -> None
-  | Some name -> Some (rec_info t, name)
+  | Some name -> Some (coercion t, name)
 
 let map_name t ~f =
   match must_be_name t with

--- a/middle_end/flambda/basic/simple.mli
+++ b/middle_end/flambda/basic/simple.mli
@@ -23,11 +23,11 @@ include module type of struct include Reg_width_things.Simple end
 
 include Contains_names.S with type t := t
 
-val has_rec_info : t -> bool
+val has_coercion : t -> bool
 
-val merge_rec_info : t -> newer_rec_info:Rec_info.t option -> t option
+val merge_coercion : t -> newer_coercion:Rec_info.t option -> t option
 
-val without_rec_info : t -> t
+val without_coercion : t -> t
 
 val must_be_var : t -> Variable.t option
 

--- a/middle_end/flambda/cmx/ids_for_export.ml
+++ b/middle_end/flambda/cmx/ids_for_export.ml
@@ -75,7 +75,7 @@ let add_name t name =
 
 let add_simple t simple =
   let simples =
-    match Simple.rec_info simple with
+    match Simple.coercion simple with
     | None -> t.simples
     | Some _ -> Simple.Set.add simple t.simples
   in
@@ -93,7 +93,7 @@ let add_continuation t continuation =
 
 let from_simple simple =
   let simples =
-    match Simple.rec_info simple with
+    match Simple.coercion simple with
     | None ->
       (* This simple will not be in the grand_table_of_simples *)
       Simple.Set.empty

--- a/middle_end/flambda/compilenv_deps/reg_width_things.ml
+++ b/middle_end/flambda/compilenv_deps/reg_width_things.ml
@@ -225,27 +225,27 @@ end
 module Simple_data = struct
   type t = {
     simple : Id.t;  (* always without [Rec_info] *)
-    rec_info : Rec_info.t;
+    coercion : Rec_info.t;
   }
 
   let flags = simple_flags
 
-  let print ppf { simple = _; rec_info; } =
+  let print ppf { simple = _; coercion; } =
     Format.fprintf ppf "@[<hov 1>\
-        @[<hov 1>(rec_info@ %a)@]\
+        @[<hov 1>(coercion@ %a)@]\
         @]"
-      Rec_info.print rec_info
+      Rec_info.print coercion
 
-  let hash { simple; rec_info; } =
-    Hashtbl.hash (Id.hash simple, Rec_info.hash rec_info)
+  let hash { simple; coercion; } =
+    Hashtbl.hash (Id.hash simple, Rec_info.hash coercion)
 
   let equal t1 t2 =
     if t1 == t2 then true
     else
-      let { simple = simple1; rec_info = rec_info1; } = t1 in
-      let { simple = simple2; rec_info = rec_info2; } = t2 in
+      let { simple = simple1; coercion = coercion1; } = t1 in
+      let { simple = simple2; coercion = coercion2; } = t2 in
       Id.equal simple1 simple2
-        && Rec_info.equal rec_info1 rec_info2
+        && Rec_info.equal coercion1 coercion2
 end
 
 module Const = struct
@@ -519,7 +519,7 @@ module Simple = struct
 
   let find_data t = Table.find !grand_table_of_simples t
 
-  let has_rec_info t =
+  let has_coercion t =
     Id.flags t = simple_flags
 
   let name n = n
@@ -553,9 +553,9 @@ module Simple = struct
     in
     pattern_match t1 ~name ~const
 
-  let [@inline always] rec_info t =
+  let [@inline always] coercion t =
     let flags = Id.flags t in
-    if flags = simple_flags then Some ((find_data t).rec_info)
+    if flags = simple_flags then Some ((find_data t).coercion)
     else None
 
   module T0 = struct
@@ -569,15 +569,15 @@ module Simple = struct
           ~name:(fun name -> Name.print ppf name)
           ~const:(fun cst -> Const.print ppf cst)
       in
-      match rec_info t with
+      match coercion t with
       | None -> print ppf t
-      | Some rec_info ->
+      | Some coercion ->
        Format.fprintf ppf "@[<hov 1>\
             @[<hov 1>(simple@ %a)@] \
-            @[<hov 1>(rec_info@ %a)@]\
+            @[<hov 1>(coercion@ %a)@]\
             @]"
           print t
-          Rec_info.print rec_info
+          Rec_info.print coercion
 
     let output chan t =
       print (Format.formatter_of_out_channel chan) t
@@ -589,12 +589,12 @@ module Simple = struct
     include T0
   end
 
-  let with_rec_info t new_rec_info =
-    if Rec_info.is_initial new_rec_info then t
+  let with_coercion t new_coercion =
+    if Rec_info.is_initial new_coercion then t
     else
-      match rec_info t with
+      match coercion t with
       | None ->
-        let data : Simple_data.t = { simple = t; rec_info = new_rec_info; } in
+        let data : Simple_data.t = { simple = t; coercion = new_coercion; } in
         Table.add !grand_table_of_simples data
       | Some _ ->
         Misc.fatal_errorf "Cannot add [Rec_info] to [Simple] %a that already \

--- a/middle_end/flambda/compilenv_deps/reg_width_things.mli
+++ b/middle_end/flambda/compilenv_deps/reg_width_things.mli
@@ -154,12 +154,12 @@ module Simple : sig
 
   val const : Const.t -> t
 
-  val rec_info : t -> Rec_info.t option
+  val coercion : t -> Rec_info.t option
 
-  val with_rec_info : t -> Rec_info.t -> t
+  val with_coercion : t -> Rec_info.t -> t
 
   (* This does not consult the grand table of [Simple]s. *)
-  val has_rec_info : t -> bool
+  val has_coercion : t -> bool
 
   val pattern_match
      : t
@@ -168,7 +168,7 @@ module Simple : sig
     -> 'a
 
   (* [same s1 s2] returns true iff they represent the same name or const
-     i.e. [same s (with_rec_info s rec_info)] returns true *)
+     i.e. [same s (with_coercion s coercion)] returns true *)
   val same : t -> t -> bool
 
   val export : t -> exported

--- a/middle_end/flambda/inlining/inlining_state.ml
+++ b/middle_end/flambda/inlining/inlining_state.ml
@@ -21,7 +21,7 @@ type t = {
   depth: int
 }
 
-let increment_depth t = { t with depth = t.depth + 1 } 
+let increment_depth t = { t with depth = t.depth + 1 }
 
 let default = {
     arguments = Inlining_arguments.unknown;

--- a/middle_end/flambda/inlining/inlining_transforms.ml
+++ b/middle_end/flambda/inlining/inlining_transforms.ml
@@ -40,8 +40,8 @@ let make_inlined_body ~callee ~unroll_to ~params ~args ~my_closure ~body
       apply_exn_continuation
   in
   let callee =
-    Simple.merge_rec_info callee
-      ~newer_rec_info:(Some (Rec_info.create ~depth:1 ~unroll_to))
+    Simple.merge_coercion callee
+      ~newer_coercion:(Some (Rec_info.create ~depth:1 ~unroll_to))
     |> Option.get  (* CR mshinwell: improve *)
   in
   Expr.apply_renaming

--- a/middle_end/flambda/naming/renaming.ml
+++ b/middle_end/flambda/naming/renaming.ml
@@ -330,15 +330,15 @@ let apply_simple t simple =
     let new_name = apply_name t old_name in
     if old_name == new_name then simple
     else
-      match Simple.rec_info simple with
+      match Simple.coercion simple with
       | None -> Simple.name new_name
-      | Some rec_info -> Simple.with_rec_info (Simple.name new_name) rec_info
+      | Some coercion -> Simple.with_coercion (Simple.name new_name) coercion
   in
   (* Constants are never permuted, only freshened upon import. *)
   Simple.pattern_match simple
     ~name
     ~const:(fun cst ->
-      assert (not (Simple.has_rec_info simple));
+      assert (not (Simple.has_coercion simple));
       Simple.const (apply_const t cst))
 
 let closure_var_is_used t closure_var =

--- a/middle_end/flambda/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda/simplify/simplify_apply_expr.ml
@@ -643,11 +643,11 @@ let simplify_function_call ~simplify_expr dacc apply ~callee_ty
       in
       (* CR mshinwell: This should go in Typing_env (ditto logic for Rec_info
          in Simplify_simple *)
-      let function_decl_rec_info =
-        let rec_info = I.rec_info inlinable in
-        match Simple.rec_info (Apply.callee apply) with
-        | None -> rec_info
-        | Some newer -> Rec_info.merge rec_info ~newer
+      let function_decl_coercion =
+        let coercion = I.rec_info inlinable in
+        match Simple.coercion (Apply.callee apply) with
+        | None -> coercion
+        | Some newer -> Rec_info.merge coercion ~newer
       in
       let callee's_code_id_from_type = I.code_id inlinable in
       let callee's_code = DE.find_code denv callee's_code_id_from_type in
@@ -658,7 +658,7 @@ let simplify_function_call ~simplify_expr dacc apply ~callee_ty
         ~result_arity:(Code.result_arity callee's_code)
         ~recursive:(Code.recursive callee's_code)
         ~must_be_detupled
-        (Some (inlinable, function_decl_rec_info))
+        (Some (inlinable, function_decl_coercion))
         ~down_to_up
     | Ok (Non_inlinable non_inlinable) ->
       let module N = T.Function_declaration_type.Non_inlinable in

--- a/middle_end/flambda/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda/simplify/simplify_unary_primitive.ml
@@ -38,12 +38,12 @@ module Int64 = Numbers.Int64
             {(thd3/0
               (Ok (Inlinable (code_id thd3_0_tuple_stub/2) (param_arity 𝕍)
                    (result_arity 𝕍) (stub true) (dbg ) (inline Default_inline)
-                   (is_a_functor false) (recursive Non_recursive) (rec_info ((depth 1) (unroll_to None))))))
+                   (is_a_functor false) (recursive Non_recursive) (coercion ((depth 1) (unroll_to None))))))
              (thd3/1
               (Ok (Inlinable (code_id thd3_0/3) (param_arity 𝕍 ⨯ 𝕍 ⨯ 𝕍)
                    (result_arity 𝕍) (stub false) (dbg tuple_stub.ml:1,9--20)
                    (inline Default_inline) (is_a_functor false) (recursive Non_recursive)
-                   (rec_info ((depth 1) (unroll_to None))))))})
+                   (coercion ((depth 1) (unroll_to None))))))})
            (closure_types ((components_by_index {(thd3/0 (Val (= Tuple_stub.camlTuple_stub__thd3_2))) (thd3/1 (Val (= Tuple_stub.camlTuple_stub__thd3_3)))})))
            (closure_var_types ((components_by_index {})))))}) (other_tags Bottom)))
     unboxed_version/48 : (Val (= Tuple_stub.camlTuple_stub__thd3_3)))))

--- a/middle_end/flambda/types/env/aliases.ml
+++ b/middle_end/flambda/types/env/aliases.ml
@@ -582,8 +582,8 @@ let add t element1 binding_time_and_mode1
           ));
   end;
   let original_t = t in
-  let element1 = Simple.without_rec_info element1 in
-  let element2 = Simple.without_rec_info element2 in
+  let element1 = Simple.without_coercion element1 in
+  let element2 = Simple.without_coercion element2 in
   let add_if_name simple data map =
     Simple.pattern_match simple
       ~const:(fun _ -> map)

--- a/middle_end/flambda/types/env/typing_env.rec.ml
+++ b/middle_end/flambda/types/env/typing_env.rec.ml
@@ -996,7 +996,7 @@ and add_equation t name ty =
       let canonical = Aliases.get_canonical_ignoring_name_mode aliases name in
       aliases, canonical, t, ty
     | alias_of ->
-      let alias_of = Simple.without_rec_info alias_of in
+      let alias_of = Simple.without_coercion alias_of in
       let alias = Simple.name name in
       let kind = Type_grammar.kind ty in
       let binding_time_and_mode_alias = binding_time_and_mode t name in
@@ -1325,7 +1325,7 @@ let get_canonical_simple_exn t ?min_name_mode ?name_mode_of_existing_simple
 let get_alias_then_canonical_simple_exn t ?min_name_mode
       ?name_mode_of_existing_simple typ =
   let simple = Type_grammar.get_alias_exn typ in
-  let simple = Simple.without_rec_info simple in
+  let simple = Simple.without_coercion simple in
   get_canonical_simple_exn t ?min_name_mode ?name_mode_of_existing_simple
     simple
 

--- a/middle_end/flambda/types/flambda_type.mli
+++ b/middle_end/flambda/types/flambda_type.mli
@@ -289,7 +289,7 @@ val make_suitable_for_environment
   -> bind_to:Name.t
   -> Typing_env_extension.With_extra_variables.t
 
-val apply_rec_info : flambda_type -> Rec_info.t -> flambda_type Or_bottom.t
+val apply_coercion : flambda_type -> Rec_info.t -> flambda_type Or_bottom.t
 
 (* Remove any information from the inside of the type, leaving only its
    outer structure, and in some cases leaving only "Unknown".  Alias types

--- a/middle_end/flambda/types/structures/function_declaration_type.rec.ml
+++ b/middle_end/flambda/types/structures/function_declaration_type.rec.ml
@@ -294,11 +294,11 @@ let join (env : Join_env.t) (t1 : t) (t2 : t) : t =
     | Unknown -> Unknown
     end
 
-let apply_rec_info (t : t) rec_info : t Or_bottom.t =
+let apply_coercion (t : t) coercion : t Or_bottom.t =
   match t with
   | Ok (Inlinable { code_id; dbg; rec_info = rec_info'; is_tupled;
                     must_be_inlined }) ->
-    let rec_info = Rec_info.merge rec_info' ~newer:rec_info in
+    let rec_info = Rec_info.merge rec_info' ~newer:coercion in
     Ok (Ok (Inlinable { code_id;
       dbg;
       rec_info;

--- a/middle_end/flambda/types/structures/function_declaration_type.rec.mli
+++ b/middle_end/flambda/types/structures/function_declaration_type.rec.mli
@@ -62,4 +62,4 @@ include Type_structure_intf.S
   with type join_env := Join_env.t
   with type typing_env_extension := Typing_env_extension.t
 
-val apply_rec_info : t -> Rec_info.t -> t Or_bottom.t
+val apply_coercion : t -> Rec_info.t -> t Or_bottom.t

--- a/middle_end/flambda/types/template/flambda_type.templ.ml
+++ b/middle_end/flambda/types/template/flambda_type.templ.ml
@@ -1096,7 +1096,7 @@ let reify ?allowed_if_free_vars_defined_in ?additional_free_var_criterion
                 | Bottom | Unknown | Ok (Non_inlinable _) ->
                   function_decls_with_closure_vars
                 | Ok (Inlinable inlinable_decl) ->
-                  (* CR mshinwell: We're ignoring [rec_info] *)
+                  (* CR mshinwell: We're ignoring [coercion] *)
                   let closure_var_types =
                     Closures_entry.closure_var_types closures_entry
                   in

--- a/middle_end/flambda/types/type_descr.rec.ml
+++ b/middle_end/flambda/types/type_descr.rec.ml
@@ -129,18 +129,18 @@ module Make (Head : Type_head_intf.S
       | Equals alias -> alias
       | No_alias _ -> assert false
 
-  let apply_rec_info t rec_info : _ Or_bottom.t =
+  let apply_coercion t coercion : _ Or_bottom.t =
     match descr t with
     | Equals simple ->
-      let newer_rec_info = Some rec_info in
-      begin match Simple.merge_rec_info simple ~newer_rec_info with
+      let newer_coercion = Some coercion in
+      begin match Simple.merge_coercion simple ~newer_coercion with
       | None -> Bottom
       | Some simple -> Ok (create_equals simple)
       end
     | No_alias Unknown -> Ok t
     | No_alias Bottom -> Bottom
     | No_alias (Ok head) ->
-      Or_bottom.map (Head.apply_rec_info head rec_info)
+      Or_bottom.map (Head.apply_coercion head coercion)
         ~f:(fun head -> create head)
 
   let force_to_head ~force_to_kind t =
@@ -179,15 +179,15 @@ module Make (Head : Type_head_intf.S
           | No_alias Unknown -> Unknown
           | No_alias (Ok head) -> Ok head
             (* CR mshinwell: Fix Rec_info
-            begin match rec_info with
+            begin match coercion with
             | None -> Ok head
-            | Some rec_info ->
-              (* CR mshinwell: check rec_info handling is correct, after
+            | Some coercion ->
+              (* CR mshinwell: check coercion handling is correct, after
                  recent changes in this area *)
-              (* [simple] already has [rec_info] applied to it (see
+              (* [simple] already has [coercion] applied to it (see
                  [get_canonical_simple], above).  However we also need to
                  apply it to the expanded head of the type. *)
-              match Head.apply_rec_info head rec_info with
+              match Head.apply_coercion head coercion with
               | Bottom -> Bottom
               | Ok head -> Ok head
             end
@@ -499,7 +499,7 @@ module Make (Head : Type_head_intf.S
       | Some bound_name ->
         (* CR vlaviron: this ensures that we're not creating an alias
            to a different simple that is just bound_name with different
-           rec_info. Such an alias is forbidden. *)
+           coercion. Such an alias is forbidden. *)
         Aliases.Alias_set.filter ~f:(fun simple ->
             not (Simple.same simple (Simple.name bound_name)))
           shared_aliases

--- a/middle_end/flambda/types/type_descr_intf.ml
+++ b/middle_end/flambda/types/type_descr_intf.ml
@@ -62,7 +62,7 @@ module type S = sig
 
   include Contains_ids.S with type t := t
 
-  val apply_rec_info : t -> Rec_info.t -> t Or_bottom.t
+  val apply_coercion : t -> Rec_info.t -> t Or_bottom.t
 
   val eviscerate
      : force_to_kind:(flambda_type -> t)  (* CR mshinwell: "of_type"? *)

--- a/middle_end/flambda/types/type_grammar.rec.ml
+++ b/middle_end/flambda/types/type_grammar.rec.ml
@@ -158,35 +158,35 @@ let all_ids_for_export t =
   | Naked_int64 ty -> T_N64.all_ids_for_export ty
   | Naked_nativeint ty -> T_NN.all_ids_for_export ty
 
-let apply_rec_info t rec_info : _ Or_bottom.t =
+let apply_coercion t coercion : _ Or_bottom.t =
   match t with
   | Value ty ->
-    begin match T_V.apply_rec_info ty rec_info with
+    begin match T_V.apply_coercion ty coercion with
     | Ok ty -> Ok (Value ty)
     | Bottom -> Bottom
     end
   | Naked_immediate ty ->
-    begin match T_NI.apply_rec_info ty rec_info with
+    begin match T_NI.apply_coercion ty coercion with
     | Ok ty -> Ok (Naked_immediate ty)
     | Bottom -> Bottom
     end
   | Naked_float ty ->
-    begin match T_Nf.apply_rec_info ty rec_info with
+    begin match T_Nf.apply_coercion ty coercion with
     | Ok ty -> Ok (Naked_float ty)
     | Bottom -> Bottom
     end
   | Naked_int32 ty ->
-    begin match T_N32.apply_rec_info ty rec_info with
+    begin match T_N32.apply_coercion ty coercion with
     | Ok ty -> Ok (Naked_int32 ty)
     | Bottom -> Bottom
     end
   | Naked_int64 ty ->
-    begin match T_N64.apply_rec_info ty rec_info with
+    begin match T_N64.apply_coercion ty coercion with
     | Ok ty -> Ok (Naked_int64 ty)
     | Bottom -> Bottom
     end
   | Naked_nativeint ty ->
-    begin match T_NN.apply_rec_info ty rec_info with
+    begin match T_NN.apply_coercion ty coercion with
     | Ok ty -> Ok (Naked_nativeint ty)
     | Bottom -> Bottom
     end

--- a/middle_end/flambda/types/type_grammar.rec.mli
+++ b/middle_end/flambda/types/type_grammar.rec.mli
@@ -39,7 +39,7 @@ val kind : t -> Flambda_kind.t
 
 val alias_type_of : Flambda_kind.t -> Simple.t -> t
 
-val apply_rec_info : t -> Rec_info.t -> t Or_bottom.t
+val apply_coercion : t -> Rec_info.t -> t Or_bottom.t
 
 val eviscerate : t -> Typing_env.t -> t
 

--- a/middle_end/flambda/types/type_head_intf.ml
+++ b/middle_end/flambda/types/type_head_intf.ml
@@ -43,7 +43,7 @@ module type S = sig
     -> t
     -> t Or_unknown.t
 
-  val apply_rec_info : t -> Rec_info.t -> t Or_bottom.t
+  val apply_coercion : t -> Rec_info.t -> t Or_bottom.t
 
   val eviscerate : t -> t Or_unknown.t
 end

--- a/middle_end/flambda/types/type_of_kind/type_of_kind_naked_float0.rec.ml
+++ b/middle_end/flambda/types/type_of_kind/type_of_kind_naked_float0.rec.ml
@@ -32,8 +32,8 @@ let free_names _t = Name_occurrences.empty
 
 let all_ids_for_export _t = Ids_for_export.empty
 
-let apply_rec_info t rec_info : _ Or_bottom.t =
-  if Rec_info.is_initial rec_info then Ok t
+let apply_coercion t coercion : _ Or_bottom.t =
+  if Rec_info.is_initial coercion then Ok t
   else Bottom
 
 let eviscerate _ : _ Or_unknown.t = Unknown

--- a/middle_end/flambda/types/type_of_kind/type_of_kind_naked_immediate0.rec.ml
+++ b/middle_end/flambda/types/type_of_kind/type_of_kind_naked_immediate0.rec.ml
@@ -61,8 +61,8 @@ let all_ids_for_export t =
   | Naked_immediates _ -> Ids_for_export.empty
   | Is_int ty | Get_tag ty -> T.all_ids_for_export ty
 
-let apply_rec_info t rec_info : _ Or_bottom.t =
-  if Rec_info.is_initial rec_info then Ok t
+let apply_coercion t coercion : _ Or_bottom.t =
+  if Rec_info.is_initial coercion then Ok t
   else Bottom
 
 let eviscerate _ : _ Or_unknown.t = Unknown

--- a/middle_end/flambda/types/type_of_kind/type_of_kind_naked_int32_0.rec.ml
+++ b/middle_end/flambda/types/type_of_kind/type_of_kind_naked_int32_0.rec.ml
@@ -32,8 +32,8 @@ let free_names _t = Name_occurrences.empty
 
 let all_ids_for_export _t = Ids_for_export.empty
 
-let apply_rec_info t rec_info : _ Or_bottom.t =
-  if Rec_info.is_initial rec_info then Ok t
+let apply_coercion t coercion : _ Or_bottom.t =
+  if Rec_info.is_initial coercion then Ok t
   else Bottom
 
 let eviscerate _ : _ Or_unknown.t = Unknown

--- a/middle_end/flambda/types/type_of_kind/type_of_kind_naked_int64_0.rec.ml
+++ b/middle_end/flambda/types/type_of_kind/type_of_kind_naked_int64_0.rec.ml
@@ -32,8 +32,8 @@ let free_names _t = Name_occurrences.empty
 
 let all_ids_for_export _t = Ids_for_export.empty
 
-let apply_rec_info t rec_info : _ Or_bottom.t =
-  if Rec_info.is_initial rec_info then Ok t
+let apply_coercion t coercion : _ Or_bottom.t =
+  if Rec_info.is_initial coercion then Ok t
   else Bottom
 
 let eviscerate _ : _ Or_unknown.t = Unknown

--- a/middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.ml
+++ b/middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.ml
@@ -31,8 +31,8 @@ let free_names _t = Name_occurrences.empty
 
 let all_ids_for_export _t = Ids_for_export.empty
 
-let apply_rec_info t rec_info : _ Or_bottom.t =
-  if Rec_info.is_initial rec_info then Ok t
+let apply_coercion t coercion : _ Or_bottom.t =
+  if Rec_info.is_initial coercion then Ok t
   else Bottom
 
 let eviscerate _ : _ Or_unknown.t = Unknown

--- a/middle_end/flambda/types/type_of_kind/type_of_kind_value0.rec.ml
+++ b/middle_end/flambda/types/type_of_kind/type_of_kind_value0.rec.ml
@@ -156,7 +156,7 @@ let all_ids_for_export t =
   | String _ -> Ids_for_export.empty
   | Array { length; } -> T.all_ids_for_export length
 
-let apply_rec_info t rec_info : _ Or_bottom.t =
+let apply_coercion t coercion : _ Or_bottom.t =
   match t with
   | Closures { by_closure_id; } ->
     Or_bottom.map
@@ -164,7 +164,7 @@ let apply_rec_info t rec_info : _ Or_bottom.t =
        map_function_decl_types
         by_closure_id
         ~f:(fun (decl : Function_declaration_type.t) : _ Or_bottom.t ->
-          Function_declaration_type.apply_rec_info decl rec_info))
+          Function_declaration_type.apply_coercion decl coercion))
       ~f:(fun by_closure_id -> Closures { by_closure_id; })
   | Variant _
   | Boxed_float _
@@ -173,7 +173,7 @@ let apply_rec_info t rec_info : _ Or_bottom.t =
   | Boxed_nativeint _
   | String _
   | Array _ ->
-    if Rec_info.is_initial rec_info then Ok t
+    if Rec_info.is_initial coercion then Ok t
     else Bottom
 
 let eviscerate t : _ Or_unknown.t =


### PR DESCRIPTION
This is purely alpha-renaming; no semantic changes for the moment.