### PR TITLE
Add depth variables to typing environments

### DIFF
--- a/.depend
+++ b/.depend
@@ -9165,6 +9165,7 @@ middle_end/flambda/types/flambda_type.cmo : \
     middle_end/flambda/types/structures/row_like_maps_to_intf.cmo \
     middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/basic/reg_width_const.cmi \
+    middle_end/flambda/terms/rec_info_expr.cmi \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
     middle_end/flambda/types/structures/product_intf.cmo \
     utils/printing_cache.cmi \
@@ -9183,6 +9184,7 @@ middle_end/flambda/types/flambda_type.cmo : \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/types/kinds/flambda_arity.cmi \
+    middle_end/flambda/compilenv_deps/depth_variable.cmi \
     lambda/debuginfo.cmi \
     middle_end/flambda/simplify/env/continuation_use_kind.cmi \
     middle_end/flambda/naming/contains_names.cmo \
@@ -9219,6 +9221,7 @@ middle_end/flambda/types/flambda_type.cmx : \
     middle_end/flambda/types/structures/row_like_maps_to_intf.cmx \
     middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/basic/reg_width_const.cmx \
+    middle_end/flambda/terms/rec_info_expr.cmx \
     middle_end/flambda/compilenv_deps/rec_info.cmx \
     middle_end/flambda/types/structures/product_intf.cmx \
     utils/printing_cache.cmx \
@@ -9237,6 +9240,7 @@ middle_end/flambda/types/flambda_type.cmx : \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/types/kinds/flambda_arity.cmx \
+    middle_end/flambda/compilenv_deps/depth_variable.cmx \
     lambda/debuginfo.cmx \
     middle_end/flambda/simplify/env/continuation_use_kind.cmx \
     middle_end/flambda/naming/contains_names.cmx \
@@ -9265,6 +9269,7 @@ middle_end/flambda/types/flambda_type.cmi : \
     middle_end/flambda/basic/scope.cmi \
     middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/basic/reg_width_const.cmi \
+    middle_end/flambda/terms/rec_info_expr.cmi \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
     utils/printing_cache.cmi \
     middle_end/flambda/types/basic/or_unknown_or_bottom.cmi \
@@ -9280,6 +9285,7 @@ middle_end/flambda/types/flambda_type.cmi : \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/types/kinds/flambda_arity.cmi \
+    middle_end/flambda/compilenv_deps/depth_variable.cmi \
     lambda/debuginfo.cmi \
     middle_end/flambda/simplify/env/continuation_use_kind.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
@@ -9676,6 +9682,7 @@ middle_end/flambda/types/env/typing_env.rec.cmo : \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/basic/scope.cmi \
     middle_end/flambda/naming/renaming.cmi \
+    middle_end/flambda/terms/rec_info_expr.cmi \
     utils/printing_cache.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
@@ -9686,6 +9693,7 @@ middle_end/flambda/types/env/typing_env.rec.cmo : \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
+    middle_end/flambda/compilenv_deps/depth_variable.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/compilenv_deps/coercion.cmi \
     middle_end/flambda/types/structures/code_age_relation.cmi \
@@ -9700,6 +9708,7 @@ middle_end/flambda/types/env/typing_env.rec.cmx : \
     middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/basic/scope.cmx \
     middle_end/flambda/naming/renaming.cmx \
+    middle_end/flambda/terms/rec_info_expr.cmx \
     utils/printing_cache.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
@@ -9710,6 +9719,7 @@ middle_end/flambda/types/env/typing_env.rec.cmx : \
     middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
+    middle_end/flambda/compilenv_deps/depth_variable.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
     middle_end/flambda/compilenv_deps/coercion.cmx \
     middle_end/flambda/types/structures/code_age_relation.cmx \
@@ -9724,6 +9734,7 @@ middle_end/flambda/types/env/typing_env.rec.cmi : \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/basic/scope.cmi \
     middle_end/flambda/naming/renaming.cmi \
+    middle_end/flambda/terms/rec_info_expr.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/naming/name_in_binding_pos.cmi \
@@ -9731,6 +9742,7 @@ middle_end/flambda/types/env/typing_env.rec.cmi : \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
+    middle_end/flambda/compilenv_deps/depth_variable.cmi \
     middle_end/flambda/simplify/env/continuation_use_kind.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/basic/code_id.cmi \
