### PR TITLE
Better accounting of closure_vars

### DIFF
--- a/middle_end/flambda/simplify/simplify.ml
+++ b/middle_end/flambda/simplify/simplify.ml
@@ -107,7 +107,7 @@ let run ~backend ~round unit =
       (Exported_code.mark_as_imported !imported_code)
   in
   let used_closure_vars =
-    UA.used_closure_vars uacc
+    UA.name_occurrences uacc
     |> Name_occurrences.closure_vars
   in
   let cmx =

--- a/middle_end/flambda/terms/code0.ml
+++ b/middle_end/flambda/terms/code0.ml
@@ -316,7 +316,9 @@ end) = struct
       code_id
 
   let make_deleted t =
-    { t with params_and_body = Deleted; }
+    { t with
+      params_and_body = Deleted;
+      free_names_of_params_and_body = Name_occurrences.empty; }
 
   let is_deleted t =
     match t.params_and_body with


### PR DESCRIPTION
In an example like this y was considered as a used closure var after simplification. There were two things to fix:
* The set of closure vars was taken from the one accumulated while going down, which doesn't account for all simplifications. It is replaced by name occurrences at the end of the transformation.
* When making a code deleted free variables where not updated at the same time.

```OCaml
let f x y =
  let g z =
    ignore y;
    z + x
  in
  Sys.opaque_identity g
```