### PR TITLE
Populating continuation occurrence count during CPS conversion

### DIFF
--- a/middle_end/flambda/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion.ml
@@ -615,7 +615,7 @@ let close_switch acc env scrutinee (sw : IR.switch)
         let trap_action = close_trap_action_opt trap_action in
         let acc, args = find_simples acc env args in
         let acc, action =
-          Apply_cont_with_acc.create acc?trap_action cont ~args
+          Apply_cont_with_acc.create acc ?trap_action cont ~args
            ~dbg:Debuginfo.none
         in
         acc,

--- a/middle_end/flambda/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion.ml
@@ -23,6 +23,7 @@ module IR =  Closure_conversion_aux.IR
 module Acc = Closure_conversion_aux.Acc
 module Env = Closure_conversion_aux.Env
 module Expr_with_acc = Closure_conversion_aux.Expr_with_acc
+module Apply_cont_with_acc = Closure_conversion_aux.Apply_cont_with_acc
 module Let_cont_with_acc = Closure_conversion_aux.Let_cont_with_acc
 module Let_with_acc = Closure_conversion_aux.Let_with_acc
 module Continuation_handler_with_acc =
@@ -235,8 +236,8 @@ let close_c_call acc ~let_bound_var (prim : Primitive.description)
             let result' = Var_in_binding_pos.create result Name_mode.normal in
             let bindable = Bindable_let_bound.singleton result' in
             let prim = P.Unary (Reinterpret_int64_as_float, arg) in
-            let return_result =
-              Apply_cont.create return_continuation
+            let acc, return_result =
+              Apply_cont_with_acc.create acc return_continuation
                 ~args:[Simple.var result]
                 ~dbg
             in
@@ -340,7 +341,6 @@ let close_c_call acc ~let_bound_var (prim : Primitive.description)
     in
     Let_cont_with_acc.create_non_recursive acc return_continuation after_call
       ~body:c_call
-      ~free_names_of_body:Unknown
       ~cost_metrics_of_handler
   in
   let keep_body ~cost_metrics_of_body acc =
@@ -441,8 +441,8 @@ let close_primitive acc env ~let_bound_var named (prim : Lambda.primitive) ~args
     in
     let raise_kind = Some (LC.raise_kind raise_kind) in
     let trap_action = Trap_action.Pop { exn_handler; raise_kind; } in
-    let apply_cont =
-      Apply_cont.create ~trap_action exn_handler ~args ~dbg
+    let acc, apply_cont =
+      Apply_cont_with_acc.create acc ~trap_action exn_handler ~args ~dbg
     in
     (* Since raising of an exception doesn't terminate, we don't call [k]. *)
     Expr_with_acc.create_apply_cont acc apply_cont
@@ -549,7 +549,7 @@ let close_let_cont acc env ~name ~is_exn_handler ~params
   begin match recursive with
   | Nonrecursive ->
     Let_cont_with_acc.create_non_recursive acc name handler ~body
-      ~free_names_of_body:Unknown ~cost_metrics_of_handler
+      ~cost_metrics_of_handler
   | Recursive ->
     let handlers = Continuation.Map.singleton name handler in
     Let_cont_with_acc.create_recursive acc handlers ~body
@@ -588,8 +588,8 @@ let close_apply_cont acc env cont trap_action args
   : Acc.t * Expr_with_acc.t =
   let acc, args = find_simples acc env args in
   let trap_action = close_trap_action_opt trap_action in
-  let apply_cont =
-    Apply_cont.create ?trap_action cont ~args ~dbg:Debuginfo.none
+  let acc, apply_cont =
+    Apply_cont_with_acc.create acc ?trap_action cont ~args ~dbg:Debuginfo.none
   in
   Expr_with_acc.create_apply_cont acc apply_cont
 
@@ -614,10 +614,12 @@ let close_switch acc env scrutinee (sw : IR.switch)
     List.fold_left_map (fun acc (case, cont, trap_action, args) ->
         let trap_action = close_trap_action_opt trap_action in
         let acc, args = find_simples acc env args in
+        let acc, action =
+          Apply_cont_with_acc.create acc?trap_action cont ~args
+           ~dbg:Debuginfo.none
+        in
         acc,
-        (Targetint_31_63.int (Targetint_31_63.Imm.of_int case),
-         Apply_cont.create ?trap_action cont ~args
-           ~dbg:Debuginfo.none))
+        (Targetint_31_63.int (Targetint_31_63.Imm.of_int case), action))
       acc
       sw.consts
   in
