### PR TITLE
Fixed a miss in #470

### DIFF
--- a/middle_end/flambda/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion.ml
@@ -967,8 +967,18 @@ let close_functions acc external_env function_declarations =
   let function_decls = Function_declarations.create funs in
   let closure_elements =
     Ident.Map.fold (fun id var_within_closure map ->
-        let external_var = Simple.var (Env.find_var external_env id) in
-        Var_within_closure.Map.add var_within_closure external_var map)
+        let external_simple = find_simple_from_id external_env id in
+        let is_simple_var = Simple.pattern_match external_simple
+            ~const:(fun _ -> false)
+            ~name:(fun name ~coercion:_ ->
+                Name.pattern_match name
+                  ~var:(fun _ -> true)
+                  ~symbol:(fun _ -> true))
+        in
+        if is_simple_var
+        then
+          Var_within_closure.Map.add var_within_closure external_simple map
+        else map)
       var_within_closures_from_idents
       Var_within_closure.Map.empty
   in

--- a/middle_end/flambda/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion.ml
@@ -968,17 +968,10 @@ let close_functions acc external_env function_declarations =
   let closure_elements =
     Ident.Map.fold (fun id var_within_closure map ->
         let external_simple = find_simple_from_id external_env id in
-        let is_simple_var = Simple.pattern_match external_simple
-            ~const:(fun _ -> false)
-            ~name:(fun name ~coercion:_ ->
-                Name.pattern_match name
-                  ~var:(fun _ -> true)
-                  ~symbol:(fun _ -> false))
-        in
-        if is_simple_var
-        then
-          Var_within_closure.Map.add var_within_closure external_simple map
-        else map)
+        (* We're sure [external_simple] is a variable since
+           [var_within_closure_from_idents] has already filtered
+           constants and symbols out. *)
+        Var_within_closure.Map.add var_within_closure external_simple map)
       var_within_closures_from_idents
       Var_within_closure.Map.empty
   in

--- a/middle_end/flambda/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion.ml
@@ -973,7 +973,7 @@ let close_functions acc external_env function_declarations =
             ~name:(fun name ~coercion:_ ->
                 Name.pattern_match name
                   ~var:(fun _ -> true)
-                  ~symbol:(fun _ -> true))
+                  ~symbol:(fun _ -> false))
         in
         if is_simple_var
         then


### PR DESCRIPTION
I missed a substitution where `close_functions` could lookup a removed identifier due to let alias. (Thanks @lukemaurer for pointing it out)