### PR TITLE
Convert raise_notrace non-escaping exceptions into jumps

### DIFF
--- a/flambdatest/mlexamples/local_exns_to_jumps.ml
+++ b/flambdatest/mlexamples/local_exns_to_jumps.ml
@@ -1,0 +1,75 @@
+type 'a ref = { mutable contents : 'a }
+external ref : 'a -> 'a ref = "%makemutable"
+external ( ! ) : 'a ref -> 'a = "%field0"
+external ( := ) : 'a ref -> 'a -> unit = "%setfield0"
+external ( < ) : 'a -> 'a -> bool = "%lessthan"
+external ( + ) : int -> int -> int = "%addint"
+external raise : exn -> 'a = "%raise"
+external raise_notrace : exn -> 'a = "%raise_notrace"
+
+exception Exit
+
+(* Should not be converted:
+   1. raise not raise_notrace
+   2. the exn handler escapes to [g]
+*)
+let f1 x g =
+  let r = ref x in
+  try
+    while !r < 42 do
+      if g !r then raise Exit;
+      r := !r + 1
+    done;
+    0
+  with Exit ->
+    42
+
+(* Should not be converted:
+   1. raise not raise_notrace
+*)
+let f2 x g =
+  let r = ref x in
+  try
+    while !r < 42 do
+      if
+        try g !r
+        with _ -> false
+      then raise Exit;
+      r := !r + 1
+    done;
+    0
+  with Exit ->
+    42
+
+(* Should be converted *)
+let f3 x g =
+  let r = ref x in
+  try
+    while !r < 42 do
+      if
+        try g !r
+        with _ -> false
+      then raise_notrace Exit;
+      r := !r + 1
+    done;
+    0
+  with Exit ->
+    42
+
+exception Exit2 of int * int
+
+(* Should be converted and unboxed *)
+let f4 x g =
+  let r = ref x in
+  try
+    while !r < 42 do
+      if
+        try g !r
+        with _ -> false
+      then raise_notrace (Exit2 (!r + 2, !r + 3));
+      r := !r + 1
+    done;
+    0
+  with (Exit2 (a, b)) ->
+    a + b
+

--- a/middle_end/flambda/basic/continuation.ml
+++ b/middle_end/flambda/basic/continuation.ml
@@ -35,19 +35,17 @@ end;
 
 module Sort = struct
   type t =
-    | Normal
+    | Normal_or_exn
     | Return
     | Define_root_symbol
     | Toplevel_return
-    | Exn
 
   let to_string t =
     match t with
-    | Normal -> "Normal"
+    | Normal_or_exn -> "Normal_or_exn"
     | Return -> "Return"
     | Define_root_symbol -> "Define_root_symbol"
     | Toplevel_return -> "Toplevel_return"
-    | Exn -> "Exn"
 
   let print ppf t = Format.pp_print_string ppf (to_string t)
 end
@@ -121,7 +119,7 @@ let initialise () = grand_table_of_continuations := Table.create ()
 (* CR mshinwell: Document why this uses [next_raise_count].  Does it need
    to?  It would be better if it didn't. *)
 let create ?sort ?name () : t =
-  let sort = Option.value sort ~default:Sort.Normal in
+  let sort = Option.value sort ~default:Sort.Normal_or_exn in
   let name = Option.value name ~default:"k" in
   let compilation_unit = Compilation_unit.get_current_exn () in
   let previous_compilation_units = [] in
@@ -216,11 +214,3 @@ module With_args = struct
       print (Format.formatter_of_out_channel chan) t
   end)
 end
-
-let is_exn t =
-  match sort t with
-  | Exn -> true
-  | Normal
-  | Return
-  | Define_root_symbol
-  | Toplevel_return -> false

--- a/middle_end/flambda/basic/continuation.mli
+++ b/middle_end/flambda/basic/continuation.mli
@@ -25,11 +25,10 @@ include Identifiable.S with type t := t
 
 module Sort : sig
   type t =
-    | Normal
+    | Normal_or_exn
     | Return
     | Define_root_symbol
     | Toplevel_return
-    | Exn
 end
 
 val create : ?sort:Sort.t -> ?name:string -> unit -> t
@@ -43,8 +42,6 @@ val name_stamp : t -> int
 val print_with_cache : cache:Printing_cache.t -> Format.formatter -> t -> unit
 
 val sort : t -> Sort.t
-
-val is_exn : t -> bool
 
 val export : t -> exported
 

