### PR TITLE
Revert tools/ci to upstream 4.12

### DIFF
--- a/tools/ci/inria/launch
+++ b/tools/ci/inria/launch
@@ -1,0 +1,31 @@
+#!/bin/sh
+#**************************************************************************
+#*                                                                        *
+#*                                 OCaml                                  *
+#*                                                                        *
+#*              Xavier Leroy, projet Cambium, INRIA Paris                 *
+#*                                                                        *
+#*   Copyright 2021 Institut National de Recherche en Informatique et     *
+#*     en Automatique.                                                    *
+#*                                                                        *
+#*   All rights reserved.  This file is distributed under the terms of    *
+#*   the GNU Lesser General Public License version 2.1, with the          *
+#*   special exception on linking described in the file LICENSE.          *
+#*                                                                        *
+#**************************************************************************
+
+# Set up the execution environment before launching the CI script
+# given as argument.
+
+# Currently, the only setup performed is to make sure that ARM-based Macs
+# run the script in ARM64 mode or in x86-64 mode, depending on what
+# the OCAML_ARCH parameter requires.
+# If OCAML_ARCH is just "macos", the default mode is used.
+
+set -x
+
+case "${OCAML_ARCH}" in
+  macos-arm) OCAML_ARCH=macos exec /usr/bin/arch -arm64 "$@";;
+  macos-x86) OCAML_ARCH=macos exec /usr/bin/arch -x86_64 "$@";;
+  *) exec "$@";;
+esac

--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -93,7 +93,7 @@ esac
 
 # be considerate towards other potential users of the test machine
 case "${OCAML_ARCH}" in
-  bsd|macos|linux) renice 10 $$ ;;
+  bsd|linux) renice 10 $$ ;;
 esac
 
 # be verbose and stop on error

--- a/tools/ci/inria/sanitizers/script
+++ b/tools/ci/inria/sanitizers/script
@@ -54,34 +54,6 @@ export TSAN_SYMBOLIZER_PATH="$ASAN_SYMBOLIZER_PATH"
 
 #########################################################################
 
-# Cleanup repository
-git clean -q -f -d -x
-
-# Ensure that the repo still passes the check-typo script
-if [ ! -x tools/check-typo ] ; then
-  error "tools/check-typo does not appear to be executable?"
-fi
-tools/check-typo
-
-#########################################################################
-
-echo "======== old school build =========="
-
-instdir="$HOME/ocaml-tmp-install-$$"
-./configure --prefix "$instdir"
-
-# Build the system without using world.opt
-make $jobs world
-make $jobs opt
-make $jobs opt.opt
-make install
-
-rm -rf "$instdir"
-
-# It's a build system test only, so we don't bother testing the compiler
-
-#########################################################################
-
 echo "======== clang 9, address sanitizer, UB sanitizer =========="
 
 git clean -q -f -d -x


### PR DESCRIPTION
Missed during the 4.12 rebase by the look of it.