@@ -640,8 +642,7 @@ let close_switch acc env scrutinee (sw : IR.switch)
     let acc, default_action =
       let acc, args = find_simples acc env default_args in
       let trap_action = close_trap_action_opt default_trap_action in
-      acc,
-      Apply_cont.create ?trap_action default_action ~args
+      Apply_cont_with_acc.create acc ?trap_action default_action ~args
         ~dbg:Debuginfo.none
     in
     let acc, switch =
@@ -670,8 +671,8 @@ let close_switch acc env scrutinee (sw : IR.switch)
             else
               let acc, args = find_simples acc env args in
               let trap_action = close_trap_action_opt trap_action in
-              let default =
-                Apply_cont.create ?trap_action default ~args
+              let acc, default =
+                Apply_cont_with_acc.create acc ?trap_action default ~args
                   ~dbg:Debuginfo.none
               in
               acc,
@@ -1057,16 +1058,16 @@ let close_program ~backend ~module_ident ~module_block_size_in_words
         Block (module_block_tag, Immutable, field_vars)
       in
       let acc, arg = use_of_symbol_as_simple acc module_symbol in
-      let acc, return =
+      let acc, apply_cont =
         (* Module initialisers return unit, but since that is taken care of
            during Cmm generation, we can instead "return" [module_symbol]
            here to ensure that its associated "let symbol" doesn't get
            deleted. *)
-        Apply_cont.create return_cont
+        Apply_cont_with_acc.create acc return_cont
           ~args:[arg]
           ~dbg:Debuginfo.none
-        |> Expr_with_acc.create_apply_cont acc
       in
+      let acc, return = Expr_with_acc.create_apply_cont acc apply_cont in
       let bound_symbols =
         Bound_symbols.singleton
           (Bound_symbols.Pattern.block_like module_symbol)
@@ -1128,7 +1129,6 @@ let close_program ~backend ~module_ident ~module_block_size_in_words
     Let_cont_with_acc.create_non_recursive acc prog_return_cont
       load_fields_cont_handler
       ~body
-      ~free_names_of_body:Unknown
       ~cost_metrics_of_handler
   in
   let acc, body =

--- a/middle_end/flambda/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion_aux.ml
@@ -491,6 +491,7 @@ module Let_cont_with_acc = struct
         acc
     in
     acc,
+    (* This function only uses continuations of [free_names_of_body] *)
     Let_cont.create_non_recursive cont handler ~body
       ~free_names_of_body:(Known free_conts)
 

--- a/middle_end/flambda/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion_aux.ml
@@ -193,6 +193,7 @@ module Acc = struct
     shareable_constants : Symbol.t Flambda.Static_const.Map.t;
     code : Flambda.Code.t Code_id.Map.t;
     free_names_of_current_function : Name_occurrences.t;
+    free_continuations : Name_occurrences.t;
     cost_metrics : Flambda.Cost_metrics.t;
     seen_a_function : bool;
   }
@@ -211,6 +212,7 @@ module Acc = struct
     shareable_constants = Flambda.Static_const.Map.empty;
     code = Code_id.Map.empty;
     free_names_of_current_function = Name_occurrences.empty;
+    free_continuations = Name_occurrences.empty;
     cost_metrics = Flambda.Cost_metrics.zero;
     seen_a_function = false;
   }
@@ -219,6 +221,7 @@ module Acc = struct
   let shareable_constants t = t.shareable_constants
   let code t = t.code
   let free_names_of_current_function t = t.free_names_of_current_function
+  let free_continuations t = t.free_continuations
 
   let add_declared_symbol ~symbol ~constant t =
     let declared_symbols = (symbol, constant) :: t.declared_symbols in
@@ -244,6 +247,13 @@ module Acc = struct
       free_names_of_current_function =
         Name_occurrences.add_closure_var t.free_names_of_current_function
           closure_var Name_mode.normal;
+    }
+
+  let add_continuation_occurrence ~cont ~has_traps t =
+    { t with
+      free_continuations =
+        Name_occurrences.add_continuation t.free_continuations
+          cont ~has_traps;
     }
 
   let with_free_names free_names t =
@@ -379,6 +389,16 @@ module Expr_with_acc = struct
         (Code_size.apply apply |> Cost_metrics.from_size)
         acc
     in
