### PR TITLE
Closure conversion done in CPS conversion

### DIFF
--- a/.depend
+++ b/.depend
@@ -4949,6 +4949,7 @@ middle_end/flambda/from_lambda/closure_conversion.cmx : \
     middle_end/flambda/from_lambda/closure_conversion.cmi
 middle_end/flambda/from_lambda/closure_conversion.cmi : \
     middle_end/flambda/from_lambda/ilambda.cmi \
+    middle_end/flambda/from_lambda/closure_conversion_aux.cmi \
     typing/ident.cmi \
     middle_end/flambda/terms/flambda_unit.cmi \
     middle_end/flambda/flambda_backend_intf.cmi
@@ -5033,6 +5034,7 @@ middle_end/flambda/from_lambda/cps_conversion.cmo : \
     parsing/asttypes.cmi \
     middle_end/flambda/flambda_backend_intf.cmi \
     middle_end/flambda/from_lambda/closure_conversion_aux.cmi \
+    middle_end/flambda/from_lambda/closure_conversion.cmi \
     middle_end/flambda/from_lambda/cps_conversion.cmi
 middle_end/flambda/from_lambda/cps_conversion.cmx : \
     lambda/tag.cmx \
@@ -5052,6 +5054,7 @@ middle_end/flambda/from_lambda/cps_conversion.cmx : \
     parsing/asttypes.cmi \
     middle_end/flambda/flambda_backend_intf.cmi \
     middle_end/flambda/from_lambda/closure_conversion_aux.cmx \
+    middle_end/flambda/from_lambda/closure_conversion.cmx \
     middle_end/flambda/from_lambda/cps_conversion.cmi
 middle_end/flambda/from_lambda/cps_conversion.cmi : \
     middle_end/flambda/flambda_backend_intf.cmi \

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -777,10 +777,6 @@ let mk_dclambda f =
   "-dclambda", Arg.Unit f, " (undocumented)"
 ;;
 
-let mk_dilambda f =
-  "-dilambda", Arg.Unit f, " Print Ilambda terms"
-;;
-
 let mk_dflambda f =
   "-dflambda", Arg.Unit f, " Print Flambda terms"
 ;;
@@ -1290,9 +1286,6 @@ module type Optcommon_options = sig
   val _no_flambda_debug_permute_every_name : unit -> unit
   val _flambda_debug_concrete_types_only_on_canonicals : unit -> unit
   val _no_flambda_debug_concrete_types_only_on_canonicals : unit -> unit
-
-  val _dprepared_lambda : unit -> unit
-  val _dilambda : unit -> unit
 end;;
 
 module type Optcomp_options = sig
@@ -1710,8 +1703,6 @@ struct
     mk_dump_into_file F._dump_into_file;
     mk_dump_pass F._dump_pass;
 
-    mk_dilambda F._dilambda;
-
     mk_args F._args;
     mk_args0 F._args0;
   ]
@@ -1862,8 +1853,6 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_dinterval F._dinterval;
     mk_dstartup F._dstartup;
     mk_dump_pass F._dump_pass;
-
-    mk_dilambda F._dilambda;
   ]
 end;;
 
@@ -2194,9 +2183,6 @@ module Default = struct
       use_inlining_arguments_set ~round:0 o1_arguments;
       *)
       ()
-
-    let _dprepared_lambda = set dump_prepared_lambda
-    let _dilambda = set dump_ilambda
   end
 
   module Compiler = struct

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -251,9 +251,6 @@ module type Optcommon_options = sig
   val _no_flambda_debug_permute_every_name : unit -> unit
   val _flambda_debug_concrete_types_only_on_canonicals : unit -> unit
   val _no_flambda_debug_concrete_types_only_on_canonicals : unit -> unit
-
-  val _dprepared_lambda : unit -> unit
-  val _dilambda : unit -> unit
 end;;
 
 module type Optcomp_options = sig

