### PR TITLE
Unrecursify in closure conversion

### DIFF
--- a/middle_end/flambda/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda/from_lambda/closure_conversion_aux.mli
@@ -24,9 +24,22 @@
 module Env : sig
   type t
 
-  val empty : backend:(module Flambda_backend_intf.S) -> t
+  val empty
+    : backend:(module Flambda_backend_intf.S)
+   -> return_continuation:Continuation.t
+   -> t
 
-  val clear_local_bindings : t -> t
+  type function_being_defined = {
+      let_rec_ident : Ident.t;
+      arity : int;
+      self_tail_call_continuation : Continuation.t;
+    }
+
+  val clear_local_bindings
+    : t
+   -> return_continuation:Continuation.t
+   -> function_being_defined
+   -> t
 
   val add_var : t -> Ident.t -> Variable.t -> t
   val add_vars : t -> Ident.t list -> Variable.t list -> t
@@ -57,6 +70,10 @@ module Env : sig
   val backend : t -> (module Flambda_backend_intf.S)
   val current_unit_id : t -> Ident.t
   val symbol_for_global' : t -> (Ident.t -> Symbol.t)
+
+  val return_continuation : t -> Continuation.t
+
+  val current_function : t -> function_being_defined option
 end
 
 (** Used to pipe some data through closure conversion *)

--- a/middle_end/flambda/naming/name_occurrences.ml
+++ b/middle_end/flambda/naming/name_occurrences.ml
@@ -1041,6 +1041,8 @@ let mem_newer_version_of_code_id t code_id =
   For_code_ids.mem t.newer_version_of_code_ids code_id
 let mem_closure_var t closure_var =
   For_closure_vars.mem t.closure_vars closure_var
+let mem_continuation t continuation =
+  For_continuations.mem t.continuations continuation
 
 let remove_var t var =
   if For_names.is_empty t.names then t

--- a/middle_end/flambda/naming/name_occurrences.mli
+++ b/middle_end/flambda/naming/name_occurrences.mli
@@ -153,6 +153,8 @@ val mem_newer_version_of_code_id : t -> Code_id.t -> bool
 
 val mem_closure_var : t -> Var_within_closure.t -> bool
 
+val mem_continuation : t -> Continuation.t -> bool
+
 val remove_var : t -> Variable.t -> t
 
 val remove_code_id_or_symbol : t -> Code_id_or_symbol.t -> t

--- a/middle_end/flambda/simplify/simplify_apply_cont_expr.mli
+++ b/middle_end/flambda/simplify/simplify_apply_cont_expr.mli
@@ -16,4 +16,6 @@
 
 [@@@ocaml.warning "+a-30-40-41-42"]
 
+val apply_cont_use_kind : Flambda.Apply_cont.t -> Continuation_use_kind.t
+
 val simplify_apply_cont : Flambda.Apply_cont.t Simplify_common.expr_simplifier

--- a/middle_end/flambda/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda/simplify/simplify_switch_expr.ml
@@ -279,12 +279,13 @@ let simplify_switch ~simplify_let dacc switch ~down_to_up =
             TE.add_env_extension typing_env_at_use env_extension
             |> DE.with_typing_env (DA.denv dacc)
           in
+          let use_kind = Simplify_apply_cont_expr.apply_cont_use_kind action in
           let args = AC.args action in
           match args with
           | [] ->
             let dacc, rewrite_id =
               DA.record_continuation_use dacc (AC.continuation action)
-                (Non_inlinable { escaping = false; }) ~env_at_use ~arg_types:[]
+                use_kind ~env_at_use ~arg_types:[]
             in
             let dacc =
               DA.map_data_flow dacc ~f:(
@@ -300,7 +301,7 @@ let simplify_switch ~simplify_let dacc switch ~down_to_up =
             in
             let dacc, rewrite_id =
               DA.record_continuation_use dacc (AC.continuation action)
-                (Non_inlinable { escaping = false; }) ~env_at_use ~arg_types
+                use_kind ~env_at_use ~arg_types
             in
             let arity = List.map T.kind arg_types in
             let action = Apply_cont.update_args action ~args in


### PR DESCRIPTION
Add a transformation to closure_conversion to turn self tail calls into apply_cont.
It is far simpler to do that in closure_conversion right now than during simplification, but this might miss a few interesting cases. I don't think that they occur often enough to bother too much.
This does not handle multiply recursive functions. If we want to handle that properly we might need to exend let_rec_cont. But this is not strictly required if we allow an intermediate dispatch.

Much of the (rather little) complexity comes from handling tupled functions.

Right now this does not allow to improve code a lot because transformed functions are not marked as non-recursive, preventing inlining.