--- a/middle_end/flambda/basic/exn_continuation.ml
+++ b/middle_end/flambda/basic/exn_continuation.ml
@@ -76,9 +76,9 @@ let print_with_cache ~cache:_ ppf t = print ppf t
 
 let create ~exn_handler ~extra_args =
   begin match Continuation.sort exn_handler with
-  | Exn -> ()
+  | Normal_or_exn -> ()
   | _ ->
-    Misc.fatal_errorf "Continuation %a has wrong sort (must be [Exn])"
+    Misc.fatal_errorf "Continuation %a has wrong sort (must be [Normal_or_exn])"
       Continuation.print exn_handler
   end;
   { exn_handler;

--- a/middle_end/flambda/basic/trap_action.mli
+++ b/middle_end/flambda/basic/trap_action.mli
@@ -18,10 +18,6 @@
     associated with an [Apply_cont] node; the trap action is executed before
     the application of the continuation.
 
-    [Pop] may not appear to need the [exn_handler] value during Flambda
-    passes---but in fact it does, since it compiles to a reference to such
-    continuation, and must not be moved out of its scope.
-
     Beware: continuations cannot be used both as an exception handler and as
     a normal continuation (since continuations used as exception handlers
     use a calling convention that may differ from normal).
@@ -38,6 +34,10 @@ type t =
   | Push of { exn_handler : Continuation.t; }
   | Pop of {
       exn_handler : Continuation.t;
+      (** Note that even for [Pop], [exn_handler] might not match the
+          target continuation in the enclosing [Apply_cont_expr].  One
+          example is when a value is being returned from the end of the
+          non-exceptional block of a try...with. *)
       raise_kind : raise_kind option;
     }
 

--- a/middle_end/flambda/compare/compare.ml
+++ b/middle_end/flambda/compare/compare.ml
@@ -1369,7 +1369,7 @@ and cont_handlers env handler1 handler2 =
 
 let flambda_units u1 u2 =
   let ret_cont = Continuation.create ~sort:Toplevel_return () in
-  let exn_cont = Continuation.create ~sort:Exn () in
+  let exn_cont = Continuation.create ~sort:Normal_or_exn () in
   let mk_perm u =
     let perm = Renaming.empty in
     let perm =

--- a/middle_end/flambda/compare/compare.ml
+++ b/middle_end/flambda/compare/compare.ml
@@ -1369,7 +1369,7 @@ and cont_handlers env handler1 handler2 =
 
 let flambda_units u1 u2 =
   let ret_cont = Continuation.create ~sort:Toplevel_return () in
-  let exn_cont = Continuation.create ~sort:Normal_or_exn () in
+  let exn_cont = Continuation.create () in
   let mk_perm u =
     let perm = Renaming.empty in
     let perm =

--- a/middle_end/flambda/from_lambda/cps_conversion.ml
+++ b/middle_end/flambda/from_lambda/cps_conversion.ml
@@ -558,7 +558,7 @@ let rec cps_non_tail env (lam : L.lambda) (k : Ident.t -> Ilambda.t)
     let body_result = Ident.create_local "body_result" in
     let result_var = Ident.create_local "try_with_result" in
     let body_continuation = Continuation.create () in
-    let handler_continuation = Continuation.create ~sort:Exn () in
+    let handler_continuation = Continuation.create ~sort:Normal_or_exn () in
     let poptrap_continuation = Continuation.create () in
     let after_continuation = Continuation.create () in
     let old_try_stack = !try_stack in
@@ -872,7 +872,7 @@ and cps_tail env (lam : L.lambda) (k : Continuation.t) (k_exn : Continuation.t)
   | Ltrywith (body, id, handler) ->
     let body_result = Ident.create_local "body_result" in
     let body_continuation = Continuation.create () in
-    let handler_continuation = Continuation.create ~sort:Exn () in
+    let handler_continuation = Continuation.create ~sort:Normal_or_exn () in
     let poptrap_continuation = Continuation.create () in
     let old_try_stack = !try_stack in
     try_stack := handler_continuation :: old_try_stack;
@@ -986,7 +986,7 @@ and cps_function env ~stub
       ({ kind; params; return; body; attr; loc; } : L.lfunction)
       : Ilambda.function_declaration =
   let body_cont = Continuation.create ~sort:Return () in
-  let body_exn_cont = Continuation.create ~sort:Exn () in
+  let body_exn_cont = Continuation.create ~sort:Normal_or_exn () in
   let free_idents_of_body = Lambda.free_variables body in
   let body = cps_tail env body body_cont body_exn_cont in
   let exn_continuation : I.exn_continuation =
@@ -1166,7 +1166,7 @@ let lambda_to_ilambda lam : Ilambda.program =
   in
   let env = Env.create ~current_unit_id in
   let the_end = Continuation.create ~sort:Define_root_symbol () in
-  let the_end_exn = Continuation.create ~sort:Exn () in
+  let the_end_exn = Continuation.create ~sort:Normal_or_exn () in
   let ilam = cps_tail env lam the_end the_end_exn in
   let exn_continuation : I.exn_continuation =
     { exn_handler = the_end_exn;

--- a/middle_end/flambda/from_lambda/cps_conversion.ml
+++ b/middle_end/flambda/from_lambda/cps_conversion.ml
@@ -558,7 +558,7 @@ let rec cps_non_tail env (lam : L.lambda) (k : Ident.t -> Ilambda.t)
     let body_result = Ident.create_local "body_result" in
     let result_var = Ident.create_local "try_with_result" in
     let body_continuation = Continuation.create () in
-    let handler_continuation = Continuation.create ~sort:Normal_or_exn () in
+    let handler_continuation = Continuation.create () in
     let poptrap_continuation = Continuation.create () in
     let after_continuation = Continuation.create () in
     let old_try_stack = !try_stack in
@@ -872,7 +872,7 @@ and cps_tail env (lam : L.lambda) (k : Continuation.t) (k_exn : Continuation.t)
   | Ltrywith (body, id, handler) ->
     let body_result = Ident.create_local "body_result" in
     let body_continuation = Continuation.create () in
-    let handler_continuation = Continuation.create ~sort:Normal_or_exn () in
+    let handler_continuation = Continuation.create () in
     let poptrap_continuation = Continuation.create () in
     let old_try_stack = !try_stack in
     try_stack := handler_continuation :: old_try_stack;
@@ -986,7 +986,7 @@ and cps_function env ~stub
       ({ kind; params; return; body; attr; loc; } : L.lfunction)
       : Ilambda.function_declaration =
   let body_cont = Continuation.create ~sort:Return () in
-  let body_exn_cont = Continuation.create ~sort:Normal_or_exn () in
+  let body_exn_cont = Continuation.create () in
   let free_idents_of_body = Lambda.free_variables body in
   let body = cps_tail env body body_cont body_exn_cont in
   let exn_continuation : I.exn_continuation =
@@ -1166,7 +1166,7 @@ let lambda_to_ilambda lam : Ilambda.program =
   in
   let env = Env.create ~current_unit_id in
   let the_end = Continuation.create ~sort:Define_root_symbol () in
-  let the_end_exn = Continuation.create ~sort:Normal_or_exn () in
+  let the_end_exn = Continuation.create () in
   let ilam = cps_tail env lam the_end the_end_exn in
   let exn_continuation : I.exn_continuation =
     { exn_handler = the_end_exn;

--- a/middle_end/flambda/inlining/inlining_transforms.ml
+++ b/middle_end/flambda/inlining/inlining_transforms.ml
@@ -93,7 +93,7 @@ let wrap_inlined_body_for_exn_support ~extra_args ~apply_exn_continuation
      a lazy rewriting, that would add the correct extra args
      to all uses of the exception continuation in the body.
    *)
-  let wrapper = Continuation.create ~sort:Exn () in
+  let wrapper = Continuation.create ~sort:Normal_or_exn () in
   let body_with_pop =
     match (apply_return_continuation : Apply.Result_continuation.t) with
     | Never_returns ->

--- a/middle_end/flambda/inlining/inlining_transforms.ml
+++ b/middle_end/flambda/inlining/inlining_transforms.ml
@@ -93,7 +93,7 @@ let wrap_inlined_body_for_exn_support ~extra_args ~apply_exn_continuation
      a lazy rewriting, that would add the correct extra args
      to all uses of the exception continuation in the body.
    *)
-  let wrapper = Continuation.create ~sort:Normal_or_exn () in
+  let wrapper = Continuation.create () in
   let body_with_pop =
     match (apply_return_continuation : Apply.Result_continuation.t) with
     | Never_returns ->

--- a/middle_end/flambda/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda/parser/fexpr_to_flambda.ml
@@ -97,7 +97,7 @@ let fresh_cont env ?sort { Fexpr.txt = name; loc = _ } arity =
     continuations = CM.add name (c, arity) env.continuations }
 
 let fresh_exn_cont env { Fexpr.txt = name; loc = _ } =