+    let acc = match Apply.continuation apply with
+      | Never_returns -> acc
+      | Return cont ->
+          Acc.add_continuation_occurrence ~cont ~has_traps:false acc
+    in
+    let acc =
+      Acc.add_continuation_occurrence
+        ~cont:(Exn_continuation.exn_handler (Apply.exn_continuation apply))
+        ~has_traps:false acc
+    in
     acc, Expr.create_apply apply
 
   let create_let (acc, let_expr) =
@@ -403,6 +423,21 @@ module Expr_with_acc = struct
         acc
     in
     acc, Expr.create_invalid ?semantics ()
+end
+
+module Apply_cont_with_acc = struct
+  let create acc ?trap_action cont ~args ~dbg =
+    let acc =
+      Acc.add_continuation_occurrence ~cont
+        ~has_traps:(match trap_action with
+            | None -> false
+            | _ -> true)
+        acc
+    in
+    acc, Apply_cont.create ?trap_action cont ~args ~dbg
+
+  let goto acc cont =
+    create acc cont ~args:[] ~dbg:(Debuginfo.none)
 end
 
 module Let_with_acc = struct
@@ -447,7 +482,8 @@ end
 
 module Let_cont_with_acc = struct
   let create_non_recursive acc cont handler
-        ~body ~free_names_of_body ~cost_metrics_of_handler =
+        ~body ~cost_metrics_of_handler =
+    let free_conts = Acc.free_continuations acc in
     let acc =
       Acc.increment_metrics
         (Cost_metrics.increase_due_to_let_cont_non_recursive
@@ -455,7 +491,8 @@ module Let_cont_with_acc = struct
         acc
     in
     acc,
-    Let_cont.create_non_recursive cont handler  ~body ~free_names_of_body
+    Let_cont.create_non_recursive cont handler ~body
+      ~free_names_of_body:(Known free_conts)
 
   let create_recursive acc handlers ~body ~cost_metrics_of_handlers =
     let acc =

--- a/middle_end/flambda/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda/from_lambda/closure_conversion_aux.mli
@@ -122,6 +122,7 @@ module Acc : sig
   val shareable_constants : t -> Symbol.t Flambda.Static_const.Map.t
   val code : t -> Flambda.Code.t Code_id.Map.t
   val free_names_of_current_function : t -> Name_occurrences.t
+  val free_continuations : t -> Name_occurrences.t
 
   val seen_a_function : t -> bool
   val with_seen_a_function : t -> bool -> t
@@ -142,6 +143,8 @@ module Acc : sig
 
   val add_symbol_to_free_names : symbol:Symbol.t -> t -> t
   val add_closure_var_to_free_names : closure_var:Var_within_closure.t -> t -> t
+  val add_continuation_occurrence
+    : cont:Continuation.t -> has_traps:bool -> t -> t
 
   val with_free_names : Name_occurrences.t -> t -> t
 
@@ -226,6 +229,21 @@ module Expr_with_acc : sig
     -> Acc.t * t
 end
 
+module Apply_cont_with_acc : sig
+  val create
+     : Acc.t
+    -> ?trap_action:Trap_action.t
+    -> Continuation.t
+    -> args:Simple.t list
+    -> dbg:Debuginfo.t
+    -> Acc.t * Apply_cont.t
+
+  val goto
+     : Acc.t
+    -> Continuation.t
+    -> Acc.t * Apply_cont.t
+end
+
 module Let_with_acc : sig
   val create
      : Acc.t
@@ -252,7 +270,6 @@ module Let_cont_with_acc : sig
     -> Continuation.t
     -> Continuation_handler.t
     -> body:Expr_with_acc.t
-    -> free_names_of_body:Name_occurrences.t Or_unknown.t
     -> cost_metrics_of_handler:Cost_metrics.t
     -> Acc.t * Expr_with_acc.t
 

--- a/middle_end/flambda/terms/let_cont_expr.rec.ml
+++ b/middle_end/flambda/terms/let_cont_expr.rec.ml
@@ -100,6 +100,8 @@ let create_non_recursive' ~cont handler ~body
 
 let create_non_recursive cont handler ~body ~free_names_of_body =
   let num_free_occurrences_of_cont_in_body, is_applied_with_traps =
+    (* Only the continuations of [free_names_of_body] are used.
+       [Closure_conversion_aux] relies on this property. *)
     match (free_names_of_body : _ Or_unknown.t) with
     | Unknown -> Or_unknown.Unknown, true
     | Known free_names_of_body ->


### PR DESCRIPTION
This populates `num_free_occurrences` of `Let_cont` at creation in `Closure_conversion`.