--- a/middle_end/flambda/from_lambda/closure_conversion.mli
+++ b/middle_end/flambda/from_lambda/closure_conversion.mli
@@ -55,9 +55,11 @@ val close_switch
    : Acc.t -> Env.t -> Ident.t -> Ilambda.switch
   -> Acc.t * Expr_with_acc.t
 
-val ilambda_to_flambda
+val close_program
    : backend:(module Flambda_backend_intf.S)
   -> module_ident:Ident.t
   -> module_block_size_in_words:int
-  -> Ilambda.program
+  -> program:(Acc.t -> Env.t -> Acc.t * Expr_with_acc.t)
+  -> prog_return_cont:Continuation.t
+  -> exn_continuation:Continuation.t
   -> Flambda_unit.t

--- a/middle_end/flambda/from_lambda/cps_conversion.mli
+++ b/middle_end/flambda/from_lambda/cps_conversion.mli
@@ -18,6 +18,9 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
-val lambda_to_ilambda
+val lambda_to_flambda
    : backend:(module Flambda_backend_intf.S)
-  -> Lambda.lambda -> Ilambda.program
+  -> module_ident:Ident.t
+  -> module_block_size_in_words:int
+  -> Lambda.lambda
+  -> Flambda_unit.t

--- a/middle_end/flambda/from_lambda/ilambda.ml
+++ b/middle_end/flambda/from_lambda/ilambda.ml
@@ -36,15 +36,7 @@ type user_visible =
   | User_visible
   | Not_user_visible
 
-type t =
-  | Let of Ident.t * user_visible * Lambda.value_kind * named * t
-  | Let_rec of function_declarations * t
-  | Let_cont of let_cont
-  | Apply of apply
-  | Apply_cont of Continuation.t * trap_action option * simple list
-  | Switch of Ident.t * switch
-
-and named =
+type named =
   | Simple of simple
   | Prim of {
       prim : Lambda.primitive;
@@ -53,33 +45,11 @@ and named =
       exn_continuation : exn_continuation option;
     }
 
-and function_declaration = {
-  kind : Lambda.function_kind;
-  return_continuation : Continuation.t;
-  exn_continuation : exn_continuation;
-  params : (Ident.t * Lambda.value_kind) list;
-  return : Lambda.value_kind;
-  body : t;
-  free_idents_of_body : Ident.Set.t;
-  (* [free_idents_of_body] saves writing a free variables function on
-     Ilambda terms. *)
-  attr : Lambda.function_attribute;
-  loc : Lambda.scoped_location;
-  stub : bool;
-}
+type apply_kind =
+  | Function
+  | Method of { kind : Lambda.meth_kind; obj : simple; }
 