-  let c = Continuation.create ~sort:Normal_or_exn ~name () in
+  let c = Continuation.create ~name () in
   let e = Exn_continuation.create ~exn_handler:c ~extra_args:[] in
   e,
   { env with
@@ -788,9 +788,7 @@ let conv ~backend ~module_ident (fexpr : Fexpr.flambda_unit) : Flambda_unit.t =
       Ident.create_persistent (Ident.name module_ident))
   in
   let return_continuation = Continuation.create ~name:"done" () in
-  let exn_continuation =
-    Continuation.create ~sort:Normal_or_exn ~name:"error" ()
-  in
+  let exn_continuation = Continuation.create ~name:"error" () in
   let exn_continuation_as_exn_continuation =
     Exn_continuation.create ~exn_handler:exn_continuation ~extra_args:[]
   in

--- a/middle_end/flambda/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda/parser/fexpr_to_flambda.ml
@@ -97,7 +97,7 @@ let fresh_cont env ?sort { Fexpr.txt = name; loc = _ } arity =
     continuations = CM.add name (c, arity) env.continuations }
 
 let fresh_exn_cont env { Fexpr.txt = name; loc = _ } =
-  let c = Continuation.create ~sort:Exn ~name () in
+  let c = Continuation.create ~sort:Normal_or_exn ~name () in
   let e = Exn_continuation.create ~exn_handler:c ~extra_args:[] in
   e,
   { env with
@@ -788,7 +788,9 @@ let conv ~backend ~module_ident (fexpr : Fexpr.flambda_unit) : Flambda_unit.t =
       Ident.create_persistent (Ident.name module_ident))
   in
   let return_continuation = Continuation.create ~name:"done" () in
