### PR TITLE
Removed Pgettag from Lambda primitives

### DIFF
--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -131,8 +131,7 @@ let preserve_tailcall_for_prim = function
   | Pbytes_load_32 _ | Pbytes_load_64 _ | Pbytes_set_16 _ | Pbytes_set_32 _
   | Pbytes_set_64 _ | Pbigstring_load_16 _ | Pbigstring_load_32 _
   | Pbigstring_load_64 _ | Pbigstring_set_16 _ | Pbigstring_set_32 _
-  | Pbigstring_set_64 _ | Pctconst _ | Pbswap16 | Pbbswap _ | Pint_as_pointer
-  | Pgettag ->
+  | Pbigstring_set_64 _ | Pctconst _ | Pbswap16 | Pbbswap _ | Pint_as_pointer ->
       false
 
 (* Add a Kpop N instruction in front of a continuation *)

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -113,8 +113,6 @@ type primitive =
   | Parraysets of array_kind
   (* Test if the argument is a block or an immediate integer *)
   | Pisint
-  (* Extract a block's tag *)
-  | Pgettag
   (* Test if the (integer) argument is outside an interval *)
   | Pisout
   (* Operations on boxed integers (Nativeint.t, Int32.t, Int64.t) *)
@@ -339,8 +337,7 @@ let primitive_can_raise = function
   | Pbswap16
   | Pbbswap _
   | Pint_as_pointer
-  | Popaque
-  | Pgettag -> false
+  | Popaque -> false
 
 type structured_constant =
     Const_base of constant

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -123,8 +123,6 @@ type primitive =
   | Parraysets of array_kind
   (* Test if the argument is a block or an immediate integer *)
   | Pisint
-  (* Extract a block's tag *)
-  | Pgettag
   (* Test if the (integer) argument is outside an interval *)
   | Pisout
   (* Operations on boxed integers (Nativeint.t, Int32.t, Int64.t) *)

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -289,7 +289,6 @@ let primitive ppf = function
        | Backend_type -> "backend_type" in
      fprintf ppf "sys.constant_%s" const_name
   | Pisint -> fprintf ppf "isint"
-  | Pgettag -> fprintf ppf "gettag"
   | Pisout -> fprintf ppf "isout"
   | Pbintofint bi -> print_boxed_integer "of_int" ppf bi
   | Pintofbint bi -> print_boxed_integer "to_int" ppf bi
@@ -440,7 +439,6 @@ let name_of_primitive = function
   | Parraysets _ -> "Parraysets"
   | Pctconst _ -> "Pctconst"
   | Pisint -> "Pisint"
-  | Pgettag -> "Pgettag"
   | Pbintofint _ -> "Pbintofint"
   | Pintofbint _ -> "Pintofbint"
   | Pcvtbint _ -> "Pcvtbint"

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -788,8 +788,8 @@ let lambda_primitive_needs_event_after = function
   | Pfloatcomp _ | Pstringlength | Pstringrefu | Pbyteslength | Pbytesrefu
   | Pbytessetu | Pmakearray ((Pintarray | Paddrarray | Pfloatarray), _)
   | Parraylength _ | Parrayrefu _ | Parraysetu _ | Pisint | Pisout
-  | Pintofbint _ | Pctconst _ | Pbswap16 | Pint_as_pointer | Popaque
-  | Pgettag -> false
+  | Pintofbint _ | Pctconst _ | Pbswap16 | Pint_as_pointer
+  | Popaque -> false
 
 (* Determine if a primitive should be surrounded by an "after" debug event *)
 let primitive_needs_event_after = function

--- a/middle_end/convert_primitives.ml
+++ b/middle_end/convert_primitives.ml
@@ -154,7 +154,6 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
   | Pidentity
   | Pgetglobal _
   | Psetglobal _
-  | Pgettag
     ->
       Misc.fatal_errorf "lambda primitive %a can't be converted to \
                          clambda primitive"

--- a/middle_end/flambda/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion.ml
@@ -474,6 +474,17 @@ let close_named acc env ~let_bound_var (named : IR.named)
   | Simple (Const cst) ->
     let acc, named, _name = close_const acc cst in
     k acc (Some named)
+  | Get_tag var ->
+    let named = find_simple_from_id env var in
+    let prim : Lambda_to_flambda_primitives_helpers.expr_primitive =
+      Unary (Box_number Untagged_immediate,
+        Prim (Unary (Get_tag, Simple named)))
+    in
+    Lambda_to_flambda_primitives_helpers.bind_rec acc
+      ~backend:(Env.backend env) None
+      ~register_const_string:(fun acc -> register_const_string acc)
+      prim Debuginfo.none
+      (fun acc named -> k acc (Some named))
   | Prim { prim; args; loc; exn_continuation; } ->
     close_primitive acc env ~let_bound_var named prim ~args loc
       exn_continuation k

--- a/middle_end/flambda/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion_aux.ml
@@ -36,6 +36,7 @@ module IR = struct
 
   type named =
     | Simple of simple
+    | Get_tag of Ident.t
     | Prim of {
         prim : Lambda.primitive;
         args : simple list;
@@ -76,6 +77,7 @@ module IR = struct
     match named with
     | Simple (Var id) -> Ident.print ppf id
     | Simple (Const cst) -> Printlambda.structured_constant ppf cst
+    | Get_tag id -> fprintf ppf "@[<2>(Gettag %a)@]" Ident.print id
     | Prim { prim; args; _ } ->
       fprintf ppf "@[<2>(%a %a)@]"
         Printlambda.primitive prim

--- a/middle_end/flambda/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda/from_lambda/closure_conversion_aux.mli
@@ -39,6 +39,7 @@ module IR : sig
 
   type named =
     | Simple of simple
+    | Get_tag of Ident.t (* Intermediary primitive for block switch *)
     | Prim of {
         prim : Lambda.primitive;
         args : simple list;

--- a/middle_end/flambda/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda/from_lambda/lambda_to_flambda.ml
@@ -1557,11 +1557,7 @@ and cps_switch acc env ccenv (switch : L.lambda_switch) ~scrutinee
             CC.close_switch acc ccenv scrutinee_tag block_switch
           in
           CC.close_let acc ccenv scrutinee_tag Not_user_visible
-            (Prim { prim = Pgettag;
-              args = [Var scrutinee];
-              loc = Loc_unknown;
-              exn_continuation = None; })
-            ~body
+            (Get_tag scrutinee) ~body
         in
         if switch.sw_numblocks = 0 then const_switch, wrappers
         else if switch.sw_numconsts = 0 then block_switch, wrappers

--- a/middle_end/flambda/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda/from_lambda/lambda_to_flambda_primitives.ml
@@ -559,8 +559,6 @@ let convert_lprim ~backend (prim : L.primitive) (args : Simple.t list)
 
   | Pisint, [arg] ->
     tag_int (Unary (Is_int, arg))
-  | Pgettag, [arg] ->
-    tag_int (Unary (Get_tag, arg))
   | Pisout, [arg1; arg2] ->
     tag_int (
       Binary (Int_comp (I.Tagged_immediate, Unsigned, Yielding_bool Lt),
@@ -1033,7 +1031,7 @@ let convert_lprim ~backend (prim : L.primitive) (args : Simple.t list)
       Printlambda.primitive prim
       H.print_list_of_simple_or_prim args
   | ( Pfield _ | Pnegint | Pnot | Poffsetint _ | Pintoffloat | Pfloatofint
-    | Pnegfloat | Pabsfloat | Pstringlength | Pbyteslength | Pgettag
+    | Pnegfloat | Pabsfloat | Pstringlength | Pbyteslength
     | Pbintofint _ | Pintofbint _ | Pnegbint _ | Popaque | Pduprecord _
     | Parraylength _ | Pduparray _ | Pfloatfield _ | Pcvtbint _ | Poffsetref _
     | Pbswap16 | Pbbswap _ | Pisint | Pint_as_pointer

--- a/middle_end/internal_variable_names.ml
+++ b/middle_end/internal_variable_names.ml
@@ -119,7 +119,6 @@ let pfloatcomp = "Pfloatcomp"
 let pfloatfield = "Pfloatfield"
 let pfloatofint = "Pfloatofint"
 let pgetglobal = "Pgetglobal"
-let pgettag = "Pgettag"
 let pidentity = "Pidentity"
 let pignore = "Pignore"
 let pint_as_pointer = "Pint_as_pointer"
@@ -223,7 +222,6 @@ let pfloatcomp_arg = "Pfloatcomp_arg"
 let pfloatfield_arg = "Pfloatfield_arg"
 let pfloatofint_arg = "Pfloatofint_arg"
 let pgetglobal_arg = "Pgetglobal_arg"
-let pgettag_arg = "Pgettag_arg"
 let pidentity_arg = "Pidentity_arg"
 let pignore_arg = "Pignore_arg"
 let pint_as_pointer_arg = "Pint_as_pointer_arg"
@@ -419,7 +417,6 @@ let of_primitive : Lambda.primitive -> string = function
   | Pbbswap _ -> pbbswap
   | Pint_as_pointer -> pint_as_pointer
   | Popaque -> popaque
-  | Pgettag -> pgettag
 
 let of_primitive_arg : Lambda.primitive -> string = function
   | Pidentity -> pidentity_arg
@@ -527,4 +524,3 @@ let of_primitive_arg : Lambda.primitive -> string = function
   | Pbbswap _ -> pbbswap_arg
   | Pint_as_pointer -> pint_as_pointer_arg
   | Popaque -> popaque_arg
-  | Pgettag -> pgettag_arg


### PR DESCRIPTION
This primitive sole use was for block switches. It has been moved to a special case in the intermediary representation of `Lambda_to_flambda`, shortcutting part of the primitive conversion.