### PR TITLE
Lifting of statically closed functions in Lambda_to_flambda

### DIFF
--- a/middle_end/flambda/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion.ml
@@ -47,6 +47,19 @@ let symbol_for_ident acc env id =
   let symbol = Env.symbol_for_global' env id in
   use_of_symbol_as_simple acc symbol
 
+let register_set_of_closures_as_symbols acc set_of_closures
+      : Acc.t * Symbol.t Closure_id.Lmap.t =
+  let symbols =
+    Set_of_closures.function_decls set_of_closures
+    |> Function_declarations.funs_in_order
+    |> Closure_id.Lmap.mapi (fun closure_id _ ->
+        Symbol.create (Compilation_unit.get_current_exn ())
+          (Linkage_name.create
+             (Variable.unique_name (Closure_id.unwrap closure_id))))
+  in
+  let acc = Acc.add_declared_set_of_closures ~symbols ~set_of_closures acc in
+  acc, symbols
+
 let register_const0 acc constant name =
   match Static_const.Map.find constant (Acc.shareable_constants acc) with
   | exception Not_found ->
@@ -985,15 +998,17 @@ let close_let_rec acc env ~function_declarations
         env)
       function_declarations env
   in
-  let closure_vars =
-    List.fold_left (fun closure_vars decl ->
+  let closure_vars, ident_map =
+    List.fold_left (fun (closure_vars, ident_map) decl ->
+        let ident = Function_decl.let_rec_ident decl in
         let closure_var =
-          VB.create (Env.find_var env (Function_decl.let_rec_ident decl))
+          VB.create (Env.find_var env ident)
             Name_mode.normal
         in
         let closure_id = Function_decl.closure_id decl in
-        Closure_id.Map.add closure_id closure_var closure_vars)
-      Closure_id.Map.empty
+        Closure_id.Map.add closure_id closure_var closure_vars,
+        Closure_id.Map.add closure_id ident ident_map)
+      (Closure_id.Map.empty, Closure_id.Map.empty)
       function_declarations
   in
   let acc, set_of_closures =
@@ -1022,13 +1037,26 @@ let close_let_rec acc env ~function_declarations
           Set_of_closures.function_decls set_of_closures)
         |> Closure_id.Lmap.bindings)
   in
-  let acc, body = body acc env in
-  let named = Named.create_set_of_closures set_of_closures in
-  Let_with_acc.create acc
-    (Bindable_let_bound.set_of_closures ~closure_vars)
-    named
-    ~body ~free_names_of_body:Unknown
-  |> Expr_with_acc.create_let
+  if Set_of_closures.environment_doesn't_mention_variables set_of_closures
+  then
+    let acc, symbols =
+      register_set_of_closures_as_symbols acc set_of_closures
+    in
+    let env =
+      Closure_id.Lmap.fold (fun closure_id symbol env ->
+          let ident = Closure_id.Map.find closure_id ident_map in
+          Env.add_simple_to_substitute env ident (Simple.symbol symbol))
+        symbols
+        env
+    in
+    body acc env
+  else
+    let acc, body = body acc env in
+    Let_with_acc.create acc
+      (Bindable_let_bound.set_of_closures ~closure_vars)
+      (Named.create_set_of_closures set_of_closures)
+      ~body ~free_names_of_body:Unknown
+    |> Expr_with_acc.create_let
 
 let close_program ~backend ~module_ident ~module_block_size_in_words
       ~program ~prog_return_cont ~exn_continuation =
@@ -1132,6 +1160,26 @@ let close_program ~backend ~module_ident ~module_block_size_in_words
       ~cost_metrics_of_handler
   in
   let acc, body =
+    List.fold_left (fun (acc, body) (symbols, set_of_closures) ->
+        let bound_symbols =
+          Bound_symbols.singleton
+            (Bound_symbols.Pattern.set_of_closures symbols)
+        in
+        let defining_expr =
+          Named.create_static_consts
+            (Static_const.Group.create [Set_of_closures set_of_closures])
+        in
+        Let_with_acc.create acc
+          (Bindable_let_bound.symbols bound_symbols Syntactic)
+          defining_expr ~body ~free_names_of_body:Unknown
+        |> Expr_with_acc.create_let
+      )
+      (acc, body)
+      (Acc.declared_static_sets_of_closures acc)
+  in
+  let acc, body =
+    (* CR Keryan: The order of the bindings is important as blocks of code
+       might refer one another. There should be a topological sort here. *)
     Code_id.Map.fold (fun code_id code (acc, body) ->
       let bound_symbols =
           Bound_symbols.singleton (Bound_symbols.Pattern.code code_id)

--- a/middle_end/flambda/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion_aux.ml
@@ -190,6 +190,8 @@ end
 module Acc = struct
   type t = {
     declared_symbols : (Symbol.t * Flambda.Static_const.t) list;
+    declared_static_sets_of_closures
+      : (Symbol.t Closure_id.Lmap.t * Flambda.Set_of_closures.t) list;
     shareable_constants : Symbol.t Flambda.Static_const.Map.t;
     code : Flambda.Code.t Code_id.Map.t;
     free_names_of_current_function : Name_occurrences.t;
@@ -209,6 +211,7 @@ module Acc = struct
 
   let empty = {
     declared_symbols = [];
+    declared_static_sets_of_closures = [];
     shareable_constants = Flambda.Static_const.Map.empty;
     code = Code_id.Map.empty;
     free_names_of_current_function = Name_occurrences.empty;
@@ -218,6 +221,7 @@ module Acc = struct
   }
 
   let declared_symbols t = t.declared_symbols
+  let declared_static_sets_of_closures t = t.declared_static_sets_of_closures
   let shareable_constants t = t.shareable_constants
   let code t = t.code
   let free_names_of_current_function t = t.free_names_of_current_function
@@ -226,6 +230,11 @@ module Acc = struct
   let add_declared_symbol ~symbol ~constant t =
     let declared_symbols = (symbol, constant) :: t.declared_symbols in
     { t with declared_symbols; }
+
+  let add_declared_set_of_closures ~symbols ~set_of_closures t =
+    { t with
+      declared_static_sets_of_closures =
+        (symbols, set_of_closures) :: t.declared_static_sets_of_closures; }
 
   let add_shareable_constant ~symbol ~constant t =
     let shareable_constants =

--- a/middle_end/flambda/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda/from_lambda/closure_conversion_aux.mli
@@ -119,6 +119,8 @@ module Acc : sig
   val empty : t
 
   val declared_symbols : t -> (Symbol.t * Flambda.Static_const.t) list
+  val declared_static_sets_of_closures
+     : t -> (Symbol.t Closure_id.Lmap.t * Flambda.Set_of_closures.t) list
   val shareable_constants : t -> Symbol.t Flambda.Static_const.Map.t
   val code : t -> Flambda.Code.t Code_id.Map.t
   val free_names_of_current_function : t -> Name_occurrences.t
@@ -130,6 +132,12 @@ module Acc : sig
   val add_declared_symbol
      : symbol:Symbol.t
     -> constant:Flambda.Static_const.t
+    -> t
+    -> t
+
+  val add_declared_set_of_closures
+     : symbols:(Symbol.t Closure_id.Lmap.t)
+    -> set_of_closures:Flambda.Set_of_closures.t
     -> t
     -> t
 


### PR DESCRIPTION
This converts sets of closures to top-level symbols when possible.

This can be improved further by removing the closure entirely, and referring recursive functions by their symbols directly in the code. It would require a more involved patch as the code of relevant functions would change, and symbols would need to be declared in topological order.