@@ -9771,6 +9783,7 @@ middle_end/flambda/types/env/typing_env_level.rec.cmo : \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
     middle_end/flambda/terms/symbol_projection.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
+    middle_end/flambda/terms/rec_info_expr.cmi \
     utils/printing_cache.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
@@ -9781,6 +9794,7 @@ middle_end/flambda/types/env/typing_env_level.rec.cmo : \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
+    middle_end/flambda/compilenv_deps/depth_variable.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/types/structures/code_age_relation.cmi \
     utils/clflags.cmi \
@@ -9791,6 +9805,7 @@ middle_end/flambda/types/env/typing_env_level.rec.cmx : \
     middle_end/flambda/naming/var_in_binding_pos.cmx \
     middle_end/flambda/terms/symbol_projection.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
+    middle_end/flambda/terms/rec_info_expr.cmx \
     utils/printing_cache.cmx \
     middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
@@ -9801,6 +9816,7 @@ middle_end/flambda/types/env/typing_env_level.rec.cmx : \
     middle_end/flambda/basic/kinded_parameter.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
+    middle_end/flambda/compilenv_deps/depth_variable.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
     middle_end/flambda/types/structures/code_age_relation.cmx \
     utils/clflags.cmx \
@@ -9810,10 +9826,12 @@ middle_end/flambda/types/env/typing_env_level.rec.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/terms/symbol_projection.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
+    middle_end/flambda/terms/rec_info_expr.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/basic/name.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
+    middle_end/flambda/compilenv_deps/depth_variable.cmi \
     middle_end/flambda/simplify/env/continuation_use_kind.cmi \
     middle_end/flambda/cmx/contains_ids.cmo \
     middle_end/flambda/types/env/binding_time.cmi \

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -258,6 +258,7 @@ MIDDLE_END_FLAMBDA_NAMING=\
   middle_end/flambda/naming/bindable_variable_in_terms.cmo
 
 MIDDLE_END_FLAMBDA_TYPES=\
+  middle_end/flambda/terms/rec_info_expr.cmo \
   middle_end/flambda/types/basic/var_within_closure_set.cmo \
   middle_end/flambda/types/kinds/flambda_arity.cmo \
   middle_end/flambda/types/env/binding_time.cmo \
@@ -294,7 +295,6 @@ MIDDLE_END_FLAMBDA_TERMS=\
   middle_end/flambda/terms/set_of_closures.cmo \
   middle_end/flambda/inlining/metrics/code_size.cmo \
   middle_end/flambda/inlining/metrics/removed_operations.cmo \
-  middle_end/flambda/terms/rec_info_expr.cmo \
   middle_end/flambda/terms/flambda.cmo \
   middle_end/flambda/terms/flambda_unit.cmo
 

