### PR TITLE
Remove Profile.enabled and per-function profiling

### DIFF
--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -484,8 +484,7 @@ let read_one_param ppf position name v =
   | "timings" | "profile" ->
      let if_on = if name = "timings" then [ `Time ] else Profile.all_columns in
      let enabled = check_bool ppf name v in
-     profile_columns := if enabled then if_on else [];
-     if enabled then Profile.enable ()
+     profile_columns := if enabled then if_on else []
 
   | "stop-after" ->
     set_compiler_pass ppf v ~name Clflags.stop_after ~filter:(fun _ -> true)

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -2197,8 +2197,8 @@ module Default = struct
     let _ccopt s = Compenv.first_ccopts := (s :: (!Compenv.first_ccopts))
     let _config = Misc.show_config_and_exit
     let _config_var = Misc.show_config_variable_and_exit
-    let _dprofile () = profile_columns := Profile.all_columns; Profile.enable ()
-    let _dtimings () = profile_columns := [`Time]; Profile.enable ()
+    let _dprofile () = profile_columns := Profile.all_columns
+    let _dtimings () = profile_columns := [`Time]
     let _dump_into_file = set dump_into_file
     let _for_pack s = for_package := (Some s)
     let _g = set debug

--- a/utils/profile.ml
+++ b/utils/profile.ml
@@ -17,10 +17,6 @@
 
 type file = string
 
-let enabled = ref false
-
-let enable () = enabled := true
-
 external time_include_children: bool -> float = "caml_sys_time_include_children"
 let cpu_time () = time_include_children true
 
@@ -75,7 +71,7 @@ let hierarchy = ref (create ())
 let initial_measure = ref None
 let reset () = hierarchy := create (); initial_measure := None
 
-let record_call0 ?(accumulate = false) name f =
+let record_call ?(accumulate = false) name f =
   let E prev_hierarchy = !hierarchy in
   let start_measure = Measure.create () in
   if !initial_measure = None then initial_measure := Some start_measure;
@@ -101,12 +97,7 @@ let record_call0 ?(accumulate = false) name f =
           Measure_diff.accumulate this_measure_diff start_measure end_measure in
         Hashtbl.add prev_hierarchy name (measure_diff, E this_table))
 
-let record_call ?accumulate pass f =
-  if !enabled then record_call0 ?accumulate pass f
-  else f ()
-
-let record ?accumulate pass f x =
-  record_call ?accumulate pass (fun () -> f x)
+let record ?accumulate pass f x = record_call ?accumulate pass (fun () -> f x)
 
 type display = {
   to_string : max:float -> width:int -> string;

--- a/utils/profile.mli
+++ b/utils/profile.mli
@@ -25,8 +25,6 @@ type file = string
 val reset : unit -> unit
 (** erase all recorded profile information *)
 
-val enable : unit -> unit
-
 val record_call : ?accumulate:bool -> string -> (unit -> 'a) -> 'a
 (** [record_call pass f] calls [f] and records its profile information. *)
 


### PR DESCRIPTION
Reverts the per-function `-dprofile` output I put in a while back.  I've found this to be a hindrance.  Removing this also means that we shouldn't need the changes to make the `Profile` module more efficient.