-and function_declarations = (Ident.t * function_declaration) list
-
-and let_cont = {
-  name : Continuation.t;
-  is_exn_handler : bool;
-  params : (Ident.t * user_visible * Lambda.value_kind) list;
-  recursive : Asttypes.rec_flag;
-  body : t;
-  handler : t;
-}
-
-and apply = {
+type apply = {
   kind : apply_kind;
   func : Ident.t;
   args : simple list;
@@ -91,20 +61,10 @@ and apply = {
   specialised : Lambda.specialise_attribute;
 }
 
-and apply_kind =
-  | Function
-  | Method of { kind : Lambda.meth_kind; obj : simple; }
-
-and switch = {
+type switch = {
   numconsts : int;
   consts : (int * Continuation.t * trap_action option * (simple list)) list;
   failaction : (Continuation.t * trap_action option * (simple list)) option;
-}
-
-type program = {
-  expr : t;
-  return_continuation : Continuation.t;
-  exn_continuation : exn_continuation;
 }
 
 let fprintf = Format.fprintf
@@ -114,46 +74,7 @@ let print_simple ppf simple =
   | Var id -> Ident.print ppf id
   | Const cst -> Printlambda.structured_constant ppf cst
 
-let print_simple_and_value_kind ppf (simple, kind) =
-  fprintf ppf "@[%a@ \u{2237}@ %a@]"
-    print_simple simple
-    Printlambda.value_kind' kind
-
-let rec print_function ppf
-      ({ return_continuation; kind; params; body; free_idents_of_body = _; attr;
-         exn_continuation; return; loc = _; stub = _;
-       } : function_declaration) =
-  let pr_params ppf params =
-    match kind with
-    | Curried ->
-      List.iter (fun (param, _) -> fprintf ppf "@ %a" Ident.print param)
-        params
-    | Tupled ->
-      fprintf ppf " (";
-      let first = ref true in
-      List.iter (fun (param, _) ->
-          if !first then first := false else fprintf ppf ",@ ";
-          Ident.print ppf param)
-        params;
-      fprintf ppf ")"
-  in
-  fprintf ppf "@[<2>(function <%a> " Continuation.print return_continuation;
-  begin match exn_continuation.extra_args with
-  | [] -> fprintf ppf "<exn=%a>" Continuation.print exn_continuation.exn_handler
-  | extra_args ->
-    fprintf ppf "<exn=%a (%a)>"
-      Continuation.print exn_continuation.exn_handler
-      (Format.pp_print_list ~pp_sep:Format.pp_print_space
-        print_simple_and_value_kind)
-      extra_args
-  end;
-  fprintf ppf "%a@ : %a@ %a%a)@]"
-    pr_params params
-    Printlambda.value_kind' return
-    Printlambda.function_attribute attr
-    print body
-
-and print_named ppf (named : named) =
+let print_named ppf (named : named) =
   match named with
   | Simple (Var id) -> Ident.print ppf id
   | Simple (Const cst) -> Printlambda.structured_constant ppf cst
@@ -162,135 +83,6 @@ and print_named ppf (named : named) =
       Printlambda.primitive prim
       (Format.pp_print_list ~pp_sep:Format.pp_print_space print_simple) args
 
-and print_trap_action ppf trap_action =
-  match trap_action with
-  | None -> ()
-  | Some (Push { exn_handler; }) ->
-    fprintf ppf "push %a then "
-      Continuation.print exn_handler
-  | Some (Pop { exn_handler; }) ->
-    fprintf ppf "pop %a then "
-      Continuation.print exn_handler
-
-and print ppf (t : t) =
-  match t with
-  | Apply ap ->
-    let print_func_and_kind ppf func =
-      match ap.kind with
-      | Function -> Ident.print ppf func
-      | Method { kind; obj; } ->
-        Format.fprintf ppf "send%a %a#%a"
-          Printlambda.meth_kind kind
-          print_simple obj
-          Ident.print func
-    in
-    fprintf ppf "@[<2>(apply@ %a<%a> %a%a%a%a)@]"
-      print_func_and_kind ap.func
-      Continuation.print ap.continuation
-      (Format.pp_print_list ~pp_sep:Format.pp_print_space print_simple) ap.args
-      Printlambda.apply_tailcall_attribute ap.tailcall
-      Printlambda.apply_inlined_attribute ap.inlined
-      Printlambda.apply_specialised_attribute ap.specialised
-  | Let (id, _user_visible, kind, arg, body) ->
-    let rec let_body = function
-      | Let (id, _user_visible, kind, arg, body) ->
-        fprintf ppf "@ @[<2>%a@ \u{2237}@ %a =@ %a@]"
-          Ident.print id
-          Printlambda.value_kind' kind
-          print_named arg;
-          let_body body
-      | expr -> expr
-    in
-    fprintf ppf "@[<2>(let@ @[<v 1>(@[<2>%a@ \u{2237}@ %a =@ %a@]"
-      Ident.print id
-      Printlambda.value_kind' kind
-      print_named arg;
-    let expr = let_body body in
-    fprintf ppf ")@]@ %a)@]" print expr
-  | Let_rec (id_arg_list, body) ->
-    let bindings ppf id_arg_list =
-      let spc = ref false in
-      List.iter (fun (id, l) ->
-          if !spc then fprintf ppf "@ " else spc := true;
-          fprintf ppf "@[<2>%a@ %a@]" Ident.print id print_function l)
-        id_arg_list in
-    fprintf ppf
-      "@[<2>(let_rec@ (@[<hv 1>%a@])@ %a)@]" bindings id_arg_list print body
-  | Switch (arg, sw) ->
-    let switch ppf sw =
-      let spc = ref false in
-      List.iter (fun (n, cont, trap, args) ->
-          if !spc then fprintf ppf "@ " else spc := true;
-          match args with
-          | [] ->
-            fprintf ppf "@[<hv 1>| %i -> %agoto %a@]"
-              n
-              print_trap_action trap
-              Continuation.print cont
-          | args ->
-            fprintf ppf "@[<hv 1>| %i -> %aapply_cont %a %a@]"
-              n
-              print_trap_action trap
-              Continuation.print cont
-              (Format.pp_print_list ~pp_sep:Format.pp_print_space print_simple)
-              args)
-        sw.consts;
-      begin match sw.failaction with
-      | None  -> ()
-      | Some (l, trap, args) ->
-        if !spc then fprintf ppf "@ " else spc := true;
-        match args with
-        | [] ->
-          fprintf ppf "@[<hv 1>default:@ %agoto %a@]"
-            print_trap_action trap
-            Continuation.print l
-        | args ->
-          fprintf ppf "@[<hv 1>default:@ %aapply_cont %a %a@]"
-            print_trap_action trap
-            Continuation.print l
-            (Format.pp_print_list ~pp_sep:Format.pp_print_space print_simple)
-            args
-      end in
-    fprintf ppf
-      "@[<1>(@[<v 1>%s %a@ @[<v 0>%a@]@])@]"
-      (match sw.failaction with None -> "switch*" | _ -> "switch")
-      Ident.print arg
-      switch sw
-  | Let_cont _ ->
-    let rec gather_let_conts let_conts (t : t) =
-      match t with
-      | Let_cont let_cont ->
-        gather_let_conts (let_cont :: let_conts) let_cont.body
-      | body -> let_conts, body
-    in
-    let let_conts, body = gather_let_conts [] t in
-    let print_let_cont ppf { name; params; recursive; handler;
-          body = _; is_exn_handler; } =
-      fprintf ppf "@[<v 2>where %a%s%s%(%)%a%(%) =@ %a@]"
-        Continuation.print name
-        (match recursive with Nonrecursive -> "" | Recursive -> "*")
-        (if is_exn_handler then "<exn>" else "")
-        ((match params with [] -> "" | _ -> " @[<h 2>(") : _ format6)
-        (Format.pp_print_list ~pp_sep:Format.pp_print_space
-          (fun ppf (ident, _user_visible, kind) ->
-            Format.fprintf ppf "%a@ \u{2237}@ %a"
-              Ident.print ident
-              Printlambda.value_kind' kind)) params
-        ((match params with [] -> "" | _ -> ")@]") : _ format6)
-        print handler
-    in
-    let pp_sep ppf () = fprintf ppf "@ " in
-    fprintf ppf "@[<2>(@[<v 0>%a@;@[<v 0>%a@]@])@]"
-      print body
-      (Format.pp_print_list ~pp_sep print_let_cont) let_conts
-  | Apply_cont (i, trap_action, ls)  ->
-    fprintf ppf "@[<2>(%aapply_cont@ %a@ %a)@]"
-      print_trap_action trap_action
-      Continuation.print i
-      (Format.pp_print_list ~pp_sep:Format.pp_print_space print_simple) ls
-
-let print_program ppf p =
-  print ppf p.expr
 
 let contains_functions (lam : Lambda.lambda) =
   let rec contains_functions_tail (lam : Lambda.lambda) k =

--- a/middle_end/flambda/from_lambda/ilambda.mli
+++ b/middle_end/flambda/from_lambda/ilambda.mli
@@ -130,6 +130,4 @@ val print : Format.formatter -> t -> unit
 val print_named : Format.formatter -> named -> unit
 val print_program : Format.formatter -> program -> unit
 
-val recursive_functions : function_declarations -> Ident.Set.t
-
-val contains_closures : t -> bool
+val contains_functions : Lambda.lambda -> bool

--- a/middle_end/flambda/from_lambda/ilambda.mli
+++ b/middle_end/flambda/from_lambda/ilambda.mli
@@ -50,17 +50,7 @@ type user_visible =
   | User_visible
   | Not_user_visible
 
-type t =
-  | Let of Ident.t * user_visible * Lambda.value_kind * named * t
-  | Let_rec of function_declarations * t
-  | Let_cont of let_cont
-  | Apply of apply
-  | Apply_cont of Continuation.t * trap_action option * simple list
-    (** Unlike in Flambda, [Apply_cont] is not used for the raising of
-        exceptions; use [Prim Praise] instead. *)
-  | Switch of Ident.t * switch
-
-and named =
+type named =
   | Simple of simple
   | Prim of {
       prim : Lambda.primitive;
@@ -71,34 +61,11 @@ and named =
     (** Set [exn_continuation] to [None] iff the given primitive can never
         raise. *)
 
-and function_declaration = {
-  kind : Lambda.function_kind;
-  return_continuation : Continuation.t;
-  exn_continuation : exn_continuation;
-  params : (Ident.t * Lambda.value_kind) list;
-  return : Lambda.value_kind;
-  body : t;
-  free_idents_of_body : Ident.Set.t;
-  attr : Lambda.function_attribute;
-  loc : Lambda.scoped_location;
-  stub : bool;
-}
+type apply_kind =
+  | Function
+  | Method of { kind : Lambda.meth_kind; obj : simple; }
 
-and function_declarations = (Ident.t * function_declaration) list
-
-and let_cont = {
-  name : Continuation.t;
-  is_exn_handler : bool;
-  (* CR mshinwell: update comment *)
-  (** Continuations that are exception handlers must be [Non_recursive] and
-      have exactly one parameter. *)
-  params : (Ident.t * user_visible * Lambda.value_kind) list;
-  recursive : Asttypes.rec_flag; (* CR mshinwell: Recursive.t *)
-  body : t;
-  handler : t;
-}
-
-and apply = {
+type apply = {
   kind : apply_kind;
   func : Ident.t;
   args : simple list;
@@ -110,24 +77,12 @@ and apply = {
   specialised : Lambda.specialise_attribute;
 }
 
-and apply_kind =
-  | Function
-  | Method of { kind : Lambda.meth_kind; obj : simple; }
-
-and switch = {
+type switch = {
   numconsts : int;
   consts : (int * Continuation.t * trap_action option * (simple list)) list;
   failaction : (Continuation.t * trap_action option * (simple list)) option;
 }
 
-type program = {
-  expr : t;
-  return_continuation : Continuation.t;
-  exn_continuation : exn_continuation;
-}
-
-val print : Format.formatter -> t -> unit
 val print_named : Format.formatter -> named -> unit
-val print_program : Format.formatter -> program -> unit
 
 val contains_functions : Lambda.lambda -> bool

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -113,9 +113,6 @@ and dump_flexpect = ref false           (* -dflexpect *)
 and dump_instr = ref false              (* -dinstr *)
 and keep_camlprimc_file = ref false     (* -dcamlprimc *)
 
-and dump_ilambda = ref false
-and dump_prepared_lambda = ref false
-
 let keep_asm_file = ref false           (* -S *)
 let optimize_for_speed = ref true       (* -compact *)
 and opaque = ref false                  (* -opaque *)

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -135,8 +135,6 @@ val dump_lambda : bool ref
 val dump_rawclambda : bool ref
 val dump_clambda : bool ref
 val dump_rawflambda : bool ref
-val dump_prepared_lambda : bool ref
-val dump_ilambda : bool ref
 val dump_flambda : bool ref
 val dump_rawfexpr : bool ref
 val dump_fexpr : bool ref


### PR DESCRIPTION
This builds on #467 and #468 to fully build flambda term in `Cps_conversion`, bypassing `Ilambda.t` entirely.

Most of the changes are simply transformations of ilambda constructs to calls to their respective functions in `Closure_conversion`.