-  let exn_continuation = Continuation.create ~sort:Exn ~name:"error" () in
+  let exn_continuation =
+    Continuation.create ~sort:Normal_or_exn ~name:"error" ()
+  in
   let exn_continuation_as_exn_continuation =
     Exn_continuation.create ~exn_handler:exn_continuation ~extra_args:[]
   in

--- a/middle_end/flambda/simplify/env/continuation_env_and_param_types.ml
+++ b/middle_end/flambda/simplify/env/continuation_env_and_param_types.ml
@@ -31,4 +31,5 @@ type t =
       arg_types_by_use_id : arg_at_use Apply_cont_rewrite_id.Map.t list;
       extra_params_and_args : Continuation_extra_params_and_args.t;
       is_single_inlinable_use : bool;
+      escapes : bool;
     }

--- a/middle_end/flambda/simplify/env/continuation_env_and_param_types.mli
+++ b/middle_end/flambda/simplify/env/continuation_env_and_param_types.mli
@@ -28,4 +28,5 @@ type t =
       arg_types_by_use_id : arg_at_use Apply_cont_rewrite_id.Map.t list;
       extra_params_and_args : Continuation_extra_params_and_args.t;
       is_single_inlinable_use : bool;
+      escapes : bool;
     }

--- a/middle_end/flambda/simplify/env/continuation_use_kind.ml
+++ b/middle_end/flambda/simplify/env/continuation_use_kind.ml
@@ -18,4 +18,4 @@
 
 type t =
   | Inlinable
-  | Non_inlinable
+  | Non_inlinable of { escaping : bool; }

--- a/middle_end/flambda/simplify/env/continuation_use_kind.mli
+++ b/middle_end/flambda/simplify/env/continuation_use_kind.mli
@@ -18,4 +18,4 @@
 
 type t =
   | Inlinable
-  | Non_inlinable
+  | Non_inlinable of { escaping : bool; }

--- a/middle_end/flambda/simplify/env/downwards_acc.ml
+++ b/middle_end/flambda/simplify/env/downwards_acc.ml
@@ -30,18 +30,20 @@ type t = {
   used_closure_vars : Name_occurrences.t;
   lifted_constants : LCS.t;
   data_flow : Data_flow.t;
+  demoted_exn_handlers : Continuation.Set.t;
 }
 
 let print ppf
       { denv; continuation_uses_env; shareable_constants; used_closure_vars;
-        lifted_constants; data_flow; } =
+        lifted_constants; data_flow; demoted_exn_handlers; } =
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(denv@ %a)@]@ \
       @[<hov 1>(continuation_uses_env@ %a)@]@ \
       @[<hov 1>(shareable_constants@ %a)@]@ \
       @[<hov 1>(used_closure_vars@ %a)@]@ \
       @[<hov 1>(lifted_constant_state@ %a)@]@ \
