### PR TITLE
Fix runtime/dune (remove .depend hack)

### DIFF
--- a/runtime/dune
+++ b/runtime/dune
@@ -34,12 +34,10 @@
           io.c extern.c intern.c hash.c sys.c meta.c parsing.c gc_ctrl.c md5.c
           obj.c lexing.c callback.c debugger.c weak.c compact.c finalise.c
           custom.c dynlink.c spacetime_byt.c afl.c unix.c win32.c bigarray.c
-          main.c memprof.c domain.c caml/domain_state.tbl eventlog.c)
+          main.c memprof.c domain.c caml/domain_state.tbl eventlog.c .depend)
  (action
    (progn
-     (bash "touch .depend") ; hack.
-     (run make %{targets})
-     (bash "rm -f .depend"))))
+     (run make %{targets}))))
 
 (rule
  (targets libasmrun.a)
@@ -53,12 +51,10 @@
   parsing.c gc_ctrl.c md5.c obj.c lexing.c unix.c printexc.c callback.c weak.c
   compact.c finalise.c custom.c globroots.c backtrace_nat.c backtrace.c
   dynlink_nat.c debugger.c meta.c dynlink.c clambda_checks.c spacetime_nat.c
-  spacetime_snapshot.c afl.c bigarray.c memprof.c eventlog.c)
+  spacetime_snapshot.c afl.c bigarray.c memprof.c eventlog.c .depend)
  (action
   (progn
-   (bash "touch .depend") ; hack.
-   (run make %{targets})
-   (bash "rm -f .depend"))))
+   (run make %{targets}))))
 
 ;; HACK
 (library


### PR DESCRIPTION
I'm hoping that this will remove the errors we get from time to time on the dune CI while building the runtime. I'm not a dune expert though, so I don't know if my solution is reasonable or likely to open the gates of hell. Reviews welcome.