--- a/middle_end/flambda/compilenv_deps/or_infinity.ml
+++ b/middle_end/flambda/compilenv_deps/or_infinity.ml
@@ -1,0 +1,40 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                   Mark Shinwell, Jane Street Europe                    *)
+(*                                                                        *)
+(*   Copyright 2021 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+type 'a t =
+  | Finite of 'a
+  | Infinity
+
+let equal ~f t1 t2 =
+  match t1, t2 with
+  | Finite a1, Finite a2 -> f a1 a2
+  | Infinity, Infinity -> true
+  | (Finite _ | Infinity), _ -> false
+
+let compare ~f t1 t2 =
+  match t1, t2 with
+  | Finite a1, Finite a2 -> f a1 a2
+  | Infinity, Infinity -> 0
+  | Finite _, Infinity -> -1
+  | Infinity, Finite _ -> 1
+
+let hash ~f = function
+  | Finite a -> Hashtbl.hash (0, f a)
+  | Infinity -> Hashtbl.hash 1
+
+let print ~f ppf = function
+  | Finite a -> f ppf a
+  | Infinity -> Format.pp_print_string ppf "\u{221e}"

--- a/middle_end/flambda/compilenv_deps/or_infinity.mli
+++ b/middle_end/flambda/compilenv_deps/or_infinity.mli
@@ -1,0 +1,24 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                   Mark Shinwell, Jane Street Europe                    *)
+(*                                                                        *)
+(*   Copyright 2021 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-30-40-41-42"]
+
+type 'a t =
+  | Finite of 'a
+  | Infinity
+
+val compare : f:('a -> 'a -> int) -> 'a t -> 'a t -> int
+val equal : f:('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+val hash : f:('a -> int) -> 'a t -> int
+val print : f:(Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit

--- a/middle_end/flambda/naming/name_occurrences.ml
+++ b/middle_end/flambda/naming/name_occurrences.ml
@@ -1041,6 +1041,8 @@ let mem_newer_version_of_code_id t code_id =
   For_code_ids.mem t.newer_version_of_code_ids code_id
 let mem_closure_var t closure_var =
   For_closure_vars.mem t.closure_vars closure_var
+let mem_depth_variable t depth_variable =
+  For_depth_variables.mem t.depth_variables depth_variable
 
 let remove_var t var =
   if For_names.is_empty t.names then t

--- a/middle_end/flambda/naming/name_occurrences.mli
+++ b/middle_end/flambda/naming/name_occurrences.mli
@@ -153,6 +153,8 @@ val mem_newer_version_of_code_id : t -> Code_id.t -> bool
 
 val mem_closure_var : t -> Var_within_closure.t -> bool
 
+val mem_depth_variable : t -> Depth_variable.t -> bool
+
 val remove_var : t -> Variable.t -> t
 
 val remove_code_id_or_symbol : t -> Code_id_or_symbol.t -> t

--- a/middle_end/flambda/terms/rec_info_expr.ml
+++ b/middle_end/flambda/terms/rec_info_expr.ml
@@ -14,26 +14,36 @@
 (*                                                                        *)
 (**************************************************************************)
 
-[@@@ocaml.warning "+a-4-30-40-41-42"]
+[@@@ocaml.warning "+a-30-40-41-42"]
 
 type t =
-  | Initial
+  | Const of { depth : int Or_infinity.t; unroll_to : int option }
   | Var of Depth_variable.t
   | Succ of t
   | Unroll_to of int * t
 
-let initial = Initial
+let initial = Const { depth = Finite 0; unroll_to = None }
+let unknown = Const { depth = Infinity; unroll_to = None }
+let const ~depth ~unroll_to = Const { depth; unroll_to }
 let var dv = Var dv
 let succ t = Succ t
 let unroll_to unroll_depth t = Unroll_to (unroll_depth, t)
 
 let is_obviously_initial = function
-  | Initial -> true
-  | _ -> false
+  | Const { depth = Finite 0; unroll_to = None } -> true
+  | Const { depth = (Finite _ | Infinity); _ }
+  | Var _ | Succ _ | Unroll_to _ -> false
 
 let rec print ppf = function
-  | Initial ->
-    Format.pp_print_string ppf "0"
+  | Const { depth; unroll_to } ->
+    Format.fprintf ppf "%s@[<hov 1>(\
+        @[<hov 1>(depth@ %a)@]@ \
+        @[<hov 1>(unroll_to@ %a)@]\
+        )@]%s"
+      (Flambda_colours.rec_info ())
+      (Or_infinity.print ~f:Format.pp_print_int) depth
+      (Misc.Stdlib.Option.print Numbers.Int.print) unroll_to
+      (Flambda_colours.normal ())
   | Var dv ->
     Depth_variable.print ppf dv
   | Succ t ->
@@ -45,18 +55,21 @@ let print_with_cache ~cache:_ ppf t = print ppf t
 
 let rec equal t1 t2 =
   match t1, t2 with
-  | Initial, Initial -> true
+  | Const { depth = depth1; unroll_to = unroll_to1 },
+    Const { depth = depth2; unroll_to = unroll_to2 } ->
+    Or_infinity.equal ~f:Int.equal depth1 depth2
+    && Option.equal Int.equal unroll_to1 unroll_to2
   | Var dv1, Var dv2 ->
     Depth_variable.equal dv1 dv2
   | Succ t1, Succ t2 ->
     equal t1 t2
   | Unroll_to (unroll_depth1, t1), Unroll_to (unroll_depth2, t2) ->
     unroll_depth1 = unroll_depth2 && equal t1 t2
-  | (Initial | Var _ | Succ _ | Unroll_to _), _ -> false
+  | (Const _ | Var _ | Succ _ | Unroll_to _), _ -> false
 
 let rec apply_renaming t perm =
   match t with
-  | Initial -> Initial
+  | Const _ -> t
   | Var dv ->
     Var (Renaming.apply_depth_variable perm dv)
   | Succ t ->
@@ -65,7 +78,7 @@ let rec apply_renaming t perm =
     Unroll_to (unroll_depth, apply_renaming t perm)
 
 let rec free_names = function
-  | Initial -> Name_occurrences.empty
+  | Const _ -> Name_occurrences.empty
   | Var dv -> Name_occurrences.singleton_depth_variable dv
   | Succ t
   | Unroll_to (_, t) -> free_names t

--- a/middle_end/flambda/terms/rec_info_expr.ml
+++ b/middle_end/flambda/terms/rec_info_expr.ml
@@ -34,6 +34,11 @@ let is_obviously_initial = function
   | Const { depth = (Finite _ | Infinity); _ }
   | Var _ | Succ _ | Unroll_to _ -> false
 
+let is_obviously_unknown = function
+  | Const { depth = Infinity; unroll_to = None } -> true
+  | Const { depth = (Finite _ | Infinity); _ }
+  | Var _ | Succ _ | Unroll_to _ -> false
+
 let rec print ppf = function
   | Const { depth; unroll_to } ->
     Format.fprintf ppf "%s@[<hov 1>(\
@@ -88,3 +93,56 @@ let invariant _ _ = ()
 let all_ids_for_export _ =
   (* Depth variables don't use the integer id system *)
   Ids_for_export.empty
+
+let compute_succ ~(depth : int Or_infinity.t) ~(unroll_to : int option) =
+  let depth : int Or_infinity.t =
+    match depth with
+    | Finite n -> Finite (n+1)
+    | Infinity -> Infinity
+  in
+  let unroll_to =
+    match unroll_to with
+    | None | Some 0 -> unroll_to
+    | Some n -> Some (n-1)
+  in
+  Const { depth; unroll_to }
+
+let compute_unroll_to ~depth ~old_unroll_to ~new_unroll_to =
+  (* Take the maximum of the two unroll depths. This allows an external
+     caller to specify more unrolling than the recursive call sites do. *)
+  let unroll_to =
+    match old_unroll_to with
+    | None ->
+      Some new_unroll_to
+    | Some unroll_to ->
+      if unroll_to >= new_unroll_to then old_unroll_to else
+        Some new_unroll_to
+  in
+  Const { depth; unroll_to }
+
+let rec simplify orig_t ~find_var =
+  match orig_t with
+  | Const _ -> orig_t
+  | Var dv ->
+    begin match find_var dv with
+    | Some t ->
+      (* All bound names are fresh, so fine to use the same environment *)
+      simplify t ~find_var
+    | None ->
+      orig_t
+    end
+  | Succ t ->
+    begin match simplify t ~find_var with
+    | Const { depth; unroll_to } ->
+      compute_succ ~depth ~unroll_to
+    | (Var _ | Succ _ | Unroll_to _) as new_t ->
+      if t == new_t then orig_t else Succ new_t
+    end
+  | Unroll_to (unroll_depth, t) ->
+    begin match simplify t ~find_var with
+    | Const { depth; unroll_to } ->
+      compute_unroll_to ~depth
+        ~old_unroll_to:unroll_to ~new_unroll_to:unroll_depth
+    | (Var _ | Succ _ | Unroll_to _) as new_t ->
+      if t == new_t then orig_t else Unroll_to (unroll_depth, new_t)
+    end

--- a/middle_end/flambda/terms/rec_info_expr.mli
+++ b/middle_end/flambda/terms/rec_info_expr.mli
@@ -38,9 +38,12 @@ val succ : t -> t
 val unroll_to : int -> t -> t
 
 val is_obviously_initial : t -> bool
+val is_obviously_unknown : t -> bool
 
 val equal : t -> t -> bool
 
 include Expr_std.S with type t := t
 
 include Contains_ids.S with type t := t
+
+val simplify : t -> find_var:(Depth_variable.t -> t option) -> t

--- a/middle_end/flambda/terms/rec_info_expr.mli
+++ b/middle_end/flambda/terms/rec_info_expr.mli
@@ -19,10 +19,8 @@
 (** An expression for the state of recursive inlining at a given occurrence.
     Forms the right-hand side of a [Let_expr] binding for a depth variable. Will
     evaluate (given a suitable environment) to a [Rec_info.t]. *)
-type t =
-  | Initial
-    (** The initial recursion depth. In user code, all occurrences have depth
-        zero. *)
+type t = private
+  | Const of { depth : int Or_infinity.t; unroll_to : int option }
   | Var of Depth_variable.t
   | Succ of t
     (** The next depth. If we inline an occurrence with depth [d], then in the
@@ -33,6 +31,8 @@ type t =
         point all unrolling should stop. *)
 
 val initial : t
+val unknown : t
+val const : depth:int Or_infinity.t -> unroll_to:int option -> t
 val var : Depth_variable.t -> t
 val succ : t -> t
 val unroll_to : int -> t -> t

--- a/middle_end/flambda/types/env/typing_env.rec.ml
+++ b/middle_end/flambda/types/env/typing_env.rec.ml
@@ -923,6 +923,17 @@ let mem_depth_variable ?min_name_mode t dv =
     ~find:(fun dv t -> Depth_variable.Map.find dv (depth_variables t))
     ~in_imported_names:(fun _ _ -> false)
 
+let find_depth_variable t dv =
+  let value, _binding_time, _name_mode =
+    Depth_variable.Map.find dv (depth_variables t)
+  in
+  value
+
+let find_depth_variable_or_missing t dv =
+  match find_depth_variable t dv with
+  | exception Not_found -> None
+  | value -> Some value
+
 let add_definition t (name : Name_in_binding_pos.t) kind =
   let name_mode = Name_in_binding_pos.name_mode name in
   Name.pattern_match (Name_in_binding_pos.name name)

--- a/middle_end/flambda/types/env/typing_env.rec.mli
+++ b/middle_end/flambda/types/env/typing_env.rec.mli
@@ -56,6 +56,12 @@ val add_symbol_projection : t -> Variable.t -> Symbol_projection.t -> t
 
 val find_symbol_projection : t -> Variable.t -> Symbol_projection.t option
 
+val add_depth_variable
+   : t
+  -> Depth_variable.t
+  -> Rec_info_expr.t
+  -> t
+
 val add_equations_on_params
    : t
   -> params:Kinded_parameter.t list
@@ -82,6 +88,9 @@ val variable_is_from_missing_cmx_file : t -> Name.t -> bool
 val mem : ?min_name_mode:Name_mode.t -> t -> Name.t -> bool
 
 val mem_simple : ?min_name_mode:Name_mode.t -> t -> Simple.t -> bool
+
+val mem_depth_variable
+   : ?min_name_mode:Name_mode.t -> t -> Depth_variable.t -> bool
 
 (* CR mshinwell: clarify that this does not meet *)
 (* CR vlaviron: If the underlying level in the extension defines several

--- a/middle_end/flambda/types/env/typing_env.rec.mli
+++ b/middle_end/flambda/types/env/typing_env.rec.mli
@@ -84,6 +84,13 @@ val find_or_missing : t -> Name.t -> Type_grammar.t option
 
 val find_params : t -> Kinded_parameter.t list -> Type_grammar.t list
 
+val find_depth_variable : t -> Depth_variable.t -> Rec_info_expr.t
+
+val find_depth_variable_or_missing
+   : t
+  -> Depth_variable.t
+  -> Rec_info_expr.t option
+
 val variable_is_from_missing_cmx_file : t -> Name.t -> bool
 
 val mem : ?min_name_mode:Name_mode.t -> t -> Name.t -> bool

--- a/middle_end/flambda/types/env/typing_env.rec.mli
+++ b/middle_end/flambda/types/env/typing_env.rec.mli
@@ -60,6 +60,7 @@ val add_depth_variable
    : t
   -> Depth_variable.t
   -> Rec_info_expr.t
+  -> name_mode:Name_mode.t
   -> t
 
 val add_equations_on_params

--- a/middle_end/flambda/types/env/typing_env.rec.mli
+++ b/middle_end/flambda/types/env/typing_env.rec.mli
@@ -52,16 +52,13 @@ val add_symbol_definition : t -> Symbol.t -> t
 
 val add_symbol_definitions : t -> Symbol.Set.t -> t
 
+val add_depth_variable_definition : t -> Depth_variable.t -> t
+
+val add_depth_variable_equation : t -> Depth_variable.t -> Rec_info_expr.t -> t
+
 val add_symbol_projection : t -> Variable.t -> Symbol_projection.t -> t
 
 val find_symbol_projection : t -> Variable.t -> Symbol_projection.t option
-
-val add_depth_variable
-   : t
-  -> Depth_variable.t
-  -> Rec_info_expr.t
-  -> name_mode:Name_mode.t
-  -> t
 
 val add_equations_on_params
    : t

--- a/middle_end/flambda/types/env/typing_env_level.rec.mli
+++ b/middle_end/flambda/types/env/typing_env_level.rec.mli
@@ -58,7 +58,13 @@ val add_symbol_projection : t -> Variable.t -> Symbol_projection.t -> t
 
 val symbol_projections : t -> Symbol_projection.t Variable.Map.t
 
-val add_depth_variable : t -> Depth_variable.t -> Rec_info_expr.t -> t
+val add_depth_var_definition : t -> Depth_variable.t -> t
+
+val add_or_replace_depth_var_equation
+   : t
+  -> Depth_variable.t
+  -> Rec_info_expr.t
+  -> t
 
 val concat : t -> t -> t
 

--- a/middle_end/flambda/types/env/typing_env_level.rec.mli
+++ b/middle_end/flambda/types/env/typing_env_level.rec.mli
@@ -58,6 +58,8 @@ val add_symbol_projection : t -> Variable.t -> Symbol_projection.t -> t
 
 val symbol_projections : t -> Symbol_projection.t Variable.Map.t
 
+val add_depth_variable : t -> Depth_variable.t -> Rec_info_expr.t -> t
+
 val concat : t -> t -> t
 
 (* val meet : Meet_env.t -> t -> t -> t *)

--- a/middle_end/flambda/types/flambda_type.mli
+++ b/middle_end/flambda/types/flambda_type.mli
@@ -109,6 +109,8 @@ module Typing_env : sig
 
   val find_symbol_projection : t -> Variable.t -> Symbol_projection.t option
 
+  val add_depth_variable : t -> Depth_variable.t -> Rec_info_expr.t -> t
+
   val add_equation : t -> Name.t -> flambda_type -> t
 
   val add_equations_on_params

--- a/middle_end/flambda/types/flambda_type.mli
+++ b/middle_end/flambda/types/flambda_type.mli
@@ -140,6 +140,13 @@ module Typing_env : sig
 
   val find_params : t -> Kinded_parameter.t list -> flambda_type list
 
+  val find_depth_variable : t -> Depth_variable.t -> Rec_info_expr.t
+
+  val find_depth_variable_or_missing
+    : t
+    -> Depth_variable.t
+    -> Rec_info_expr.t option
+
   val add_env_extension : t -> Typing_env_extension.t -> t
 
   val add_env_extension_with_extra_variables

--- a/middle_end/flambda/types/flambda_type.mli
+++ b/middle_end/flambda/types/flambda_type.mli
@@ -109,7 +109,12 @@ module Typing_env : sig
 
   val find_symbol_projection : t -> Variable.t -> Symbol_projection.t option
 
-  val add_depth_variable : t -> Depth_variable.t -> Rec_info_expr.t -> t
+  val add_depth_variable
+     : t
+    -> Depth_variable.t
+    -> Rec_info_expr.t
+    -> name_mode:Name_mode.t
+    -> t
 
   val add_equation : t -> Name.t -> flambda_type -> t
 


### PR DESCRIPTION
The implementation mostly just parallels `symbol_projections`, though the depth variables also need to store their binding time and name mode (for symbol projections those are already known from the variable).