-      @[<hov 1>(data_flow %a)@]\
+      @[<hov 1>(data_flow@ %a)@]@ \
+      @[<hov 1>(demoted_exn_handlers@ %a)@]\
       )@]"
     DE.print denv
     CUE.print continuation_uses_env
@@ -49,6 +51,7 @@ let print ppf
     Name_occurrences.print used_closure_vars
     LCS.print lifted_constants
     Data_flow.print data_flow
+    Continuation.Set.print demoted_exn_handlers
 
 let create denv continuation_uses_env =
   { denv;
@@ -57,6 +60,7 @@ let create denv continuation_uses_env =
     used_closure_vars = Name_occurrences.empty;
     lifted_constants = LCS.empty;
     data_flow = Data_flow.empty;
+    demoted_exn_handlers = Continuation.Set.empty;
   }
 
 let denv t = t.denv
@@ -201,3 +205,10 @@ let are_rebuilding_terms t =
 
 let do_not_rebuild_terms t =
   Are_rebuilding_terms.do_not_rebuild_terms (are_rebuilding_terms t)
+
+let demote_exn_handler t cont =
+  { t with
+    demoted_exn_handlers = Continuation.Set.add cont t.demoted_exn_handlers;
+  }
+
+let demoted_exn_handlers t = t.demoted_exn_handlers

--- a/middle_end/flambda/simplify/env/downwards_acc.mli
+++ b/middle_end/flambda/simplify/env/downwards_acc.mli
@@ -54,6 +54,13 @@ val continuation_uses_env : t -> Continuation_uses_env.t
 
 val with_continuation_uses_env : t -> cont_uses_env:Continuation_uses_env.t -> t
 
+(** Mark that an exception handler continuation should be converted to a
+    normal continuation.  This is used when turning local exceptions into
+    jumps. *)
+val demote_exn_handler : t -> Continuation.t -> t
+
+val demoted_exn_handlers : t -> Continuation.Set.t
+
 val code_age_relation : t -> Code_age_relation.t
 
 val with_code_age_relation : t -> Code_age_relation.t -> t

--- a/middle_end/flambda/simplify/env/upwards_acc.ml
+++ b/middle_end/flambda/simplify/env/upwards_acc.ml
@@ -38,13 +38,14 @@ type t = {
   are_rebuilding_terms : ART.t;
   generate_phantom_lets : bool;
   required_variables : Variable.Set.t;
+  demoted_exn_handlers : Continuation.Set.t;
 }
 
 let print ppf
       { uenv; creation_dacc = _; code_age_relation; lifted_constants;
         name_occurrences; used_closure_vars; all_code = _;
         shareable_constants; cost_metrics; are_rebuilding_terms;
-        generate_phantom_lets; required_variables; } =
+        generate_phantom_lets; required_variables; demoted_exn_handlers; } =
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(uenv@ %a)@]@ \
       @[<hov 1>(code_age_relation@ %a)@]@ \
@@ -55,7 +56,8 @@ let print ppf
       @[<hov 1>(cost_metrics@ %a)@]@ \
       @[<hov 1>(are_rebuilding_terms@ %a)@]@ \
       @[<hov 1>(generate_phantom_lets@ %b)@]@ \
-      @[<hov 1>(required_variables %a)@]\
+      @[<hov 1>(required_variables@ %a)@]@ \
+      @[<hov 1>(demoted_exn_handlers@ %a)@]\
       )@]"
     UE.print uenv
     Code_age_relation.print code_age_relation
@@ -67,6 +69,7 @@ let print ppf
     ART.print are_rebuilding_terms
     generate_phantom_lets
     Variable.Set.print required_variables
+    Continuation.Set.print demoted_exn_handlers
 
 let create ~required_variables uenv dacc =
   let are_rebuilding_terms = DE.are_rebuilding_terms (DA.denv dacc) in
@@ -87,6 +90,7 @@ let create ~required_variables uenv dacc =
     are_rebuilding_terms;
     generate_phantom_lets;
     required_variables;
+    demoted_exn_handlers = DA.demoted_exn_handlers dacc;
   }
 
 let creation_dacc t = t.creation_dacc
@@ -168,3 +172,6 @@ let add_cost_metrics cost_metrics t =
   { t with cost_metrics = Flambda.Cost_metrics.(+) t.cost_metrics cost_metrics }
 
 let generate_phantom_lets t = t.generate_phantom_lets
