### PR TITLE
Compute contains_subfunctions on the fly

### DIFF
--- a/middle_end/flambda/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion_aux.ml
@@ -192,6 +192,7 @@ module Acc = struct
     code : Flambda.Code.t Code_id.Map.t;
     free_names_of_current_function : Name_occurrences.t;
     cost_metrics : Flambda.Cost_metrics.t;
+    seen_a_function : bool;
   }
 
   let cost_metrics t = t.cost_metrics
@@ -199,12 +200,17 @@ module Acc = struct
     { t with cost_metrics = Flambda.Cost_metrics.(+) t.cost_metrics metrics }
   let with_cost_metrics cost_metrics t = { t with cost_metrics }
 
+  let seen_a_function t = t.seen_a_function
+  let with_seen_a_function t seen_a_function =
+    { t with seen_a_function; }
+
   let empty = {
     declared_symbols = [];
     shareable_constants = Flambda.Static_const.Map.empty;
     code = Code_id.Map.empty;
     free_names_of_current_function = Name_occurrences.empty;
     cost_metrics = Flambda.Cost_metrics.zero;
+    seen_a_function = false;
   }
 
   let declared_symbols t = t.declared_symbols
@@ -265,12 +271,11 @@ module Function_decls = struct
       loc : Lambda.scoped_location;
       stub : bool;
       recursive : Recursive.t;
-      contains_closures : bool;
     }
 
     let create ~let_rec_ident ~closure_id ~kind ~params ~return
         ~return_continuation ~exn_continuation ~body ~attr
-        ~loc ~free_idents_of_body ~stub recursive ~contains_closures =
+        ~loc ~free_idents_of_body ~stub recursive =
       let let_rec_ident =
         match let_rec_ident with
         | None -> Ident.create_local "unnamed_function"
@@ -289,7 +294,6 @@ module Function_decls = struct
         loc;
         stub;
         recursive;
-        contains_closures;
       }
 
     let let_rec_ident t = t.let_rec_ident
@@ -307,7 +311,6 @@ module Function_decls = struct
     let stub t = t.attr.stub
     let loc t = t.loc
     let recursive t = t.recursive
-    let contains_closures t = t.contains_closures
   end
 
   type t = {

--- a/middle_end/flambda/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda/from_lambda/closure_conversion_aux.mli
@@ -122,6 +122,9 @@ module Acc : sig
   val code : t -> Flambda.Code.t Code_id.Map.t
   val free_names_of_current_function : t -> Name_occurrences.t
 
+  val seen_a_function : t -> bool
+  val with_seen_a_function : t -> bool -> t
+
   val add_declared_symbol
      : symbol:Symbol.t
     -> constant:Flambda.Static_const.t
@@ -175,7 +178,6 @@ module Function_decls : sig
       -> free_idents_of_body:Ident.Set.t
       -> stub:bool
       -> Recursive.t
-      -> contains_closures:bool
       -> t
 
 
@@ -193,7 +195,6 @@ module Function_decls : sig
     val stub : t -> bool
     val loc : t -> Lambda.scoped_location
     val recursive : t -> Recursive.t
-    val contains_closures : t -> bool
 
     (* Like [all_free_idents], but for just one function. *)
     val free_idents : t -> Ident.Set.t

--- a/middle_end/flambda/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda/from_lambda/lambda_to_flambda.ml
@@ -287,49 +287,6 @@ let name_for_function (func : Lambda.lfunction) =
   | Loc_known { loc; _ } ->
     Format.asprintf "anon-fn[%a]" Location.print_compact loc
 
-let contains_functions (lam : Lambda.lambda) =
-  let rec contains_functions_tail (lam : Lambda.lambda) k =
-  match lam with
-    | Lvar _  | Lconst _ -> k ()
-    | Lfunction _ | Lletrec _ -> true
-    | Lassign (_, lam) | Levent (lam, _) | Lifused (_, lam)
-      -> contains_functions_tail lam k
-    | Lapply { ap_func; ap_args; _}
-      -> contains_functions_list (ap_func::ap_args) k
-    | Llet (_, _, _, lam1, lam2) | Lstaticcatch (lam1, _, lam2)
-    | Ltrywith (lam1, _, lam2) | Lsequence (lam1, lam2)
-    | Lwhile (lam1, lam2)
-      -> contains_functions_list [lam1; lam2] k
-    | Lifthenelse (lam1, lam2, lam3) | Lfor (_, lam1, lam2, _, lam3)
-      -> contains_functions_list [lam1; lam2; lam3] k
-    | Lprim (_, lams, _) | Lstaticraise (_, lams)
-      -> contains_functions_list lams k
-    | Lsend (_, lam1, lam2, lams, _)
-      -> contains_functions_list (lam1::lam2::lams) k
-    | Lswitch (lam1, { sw_consts; sw_blocks; sw_failaction; _ }, _) ->
-      let lams1 = List.map snd sw_consts in
-      let lams2 = List.map snd sw_blocks in
-      let lams = match sw_failaction with
-        | None -> lam1::lams1 @ lams2
-        | Some lam2 -> lam1::lam2::lams1 @ lams2
-      in
-      contains_functions_list lams k
-    | Lstringswitch (lam1, branches, failaction, _) ->
-      let lams = List.map snd branches in
-      let lams = match failaction with
-        | None -> lam1::lams
-        | Some lam2 -> lam1::lam2::lams
-      in
-      contains_functions_list lams k
-  and contains_functions_list lams k =
-    match lams with
-    | [] -> k ()
-    | lam::lams ->
-        contains_functions_tail lam
-          (fun () -> contains_functions_list lams k)
-  in
-  contains_functions_tail lam (fun () -> false)
-
 let extra_args_for_exn_continuation env exn_handler =
   let more_extra_args =
     Env.extra_args_for_continuation_with_kinds env exn_handler
@@ -1420,12 +1377,6 @@ and cps_function env ~fid ~stub
     Closure_id.wrap (Compilation_unit.get_current_exn ())
       (Variable.create_with_same_name_as_ident fid)
   in
-  let contains_closures =
-    (* only useful with this flag *)
-    if !Clflags.Flambda.Expert.fallback_inlining_heuristic
-    then contains_functions body
-    else false
-  in
   let body = fun acc ccenv ->
     cps_tail acc new_env ccenv body body_cont body_exn_cont
   in
@@ -1433,7 +1384,7 @@ and cps_function env ~fid ~stub
     ~closure_id ~kind ~params ~return ~return_continuation:body_cont
     ~exn_continuation ~body
     ~attr ~loc ~free_idents_of_body ~stub
-    recursive ~contains_closures
+    recursive
 
 and cps_switch acc env ccenv (switch : L.lambda_switch) ~scrutinee
       (k : Continuation.t) (k_exn : Continuation.t)


### PR DESCRIPTION
This avoids the separate calculation of what used to be called "contains_closures".  This saves code and also, most importantly, should allow `Dissect_letrec` to be called directly from CPS conversion.  (We might not want to do that in the long run, but as long as that dissection code hasn't been upstreamed, it will be easier to keep it in the Flambda 2 directory tree.)