### PR TITLE
Fix incorrect types in unboxing code

### DIFF
--- a/middle_end/flambda/unboxing/unboxing_epa.ml
+++ b/middle_end/flambda/unboxing/unboxing_epa.ml
@@ -39,11 +39,10 @@ let _print_unboxed_arg ppf = function
     Format.fprintf ppf "added_by_wrapper(%d)" nth_arg
 
 let type_of_arg_being_unboxed unboxed_arg =
-  let aux simple = T.alias_type_of K.value simple in
   match unboxed_arg with
   | Poison -> None
-  | Available simple -> Some (aux simple)
-  | Generated var -> Some (aux (Simple.var var))
+  | Available simple -> Some (T.alias_type_of K.value simple)
+  | Generated _ -> Some (T.unknown K.value)
   | Added_by_wrapper_at_rewrite_use _ -> prevent_current_unboxing ()
 
 let unbox_arg (unboxer : Unboxers.unboxer)


### PR DESCRIPTION
The current unboxing code can generate incorrect types in situations where we generate new let bindings, since the generated variable has just been created by the unboxing ode, and thus cannot be found in the typing env (I think @lthls  encountered this bug while working on another PR), this PR fixes that in the simplest way, even if in some cases, this could lose some precision.

cc @chambart 