+
+let is_demoted_exn_handler t cont =
+  Continuation.Set.mem cont t.demoted_exn_handlers

--- a/middle_end/flambda/simplify/env/upwards_acc.mli
+++ b/middle_end/flambda/simplify/env/upwards_acc.mli
@@ -91,3 +91,5 @@ val notify_removed: operation:Removed_operations.t -> t -> t
 val generate_phantom_lets : t -> bool
 
 val are_rebuilding_terms : t -> Are_rebuilding_terms.t
+
+val is_demoted_exn_handler : t -> Continuation.t -> bool

--- a/middle_end/flambda/simplify/rebuilt_static_const.ml
+++ b/middle_end/flambda/simplify/rebuilt_static_const.ml
@@ -301,7 +301,7 @@ module Group = struct
     lazy (Function_params_and_body.create
       ~return_continuation:(Continuation.create ())
       (Exn_continuation.create
-        ~exn_handler:(Continuation.create ~sort:Exn ())
+        ~exn_handler:(Continuation.create ~sort:Normal_or_exn ())
         ~extra_args:[])
       [] ~dbg:Debuginfo.none ~body:(Expr.create_invalid ())
       ~free_names_of_body:Unknown ~my_closure:(Variable.create "my_closure")

--- a/middle_end/flambda/simplify/rebuilt_static_const.ml
+++ b/middle_end/flambda/simplify/rebuilt_static_const.ml
@@ -301,7 +301,7 @@ module Group = struct
     lazy (Function_params_and_body.create
       ~return_continuation:(Continuation.create ())
       (Exn_continuation.create
-        ~exn_handler:(Continuation.create ~sort:Normal_or_exn ())
+        ~exn_handler:(Continuation.create ())
         ~extra_args:[])
       [] ~dbg:Debuginfo.none ~body:(Expr.create_invalid ())
       ~free_names_of_body:Unknown ~my_closure:(Variable.create "my_closure")

--- a/middle_end/flambda/simplify/simplify_apply_cont_expr.ml
+++ b/middle_end/flambda/simplify/simplify_apply_cont_expr.ml
@@ -165,9 +165,13 @@ let simplify_apply_cont dacc apply_cont ~down_to_up =
         match raise_kind with
         | None | Some Regular | Some Reraise ->
           (* Until such time as we can manually add to the backtrace buffer,
-             we only convert "raise_notrace" into jumps.  So we set
-             [escaping = true] for these other cases. *)
-          Non_inlinable { escaping = true; }
+             we only convert "raise_notrace" into jumps, except if debugging
+             information generation is disabled.  (This matches the handling
+             at Cmm level; see [Cmm_helpers.raise_prim].)
+             We set [escaping = true] for the cases we do not want to
+             convert into jumps. *)
+          if !Clflags.debug then Non_inlinable { escaping = true; }
+          else Non_inlinable { escaping = false; }
         | Some No_trace ->
           Non_inlinable { escaping = false; }
       end

--- a/middle_end/flambda/simplify/simplify_apply_cont_expr.ml
+++ b/middle_end/flambda/simplify/simplify_apply_cont_expr.ml
@@ -80,7 +80,9 @@ let rebuild_apply_cont apply_cont ~args ~rewrite_id uacc ~after_rebuild =
         match AC.trap_action apply_cont with
         | None -> apply_cont
         | Some (Push { exn_handler; } | Pop { exn_handler; _ }) ->
-          if UE.mem_continuation uenv exn_handler then apply_cont
+          if UE.mem_continuation uenv exn_handler
+            && not (UA.is_demoted_exn_handler uacc exn_handler)
+          then apply_cont
           else AC.clear_trap_action apply_cont
       in
       match rewrite with
@@ -155,12 +157,22 @@ let simplify_apply_cont dacc apply_cont ~down_to_up =
        the toplevel continuation?  Probably not -- we should store it in
        the environment. *)
     match Continuation.sort (AC.continuation apply_cont) with
