### PR TITLE
Closure conversion to library module

### DIFF
--- a/middle_end/flambda/from_lambda/closure_conversion.mli
+++ b/middle_end/flambda/from_lambda/closure_conversion.mli
@@ -18,6 +18,43 @@
 
 (** Introduce closures into Ilambda code, producing Flambda. *)
 
+module Env = Closure_conversion_aux.Env
+module Acc = Closure_conversion_aux.Acc
+module Function_decl = Closure_conversion_aux.Function_decls.Function_decl
+module Expr_with_acc = Closure_conversion_aux.Expr_with_acc
+
+val close_let
+   : Acc.t -> Env.t -> Ident.t -> Ilambda.user_visible
+  -> Ilambda.named
+  -> body:(Acc.t -> Env.t -> Acc.t * Expr_with_acc.t)
+  -> Acc.t * Expr_with_acc.t
+
+val close_let_rec
+   : Acc.t -> Env.t -> function_declarations:(Function_decl.t list)
+  -> body:(Acc.t -> Env.t -> Acc.t * Expr_with_acc.t)
+  -> Acc.t * Expr_with_acc.t
+
+val close_let_cont
+   : Acc.t -> Env.t -> name:Continuation.t -> is_exn_handler:bool
+  -> params:((Ident.t * Ilambda.user_visible * Lambda.value_kind) list)
+  -> recursive:Asttypes.rec_flag
+  -> handler:(Acc.t -> Env.t -> Acc.t * Expr_with_acc.t)
+  -> body:(Acc.t -> Env.t -> Acc.t * Expr_with_acc.t)
+  -> Acc.t * Expr_with_acc.t
+
+val close_apply
+   : Acc.t -> Env.t -> Ilambda.apply
+  -> Acc.t * Expr_with_acc.t
+
+val close_apply_cont
+   : Acc.t -> Env.t -> Continuation.t
+  -> Ilambda.trap_action option -> Ilambda.simple list
+  -> Acc.t * Expr_with_acc.t
+
+val close_switch
+   : Acc.t -> Env.t -> Ident.t -> Ilambda.switch
+  -> Acc.t * Expr_with_acc.t
+
 val ilambda_to_flambda
    : backend:(module Flambda_backend_intf.S)
   -> module_ident:Ident.t

--- a/middle_end/flambda/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion_aux.ml
@@ -193,7 +193,7 @@ module Function_decls = struct
       return : Lambda.value_kind;
       return_continuation : Continuation.t;
       exn_continuation : Ilambda.exn_continuation;
-      body : Ilambda.t;
+      body : (Acc.t -> Env.t -> Acc.t * Flambda.Import.Expr.t);
       free_idents_of_body : Ident.Set.t;
       attr : Lambda.function_attribute;
       loc : Lambda.scoped_location;
@@ -204,13 +204,12 @@ module Function_decls = struct
 
     let create ~let_rec_ident ~closure_id ~kind ~params ~return
         ~return_continuation ~exn_continuation ~body ~attr
-        ~loc ~free_idents_of_body ~stub recursive =
+        ~loc ~free_idents_of_body ~stub recursive ~contains_closures =
       let let_rec_ident =
         match let_rec_ident with
         | None -> Ident.create_local "unnamed_function"
         | Some let_rec_ident -> let_rec_ident
       in
-      let contains_closures = Ilambda.contains_closures body in
       { let_rec_ident;
         closure_id;
         kind;

--- a/middle_end/flambda/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda/from_lambda/closure_conversion_aux.mli
@@ -116,13 +116,15 @@ module Function_decls : sig
       -> return:Lambda.value_kind
       -> return_continuation:Continuation.t
       -> exn_continuation:Ilambda.exn_continuation
-      -> body:Ilambda.t
+      -> body:(Acc.t -> Env.t -> Acc.t * Flambda.Import.Expr.t)
       -> attr:Lambda.function_attribute
       -> loc:Lambda.scoped_location
       -> free_idents_of_body:Ident.Set.t
       -> stub:bool
       -> Recursive.t
+      -> contains_closures:bool
       -> t
+
 
     val let_rec_ident : t -> Ident.t
     val closure_id : t -> Closure_id.t
@@ -131,7 +133,7 @@ module Function_decls : sig
     val return : t -> Lambda.value_kind
     val return_continuation : t -> Continuation.t
     val exn_continuation : t -> Ilambda.exn_continuation
-    val body : t -> Ilambda.t
+    val body : t -> (Acc.t -> Env.t -> Acc.t * Flambda.Import.Expr.t)
     val inline : t -> Lambda.inline_attribute
     val specialise : t -> Lambda.specialise_attribute
     val is_a_functor : t -> bool


### PR DESCRIPTION
This exposes previously extracted by-case conversion functions on the interface, and remove dependency to the main function `close`, making it trivially replaceable.

The goal *in fine* is to have this conversion done in `Cps_conversion`. This leads to changing ilambda terms to functions requiring `Env` and `Acc` from `Closure_conversion`, producing flambda expressions directly. It is necessary to delay computation of `Cps_conversion` tranformations which will then themselves produce flambda terms.