-    | Normal ->
-      (* Until such time as we can manually add to the backtrace buffer,
-         never substitute a "raise" for the body of an exception handler. *)
-      if Option.is_none (Apply_cont.trap_action apply_cont) then Inlinable
-      else Non_inlinable
-    | Return | Toplevel_return | Exn -> Non_inlinable
+    | Normal_or_exn ->
+      begin match Apply_cont.trap_action apply_cont with
+      | None -> Inlinable
+      | Some (Push _) -> Non_inlinable { escaping = false; }
+      | Some (Pop { raise_kind; _ }) ->
+        match raise_kind with
+        | None | Some Regular | Some Reraise ->
+          (* Until such time as we can manually add to the backtrace buffer,
+             we only convert "raise_notrace" into jumps.  So we set
+             [escaping = true] for these other cases. *)
+          Non_inlinable { escaping = true; }
+        | Some No_trace ->
+          Non_inlinable { escaping = false; }
+      end
+    | Return | Toplevel_return ->
+      Non_inlinable { escaping = false; }
     | Define_root_symbol ->
       assert (Option.is_none (Apply_cont.trap_action apply_cont));
       Inlinable

--- a/middle_end/flambda/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda/simplify/simplify_apply_expr.ml
@@ -155,7 +155,8 @@ let simplify_direct_full_application ~simplify_expr dacc apply function_decl_opt
       | Never_returns -> dacc, None
       | Return apply_return_continuation ->
         let dacc, use_id =
-          DA.record_continuation_use dacc apply_return_continuation Non_inlinable
+          DA.record_continuation_use dacc apply_return_continuation
+            (Non_inlinable { escaping = true; })
             ~env_at_use:(DA.denv dacc)
             ~arg_types:(T.unknown_types_from_arity_with_subkinds result_arity)
         in
@@ -164,7 +165,7 @@ let simplify_direct_full_application ~simplify_expr dacc apply function_decl_opt
     let dacc, exn_cont_use_id =
       DA.record_continuation_use dacc
         (Exn_continuation.exn_handler (Apply.exn_continuation apply))
-        Non_inlinable
+        (Non_inlinable { escaping = true; })
         ~env_at_use:(DA.denv dacc)
         ~arg_types:(T.unknown_types_from_arity_with_subkinds (
           Exn_continuation.arity (Apply.exn_continuation apply)))
@@ -505,7 +506,7 @@ let simplify_function_call_where_callee's_type_unavailable dacc apply
   let dacc, exn_cont_use_id =
     DA.record_continuation_use dacc
       (Exn_continuation.exn_handler (Apply.exn_continuation apply))
-      Non_inlinable
+      (Non_inlinable { escaping = true; })
       ~env_at_use:(DA.denv dacc)
       ~arg_types:(T.unknown_types_from_arity_with_subkinds (
         Exn_continuation.arity (Apply.exn_continuation apply)))
@@ -521,14 +522,17 @@ let simplify_function_call_where_callee's_type_unavailable dacc apply
         Apply.print apply
     end;
 *)
-    DA.record_continuation_use dacc cont Non_inlinable ~env_at_use
+    DA.record_continuation_use dacc cont
+      (Non_inlinable { escaping = true; })
+      ~env_at_use
       ~arg_types:(T.unknown_types_from_arity_with_subkinds return_arity)
   in
   let call_kind, use_id, dacc =
     match call with
     | Indirect_unknown_arity ->
       let dacc, use_id =
-        DA.record_continuation_use dacc cont Non_inlinable
+        DA.record_continuation_use dacc cont
+          (Non_inlinable { escaping = true; })
           ~env_at_use ~arg_types:[T.any_value ()]
       in
       Call_kind.indirect_function_call_unknown_arity (), use_id, dacc
@@ -772,14 +776,15 @@ let simplify_method_call dacc apply ~callee_ty ~kind:_ ~obj ~arg_types
       Apply.print apply
   end;
   let dacc, use_id =
-    DA.record_continuation_use dacc apply_cont Non_inlinable
+    DA.record_continuation_use dacc apply_cont
+      (Non_inlinable { escaping = true; })
       ~env_at_use:denv
       ~arg_types:[T.any_value ()]
   in
   let dacc, exn_cont_use_id =
     DA.record_continuation_use dacc
       (Exn_continuation.exn_handler (Apply.exn_continuation apply))
-      Non_inlinable
+      (Non_inlinable { escaping = true; })
       ~env_at_use:(DA.denv dacc)
       ~arg_types:(T.unknown_types_from_arity_with_subkinds (
         Exn_continuation.arity (Apply.exn_continuation apply)))
@@ -857,7 +862,8 @@ let simplify_c_call ~simplify_expr dacc apply ~callee_ty ~param_arity
       match Apply.continuation apply with
       | Return apply_continuation ->
         let dacc, use_id =
-          DA.record_continuation_use dacc apply_continuation Non_inlinable
+          DA.record_continuation_use dacc apply_continuation
+            (Non_inlinable { escaping = true; })
             ~env_at_use:(DA.denv dacc)
             ~arg_types:(T.unknown_types_from_arity return_arity)
         in
@@ -869,7 +875,7 @@ let simplify_c_call ~simplify_expr dacc apply ~callee_ty ~param_arity
       (* CR mshinwell: Try to factor out these stanzas, here and above. *)
       DA.record_continuation_use dacc
         (Exn_continuation.exn_handler (Apply.exn_continuation apply))
-        Non_inlinable
+        (Non_inlinable { escaping = true; })
         ~env_at_use:(DA.denv dacc)
         ~arg_types:(T.unknown_types_from_arity_with_subkinds (
           Exn_continuation.arity (Apply.exn_continuation apply)))

--- a/middle_end/flambda/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda/simplify/simplify_switch_expr.ml
@@ -284,7 +284,7 @@ let simplify_switch ~simplify_let dacc switch ~down_to_up =
           | [] ->
             let dacc, rewrite_id =
               DA.record_continuation_use dacc (AC.continuation action)
-                Non_inlinable ~env_at_use ~arg_types:[]
+                (Non_inlinable { escaping = false; }) ~env_at_use ~arg_types:[]
             in
             let dacc =
               DA.map_data_flow dacc ~f:(
@@ -300,7 +300,7 @@ let simplify_switch ~simplify_let dacc switch ~down_to_up =
             in
             let dacc, rewrite_id =
               DA.record_continuation_use dacc (AC.continuation action)
-                Non_inlinable ~env_at_use ~arg_types
+                (Non_inlinable { escaping = false; }) ~env_at_use ~arg_types
             in
             let arity = List.map T.kind arg_types in
             let action = Apply_cont.update_args action ~args in

--- a/middle_end/flambda/to_cmm/un_cps.ml
+++ b/middle_end/flambda/to_cmm/un_cps.ml
@@ -1054,7 +1054,7 @@ and wrap_cont env res effs call e =
 and apply_cont env res e =
   let k = Apply_cont_expr.continuation e in
   let args = Apply_cont_expr.args e in
-  if Continuation.is_exn k then
+  if Env.is_exn_handler env k then
     apply_cont_exn env res e k args
   else if Continuation.equal (Env.return_cont env) k then
     apply_cont_ret env res e k args
@@ -1486,7 +1486,7 @@ let unit (middle_end_result : Flambda_middle_end.middle_end_result) =
        (Module initialisers return the unit value). *)
     let env =
       Env.mk offsets functions_info dummy_k
-        (Flambda_unit.exn_continuation unit)
+        ~exn_continuation:(Flambda_unit.exn_continuation unit)
         ~used_closure_vars
     in
     let _env, return_cont_params =

--- a/middle_end/flambda/to_cmm/un_cps_env.mli
+++ b/middle_end/flambda/to_cmm/un_cps_env.mli
@@ -48,7 +48,7 @@ type t
 val mk :
   Exported_offsets.t ->
   Exported_code.t ->
-  Continuation.t -> Continuation.t ->
+  Continuation.t -> exn_continuation:Continuation.t ->
   used_closure_vars:Var_within_closure.Set.t Or_unknown.t -> t
 (** [mk offsets k k_exn ~used_closure_vars] creates a local environment for
     translating a flambda expression, with return continuation [k], exception
@@ -153,7 +153,12 @@ val add_inline_cont :
 val add_exn_handler :
   t -> Continuation.t -> Flambda_arity.t
   -> t * (Backend_var.t * Flambda_kind.t) list
-(** Setup the extra mutable variables needed if the handler has extra arguments *)
+(** Register the given continuation as an exception handler and set up the
+    extra mutable variables needed if the handler has extra arguments *)
+
+val is_exn_handler : t -> Continuation.t -> bool
+(** Return whether the given continuation has been registered as an
+    exception handler. *)
 
 val get_exn_extra_args :
   t -> Continuation.t -> Backend_var.t list


### PR DESCRIPTION
I was discussing this with @gretay-js today and decided to write the code down.  I thought it would take one hour but it took two, even so, not too bad.  This exercise was quite useful for code review purposes, as there are some tricky details in this area.

There are no doubt still problems with this patch.  However some small examples work.  Example number 4 in the new test file even correctly unboxes the two arguments to the exception constructor.

In the future we should write some code to add to the backtrace buffer.  Then this could be used for regular exception raises too, not just `notrace` ones.