### PR TITLE
Targetint_32_64

### DIFF
--- a/.depend
+++ b/.depend
@@ -3906,13 +3906,13 @@ middle_end/flambda/compilenv_deps/lmap.cmx : \
     middle_end/flambda/compilenv_deps/lmap.cmi
 middle_end/flambda/compilenv_deps/lmap.cmi :
 middle_end/flambda/compilenv_deps/one_bit_fewer.cmo : \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/one_bit_fewer.cmi
 middle_end/flambda/compilenv_deps/one_bit_fewer.cmx : \
-    utils/targetint.cmx \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmx \
     middle_end/flambda/compilenv_deps/one_bit_fewer.cmi
 middle_end/flambda/compilenv_deps/one_bit_fewer.cmi : \
-    utils/targetint.cmi
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi
 middle_end/flambda/compilenv_deps/patricia_tree.cmo : \
     utils/numbers.cmi \
     utils/misc.cmi \
@@ -3941,7 +3941,7 @@ middle_end/flambda/compilenv_deps/rec_info.cmx : \
 middle_end/flambda/compilenv_deps/rec_info.cmi : \
     utils/identifiable.cmi
 middle_end/flambda/compilenv_deps/reg_width_things.cmo : \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     middle_end/flambda/compilenv_deps/table_by_int_id.cmi \
     middle_end/flambda/compilenv_deps/patricia_tree.cmi \
@@ -3955,7 +3955,7 @@ middle_end/flambda/compilenv_deps/reg_width_things.cmo : \
     middle_end/flambda/compilenv_deps/coercion.cmi \
     middle_end/flambda/compilenv_deps/reg_width_things.cmi
 middle_end/flambda/compilenv_deps/reg_width_things.cmx : \
-    utils/targetint.cmx \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmx \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmx \
     middle_end/flambda/compilenv_deps/table_by_int_id.cmx \
     middle_end/flambda/compilenv_deps/patricia_tree.cmx \
@@ -3969,7 +3969,7 @@ middle_end/flambda/compilenv_deps/reg_width_things.cmx : \
     middle_end/flambda/compilenv_deps/coercion.cmx \
     middle_end/flambda/compilenv_deps/reg_width_things.cmi
 middle_end/flambda/compilenv_deps/reg_width_things.cmi : \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     middle_end/flambda/compilenv_deps/table_by_int_id.cmi \
     utils/numbers.cmi \
@@ -4002,39 +4002,51 @@ middle_end/flambda/compilenv_deps/table_by_int_id.cmx : \
     middle_end/flambda/compilenv_deps/table_by_int_id.cmi
 middle_end/flambda/compilenv_deps/table_by_int_id.cmi :
 middle_end/flambda/compilenv_deps/tag.cmo : \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     utils/numbers.cmi \
     utils/misc.cmi \
     utils/identifiable.cmi \
     middle_end/flambda/compilenv_deps/tag.cmi
 middle_end/flambda/compilenv_deps/tag.cmx : \
-    utils/targetint.cmx \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmx \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmx \
     utils/numbers.cmx \
     utils/misc.cmx \
     utils/identifiable.cmx \
     middle_end/flambda/compilenv_deps/tag.cmi
 middle_end/flambda/compilenv_deps/tag.cmi : \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     utils/identifiable.cmi
 middle_end/flambda/compilenv_deps/targetint_31_63.cmo : \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/one_bit_fewer.cmi \
     utils/numbers.cmi \
     utils/misc.cmi \
     utils/identifiable.cmi \
+    utils/config.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi
 middle_end/flambda/compilenv_deps/targetint_31_63.cmx : \
-    utils/targetint.cmx \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmx \
     middle_end/flambda/compilenv_deps/one_bit_fewer.cmx \
     utils/numbers.cmx \
     utils/misc.cmx \
     utils/identifiable.cmx \
+    utils/config.cmx \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi
 middle_end/flambda/compilenv_deps/targetint_31_63.cmi : \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
+    utils/identifiable.cmi
+middle_end/flambda/compilenv_deps/targetint_32_64.cmo : \
+    utils/misc.cmi \
+    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi
+middle_end/flambda/compilenv_deps/targetint_32_64.cmx : \
+    utils/misc.cmx \
+    utils/identifiable.cmx \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi
+middle_end/flambda/compilenv_deps/targetint_32_64.cmi : \
     utils/identifiable.cmi
 middle_end/flambda/compilenv_deps/variable.cmo : \
     middle_end/flambda/compilenv_deps/reg_width_things.cmi \
@@ -4800,7 +4812,7 @@ middle_end/flambda/from_lambda/closure_conversion.cmo : \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
     middle_end/flambda/basic/trap_action.cmi \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     middle_end/flambda/compilenv_deps/tag.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
@@ -4854,7 +4866,7 @@ middle_end/flambda/from_lambda/closure_conversion.cmx : \
     middle_end/flambda/basic/var_within_closure.cmx \
     middle_end/flambda/naming/var_in_binding_pos.cmx \
     middle_end/flambda/basic/trap_action.cmx \
-    utils/targetint.cmx \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmx \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmx \
     middle_end/flambda/compilenv_deps/tag.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
@@ -4926,6 +4938,8 @@ middle_end/flambda/from_lambda/closure_conversion_aux.cmo : \
     typing/ident.cmi \
     middle_end/flambda/flambda_backend_intf.cmi \
     middle_end/flambda/terms/flambda.cmi \
+    middle_end/flambda/basic/exn_continuation.cmi \
+    lambda/debuginfo.cmi \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/inlining/metrics/code_size.cmi \
@@ -4947,6 +4961,8 @@ middle_end/flambda/from_lambda/closure_conversion_aux.cmx : \
     typing/ident.cmx \
     middle_end/flambda/flambda_backend_intf.cmi \
     middle_end/flambda/terms/flambda.cmx \
+    middle_end/flambda/basic/exn_continuation.cmx \
+    lambda/debuginfo.cmx \
     middle_end/flambda/basic/continuation.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
     middle_end/flambda/inlining/metrics/code_size.cmx \
@@ -4956,6 +4972,7 @@ middle_end/flambda/from_lambda/closure_conversion_aux.cmx : \
 middle_end/flambda/from_lambda/closure_conversion_aux.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/var_within_closure.cmi \
+    middle_end/flambda/basic/trap_action.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     lambda/switch.cmi \
     middle_end/flambda/basic/simple.cmi \
@@ -4969,6 +4986,7 @@ middle_end/flambda/from_lambda/closure_conversion_aux.cmi : \
     typing/ident.cmi \
     middle_end/flambda/flambda_backend_intf.cmi \
     middle_end/flambda/terms/flambda.cmi \
+    lambda/debuginfo.cmi \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/basic/closure_id.cmi \
@@ -5087,7 +5105,7 @@ middle_end/flambda/from_lambda/lambda_to_flambda.cmi : \
     middle_end/flambda/terms/flambda_unit.cmi \
     middle_end/flambda/flambda_backend_intf.cmi
 middle_end/flambda/from_lambda/lambda_to_flambda_primitives.cmo : \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     middle_end/flambda/compilenv_deps/tag.cmi \
     middle_end/flambda/basic/simple.cmi \
@@ -5105,7 +5123,7 @@ middle_end/flambda/from_lambda/lambda_to_flambda_primitives.cmo : \
     middle_end/flambda/from_lambda/closure_conversion_aux.cmi \
     middle_end/flambda/from_lambda/lambda_to_flambda_primitives.cmi
 middle_end/flambda/from_lambda/lambda_to_flambda_primitives.cmx : \
-    utils/targetint.cmx \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmx \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmx \
     middle_end/flambda/compilenv_deps/tag.cmx \
     middle_end/flambda/basic/simple.cmx \
@@ -5312,7 +5330,7 @@ middle_end/flambda/inlining/inlining_transforms.cmi : \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/simplify/env/downwards_acc.cmi
 middle_end/flambda/inlining/metrics/code_size.cmo : \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/terms/switch_expr.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/terms/flambda_primitive.cmi \
@@ -5321,7 +5339,7 @@ middle_end/flambda/inlining/metrics/code_size.cmo : \
     middle_end/flambda/terms/apply_cont_expr.cmi \
     middle_end/flambda/inlining/metrics/code_size.cmi
 middle_end/flambda/inlining/metrics/code_size.cmx : \
-    utils/targetint.cmx \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmx \
     middle_end/flambda/terms/switch_expr.cmx \
     middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/terms/flambda_primitive.cmx \
@@ -5790,7 +5808,7 @@ middle_end/flambda/parser/fexpr_to_flambda.cmo : \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
     middle_end/flambda/basic/trap_action.cmi \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     middle_end/flambda/compilenv_deps/tag.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
@@ -5840,7 +5858,7 @@ middle_end/flambda/parser/fexpr_to_flambda.cmx : \
     middle_end/flambda/basic/var_within_closure.cmx \
     middle_end/flambda/naming/var_in_binding_pos.cmx \
     middle_end/flambda/basic/trap_action.cmx \
-    utils/targetint.cmx \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmx \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmx \
     middle_end/flambda/compilenv_deps/tag.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
@@ -5927,7 +5945,7 @@ middle_end/flambda/parser/flambda_to_fexpr.cmo : \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
     middle_end/flambda/basic/trap_action.cmi \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     middle_end/flambda/compilenv_deps/tag.cmi \
     middle_end/flambda/basic/symbol_scoping_rule.cmi \
@@ -5970,7 +5988,7 @@ middle_end/flambda/parser/flambda_to_fexpr.cmx : \
     middle_end/flambda/basic/var_within_closure.cmx \
     middle_end/flambda/naming/var_in_binding_pos.cmx \
     middle_end/flambda/basic/trap_action.cmx \
-    utils/targetint.cmx \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmx \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmx \
     middle_end/flambda/compilenv_deps/tag.cmx \
     middle_end/flambda/basic/symbol_scoping_rule.cmx \
@@ -6283,7 +6301,7 @@ middle_end/flambda/simplify/rebuilt_static_const.cmx : \
     middle_end/flambda/simplify/env/are_rebuilding_terms.cmx \
     middle_end/flambda/simplify/rebuilt_static_const.cmi
 middle_end/flambda/simplify/rebuilt_static_const.cmi : \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/tag.cmi \
     middle_end/flambda/terms/set_of_closures.cmi \
     middle_end/flambda/basic/recursive.cmi \
@@ -6919,7 +6937,6 @@ middle_end/flambda/simplify/simplify_set_of_closures.cmo : \
     middle_end/flambda/basic/scope.cmi \
     middle_end/flambda/compilenv_deps/rec_info.cmi \
     middle_end/flambda/simplify/rebuilt_static_const.cmi \
-    utils/profile.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/naming/name_in_binding_pos.cmi \
@@ -6961,7 +6978,6 @@ middle_end/flambda/simplify/simplify_set_of_closures.cmx : \
     middle_end/flambda/basic/scope.cmx \
     middle_end/flambda/compilenv_deps/rec_info.cmx \
     middle_end/flambda/simplify/rebuilt_static_const.cmx \
-    utils/profile.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/naming/name_in_binding_pos.cmx \
@@ -7120,7 +7136,7 @@ middle_end/flambda/simplify/simplify_ternary_primitive.cmi : \
     lambda/debuginfo.cmi
 middle_end/flambda/simplify/simplify_unary_primitive.cmo : \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     middle_end/flambda/types/basic/string_info.cmi \
     middle_end/flambda/simplify/simplify_import.cmi \
@@ -7134,7 +7150,7 @@ middle_end/flambda/simplify/simplify_unary_primitive.cmo : \
     middle_end/flambda/simplify/simplify_unary_primitive.cmi
 middle_end/flambda/simplify/simplify_unary_primitive.cmx : \
     middle_end/flambda/naming/var_in_binding_pos.cmx \
-    utils/targetint.cmx \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmx \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmx \
     middle_end/flambda/types/basic/string_info.cmx \
     middle_end/flambda/simplify/simplify_import.cmx \
@@ -7669,7 +7685,7 @@ middle_end/flambda/simplify/typing_helpers/continuation_uses.cmi : \
     middle_end/flambda/types/structures/code_age_relation.cmi \
     middle_end/flambda/basic/apply_cont_rewrite_id.cmi
 middle_end/flambda/simplify/typing_helpers/number_adjuncts.cmo : \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/basic/reg_width_const.cmi \
@@ -7681,7 +7697,7 @@ middle_end/flambda/simplify/typing_helpers/number_adjuncts.cmo : \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/simplify/typing_helpers/number_adjuncts.cmi
 middle_end/flambda/simplify/typing_helpers/number_adjuncts.cmx : \
-    utils/targetint.cmx \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmx \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmx \
     middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/basic/reg_width_const.cmx \
@@ -7693,7 +7709,7 @@ middle_end/flambda/simplify/typing_helpers/number_adjuncts.cmx : \
     middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/simplify/typing_helpers/number_adjuncts.cmi
 middle_end/flambda/simplify/typing_helpers/number_adjuncts.cmi : \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     middle_end/flambda/basic/reg_width_const.cmi \
     utils/numbers.cmi \
@@ -8057,7 +8073,7 @@ middle_end/flambda/terms/flambda.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     middle_end/flambda/compilenv_deps/tag.cmi \
     middle_end/flambda/basic/symbol_scoping_rule.cmi \
@@ -8118,7 +8134,7 @@ middle_end/flambda/terms/flambda.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
     middle_end/flambda/basic/var_within_closure.cmx \
     middle_end/flambda/naming/var_in_binding_pos.cmx \
-    utils/targetint.cmx \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmx \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmx \
     middle_end/flambda/compilenv_deps/tag.cmx \
     middle_end/flambda/basic/symbol_scoping_rule.cmx \
@@ -8177,7 +8193,7 @@ middle_end/flambda/terms/flambda.cmx : \
     middle_end/flambda/terms/flambda.cmi
 middle_end/flambda/terms/flambda.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     middle_end/flambda/compilenv_deps/tag.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
@@ -8484,7 +8500,7 @@ middle_end/flambda/terms/let_expr.rec.cmi : \
     middle_end/flambda/cmx/contains_ids.cmo \
     middle_end/flambda/naming/bindable_let_bound.cmi
 middle_end/flambda/terms/named.rec.cmo : \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/terms/set_of_closures.cmi \
@@ -8501,7 +8517,7 @@ middle_end/flambda/terms/named.rec.cmo : \
     lambda/debuginfo.cmi \
     middle_end/flambda/terms/named.rec.cmi
 middle_end/flambda/terms/named.rec.cmx : \
-    utils/targetint.cmx \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmx \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmx \
     middle_end/flambda/basic/simple.cmx \
     middle_end/flambda/terms/set_of_closures.cmx \
@@ -8620,7 +8636,7 @@ middle_end/flambda/terms/set_of_closures.cmi : \
     middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/terms/static_const.rec.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     middle_end/flambda/compilenv_deps/tag.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
@@ -8644,7 +8660,7 @@ middle_end/flambda/terms/static_const.rec.cmo : \
     middle_end/flambda/terms/static_const.rec.cmi
 middle_end/flambda/terms/static_const.rec.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
-    utils/targetint.cmx \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmx \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmx \
     middle_end/flambda/compilenv_deps/tag.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
@@ -8668,7 +8684,7 @@ middle_end/flambda/terms/static_const.rec.cmx : \
     middle_end/flambda/terms/static_const.rec.cmi
 middle_end/flambda/terms/static_const.rec.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     middle_end/flambda/compilenv_deps/tag.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
@@ -8741,7 +8757,7 @@ middle_end/flambda/to_cmm/un_cps.cmo : \
     middle_end/flambda/to_cmm/un_cps_helper.cmi \
     middle_end/flambda/to_cmm/un_cps_env.cmi \
     middle_end/flambda/to_cmm/un_cps_closure.cmi \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     lambda/switch.cmi \
@@ -8805,7 +8821,7 @@ middle_end/flambda/to_cmm/un_cps.cmx : \
     middle_end/flambda/to_cmm/un_cps_helper.cmx \
     middle_end/flambda/to_cmm/un_cps_env.cmx \
     middle_end/flambda/to_cmm/un_cps_closure.cmx \
-    utils/targetint.cmx \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmx \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
     lambda/switch.cmx \
@@ -8974,7 +8990,7 @@ middle_end/flambda/to_cmm/un_cps_env.cmi : \
     middle_end/backend_var.cmi
 middle_end/flambda/to_cmm/un_cps_helper.cmo : \
     middle_end/flambda/basic/trap_action.cmi \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/tag.cmi \
     typing/primitive.cmi \
     middle_end/flambda/basic/mutability.cmi \
@@ -8993,7 +9009,7 @@ middle_end/flambda/to_cmm/un_cps_helper.cmo : \
     middle_end/flambda/to_cmm/un_cps_helper.cmi
 middle_end/flambda/to_cmm/un_cps_helper.cmx : \
     middle_end/flambda/basic/trap_action.cmx \
-    utils/targetint.cmx \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmx \
     middle_end/flambda/compilenv_deps/tag.cmx \
     typing/primitive.cmx \
     middle_end/flambda/basic/mutability.cmx \
@@ -9012,7 +9028,7 @@ middle_end/flambda/to_cmm/un_cps_helper.cmx : \
     middle_end/flambda/to_cmm/un_cps_helper.cmi
 middle_end/flambda/to_cmm/un_cps_helper.cmi : \
     middle_end/flambda/basic/trap_action.cmi \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     typing/primitive.cmi \
     middle_end/flambda/basic/mutability.cmi \
     lambda/lambda.cmi \
@@ -9049,7 +9065,7 @@ middle_end/flambda/to_cmm/un_cps_static.cmo : \
     middle_end/flambda/to_cmm/un_cps_helper.cmi \
     middle_end/flambda/to_cmm/un_cps_env.cmi \
     middle_end/flambda/to_cmm/un_cps_closure.cmi \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     middle_end/flambda/compilenv_deps/tag.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
@@ -9085,7 +9101,7 @@ middle_end/flambda/to_cmm/un_cps_static.cmx : \
     middle_end/flambda/to_cmm/un_cps_helper.cmx \
     middle_end/flambda/to_cmm/un_cps_env.cmx \
     middle_end/flambda/to_cmm/un_cps_closure.cmx \
-    utils/targetint.cmx \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmx \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmx \
     middle_end/flambda/compilenv_deps/tag.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
@@ -9132,7 +9148,7 @@ middle_end/flambda/types/flambda_type.cmo : \
     middle_end/flambda/types/structures/type_structure_intf.cmo \
     middle_end/flambda/types/type_head_intf.cmo \
     middle_end/flambda/types/type_descr_intf.cmo \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     middle_end/flambda/types/basic/tag_or_unknown_and_size.cmi \
     middle_end/flambda/types/basic/tag_and_size.cmi \
@@ -9187,7 +9203,7 @@ middle_end/flambda/types/flambda_type.cmx : \
     middle_end/flambda/types/structures/type_structure_intf.cmx \
     middle_end/flambda/types/type_head_intf.cmx \
     middle_end/flambda/types/type_descr_intf.cmx \
-    utils/targetint.cmx \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmx \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmx \
     middle_end/flambda/types/basic/tag_or_unknown_and_size.cmx \
     middle_end/flambda/types/basic/tag_and_size.cmx \
@@ -9238,7 +9254,7 @@ middle_end/flambda/types/flambda_type.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     middle_end/flambda/compilenv_deps/tag.cmi \
     middle_end/flambda/terms/symbol_projection.cmi \
@@ -9350,7 +9366,7 @@ middle_end/flambda/types/type_descr_intf.cmx : \
 middle_end/flambda/types/type_grammar.rec.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/var_within_closure.cmi \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     middle_end/flambda/compilenv_deps/tag.cmi \
     middle_end/flambda/types/basic/string_info.cmi \
@@ -9374,7 +9390,7 @@ middle_end/flambda/types/type_grammar.rec.cmo : \
 middle_end/flambda/types/type_grammar.rec.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
     middle_end/flambda/basic/var_within_closure.cmx \
-    utils/targetint.cmx \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmx \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmx \
     middle_end/flambda/compilenv_deps/tag.cmx \
     middle_end/flambda/types/basic/string_info.cmx \
@@ -9398,7 +9414,7 @@ middle_end/flambda/types/type_grammar.rec.cmx : \
 middle_end/flambda/types/type_grammar.rec.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/var_within_closure.cmi \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     middle_end/flambda/compilenv_deps/tag.cmi \
     middle_end/flambda/basic/simple.cmi \
@@ -9823,7 +9839,7 @@ middle_end/flambda/types/kinds/flambda_arity.cmi : \
     utils/identifiable.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi
 middle_end/flambda/types/kinds/flambda_kind.cmo : \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     utils/numbers.cmi \
     utils/misc.cmi \
@@ -9831,7 +9847,7 @@ middle_end/flambda/types/kinds/flambda_kind.cmo : \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi
 middle_end/flambda/types/kinds/flambda_kind.cmx : \
-    utils/targetint.cmx \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmx \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmx \
     utils/numbers.cmx \
     utils/misc.cmx \
@@ -9839,7 +9855,7 @@ middle_end/flambda/types/kinds/flambda_kind.cmx : \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmi
 middle_end/flambda/types/kinds/flambda_kind.cmi : \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     utils/numbers.cmi \
     utils/identifiable.cmi
@@ -10138,7 +10154,7 @@ middle_end/flambda/types/type_of_kind/type_of_kind_naked_int64_0.rec.cmx : \
 middle_end/flambda/types/type_of_kind/type_of_kind_naked_int64_0.rec.cmi : \
     middle_end/flambda/types/type_head_intf.cmo
 middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.cmo : \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
@@ -10146,7 +10162,7 @@ middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.cmo : \
     middle_end/flambda/compilenv_deps/coercion.cmi \
     middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.cmi
 middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.cmx : \
-    utils/targetint.cmx \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmx \
     middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/types/basic/or_bottom.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
@@ -10155,7 +10171,7 @@ middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.cmx : \
     middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.cmi
 middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.cmi : \
     middle_end/flambda/types/type_head_intf.cmo \
-    utils/targetint.cmi
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi
 middle_end/flambda/types/type_of_kind/type_of_kind_rec_info0.rec.cmo : \
     middle_end/flambda/terms/rec_info_expr.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
@@ -10360,7 +10376,7 @@ middle_end/flambda/unboxing/unbox_continuation_params.cmi : \
     middle_end/flambda/simplify/env/continuation_env_and_param_types.cmi \
     middle_end/flambda/basic/apply_cont_rewrite_id.cmi
 middle_end/flambda/unboxing/unboxers.cmo : \
-    utils/targetint.cmi \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     middle_end/flambda/simplify/simplify_import.cmi \
     middle_end/flambda/basic/simple.cmi \
@@ -10368,7 +10384,7 @@ middle_end/flambda/unboxing/unboxers.cmo : \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/unboxing/unboxers.cmi
 middle_end/flambda/unboxing/unboxers.cmx : \
-    utils/targetint.cmx \
+    middle_end/flambda/compilenv_deps/targetint_32_64.cmx \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmx \
     middle_end/flambda/simplify/simplify_import.cmx \
     middle_end/flambda/basic/simple.cmx \

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -179,6 +179,7 @@ MIDDLE_END_CLOSURE_CMI=
 MIDDLE_END_FLAMBDA_COMPILENV_DEPS=\
   middle_end/flambda/compilenv_deps/one_bit_fewer.cmo \
   middle_end/flambda/compilenv_deps/lmap.cmo \
+  middle_end/flambda/compilenv_deps/targetint_32_64.cmo \
   middle_end/flambda/compilenv_deps/targetint_31_63.cmo \
   middle_end/flambda/compilenv_deps/tag.cmo \
   middle_end/flambda/compilenv_deps/table_by_int_id.cmo \

--- a/middle_end/flambda/compilenv_deps/one_bit_fewer.ml
+++ b/middle_end/flambda/compilenv_deps/one_bit_fewer.ml
@@ -39,7 +39,7 @@ module type S = sig
   val of_int_option : int -> t option
   val of_int32 : int32 -> t
   val of_int64 : int64 -> t
-  val of_targetint : Targetint.t -> t
+  val of_targetint : Targetint_32_64.t -> t
   val of_float : float -> t
 
   val to_float : t -> float
@@ -48,7 +48,7 @@ module type S = sig
   val to_int_option : t -> int option
   val to_int32 : t -> int32
   val to_int64 : t -> int64
-  val to_targetint : t -> Targetint.t
+  val to_targetint : t -> Targetint_32_64.t
 
   val neg : t -> t
   val get_least_significant_16_bits_then_byte_swap : t -> t

--- a/middle_end/flambda/compilenv_deps/one_bit_fewer.mli
+++ b/middle_end/flambda/compilenv_deps/one_bit_fewer.mli
@@ -22,7 +22,7 @@ module type S =
     val of_int_option : int -> t option
     val of_int32 : int32 -> t
     val of_int64 : int64 -> t
-    val of_targetint : Targetint.t -> t
+    val of_targetint : Targetint_32_64.t -> t
     val of_float : float -> t
     val to_float : t -> float
     val to_int : t -> int
@@ -30,7 +30,7 @@ module type S =
     val to_int_option : t -> int option
     val to_int32 : t -> int32
     val to_int64 : t -> int64
-    val to_targetint : t -> Targetint.t
+    val to_targetint : t -> Targetint_32_64.t
     val neg : t -> t
     val get_least_significant_16_bits_then_byte_swap : t -> t
     val add : t -> t -> t
@@ -72,7 +72,7 @@ module Make :
       val of_int_option : int -> t option
       val of_int32 : int32 -> t
       val of_int64 : int64 -> t
-      val of_targetint : Targetint.t -> t
+      val of_targetint : Targetint_32_64.t -> t
       val of_float : float -> t
       val to_float : t -> float
       val to_int : t -> int
@@ -80,7 +80,7 @@ module Make :
       val to_int_option : t -> int option
       val to_int32 : t -> int32
       val to_int64 : t -> int64
-      val to_targetint : t -> Targetint.t
+      val to_targetint : t -> Targetint_32_64.t
       val neg : t -> t
       val get_least_significant_16_bits_then_byte_swap : t -> t
       val add : t -> t -> t

--- a/middle_end/flambda/compilenv_deps/reg_width_things.ml
+++ b/middle_end/flambda/compilenv_deps/reg_width_things.ml
@@ -32,7 +32,7 @@ module Const_data = struct
     | Naked_float of Numbers.Float_by_bit_pattern.t
     | Naked_int32 of Int32.t
     | Naked_int64 of Int64.t
-    | Naked_nativeint of Targetint.t
+    | Naked_nativeint of Targetint_32_64.t
 
   let flags = const_flags
 
@@ -69,7 +69,7 @@ module Const_data = struct
       | Naked_nativeint n ->
         Format.fprintf ppf "@<0>%s#%an@<0>%s"
           (Flambda_colours.naked_number ())
-          Targetint.print n
+          Targetint_32_64.print n
           (Flambda_colours.normal ())
 
     let output _ _ = Misc.fatal_error "[output] not yet implemented"
@@ -87,7 +87,7 @@ module Const_data = struct
       | Naked_int64 n1, Naked_int64 n2 ->
         Int64.compare n1 n2
       | Naked_nativeint n1, Naked_nativeint n2 ->
-        Targetint.compare n1 n2
+        Targetint_32_64.compare n1 n2
       | Naked_immediate _, _ -> -1
       | _, Naked_immediate _ -> 1
       | Tagged_immediate _, _ -> -1
@@ -114,7 +114,7 @@ module Const_data = struct
         | Naked_int64 n1, Naked_int64 n2 ->
           Int64.equal n1 n2
         | Naked_nativeint n1, Naked_nativeint n2 ->
-          Targetint.equal n1 n2
+          Targetint_32_64.equal n1 n2
         | (Naked_immediate _ | Tagged_immediate _ | Naked_float _
             | Naked_int32 _ | Naked_int64 _ | Naked_nativeint _), _ -> false
 
@@ -125,7 +125,7 @@ module Const_data = struct
       | Naked_float n -> Numbers.Float_by_bit_pattern.hash n
       | Naked_int32 n -> Hashtbl.hash n
       | Naked_int64 n -> Hashtbl.hash n
-      | Naked_nativeint n -> Targetint.hash n
+      | Naked_nativeint n -> Targetint_32_64.hash n
   end)
 end
 

--- a/middle_end/flambda/compilenv_deps/reg_width_things.mli
+++ b/middle_end/flambda/compilenv_deps/reg_width_things.mli
@@ -50,7 +50,7 @@ module Const : sig
   val naked_float : Numbers.Float_by_bit_pattern.t -> t
   val naked_int32 : Int32.t -> t
   val naked_int64 : Int64.t -> t
-  val naked_nativeint : Targetint.t -> t
+  val naked_nativeint : Targetint_32_64.t -> t
 
   module Descr : sig
     type t = private
@@ -59,7 +59,7 @@ module Const : sig
       | Naked_float of Numbers.Float_by_bit_pattern.t
       | Naked_int32 of Int32.t
       | Naked_int64 of Int64.t
-      | Naked_nativeint of Targetint.t
+      | Naked_nativeint of Targetint_32_64.t
 
     include Identifiable.S with type t := t
   end

--- a/middle_end/flambda/compilenv_deps/tag.ml
+++ b/middle_end/flambda/compilenv_deps/tag.ml
@@ -58,7 +58,7 @@ let create_from_targetint imm =
   create_from_targetint_imm (Targetint_31_63.to_targetint imm)
 
 let to_int t = t
-let to_targetint t = Targetint.of_int (to_int t)
+let to_targetint t = Targetint_32_64.of_int (to_int t)
 let to_targetint_ocaml t = Targetint_31_63.Imm.of_int (to_int t)
 let to_target_imm t = Targetint_31_63.int (to_targetint_ocaml t)
 
@@ -91,7 +91,7 @@ module Scannable = struct
       Misc.fatal_error (Printf.sprintf "Tag.Scannable.create_exn %d" tag)
 
   let to_int t = t
-  let to_targetint t = Targetint.of_int (to_int t)
+  let to_targetint t = Targetint_32_64.of_int (to_int t)
   let to_tag t = t
 
   let of_tag tag =

--- a/middle_end/flambda/compilenv_deps/tag.mli
+++ b/middle_end/flambda/compilenv_deps/tag.mli
@@ -30,7 +30,7 @@ val create_from_targetint_imm : Targetint_31_63.Imm.t -> t option
 
 val to_int : t -> int
 val to_target_imm : t -> Targetint_31_63.t
-val to_targetint : t -> Targetint.t
+val to_targetint : t -> Targetint_32_64.t
 val to_targetint_ocaml : t -> Targetint_31_63.Imm.t
 
 val zero : t
@@ -76,7 +76,7 @@ module Scannable : sig
   val of_tag : tag -> t option
 
   val to_int : t -> int
-  val to_targetint : t -> Targetint.t
+  val to_targetint : t -> Targetint_32_64.t
   val to_tag : t -> tag
 
   val zero : t

--- a/middle_end/flambda/compilenv_deps/targetint_31_63.ml
+++ b/middle_end/flambda/compilenv_deps/targetint_31_63.ml
@@ -17,7 +17,7 @@
 [@@@ocaml.warning "+a-30-40-41-42"]
 
 let () =
-  match Targetint.num_bits with
+  match Targetint_32_64.num_bits with
   | Sixty_four -> ()
   | Thirty_two ->
     if Config.flambda then begin
@@ -106,9 +106,9 @@ module Imm = struct
 
     let to_float = Int64.to_float
 
-    let to_targetint = Targetint.of_int64
+    let to_targetint = Targetint_32_64.of_int64
 
-    let of_targetint = Targetint.to_int64
+    let of_targetint = Targetint_32_64.to_int64
 
     let max_array_length = Int64.sub (Int64.shift_left 1L 54) 1L
 
@@ -248,11 +248,11 @@ let set_to_targetint_set (set : Set.t) : Imm.Set.t =
     (fun t targetints -> Imm.Set.add t.value targetints)
     set Imm.Set.empty
 
-let set_to_targetint_set' (set : Set.t) : Targetint.Set.t =
+let set_to_targetint_set' (set : Set.t) : Targetint_32_64.Set.t =
   Set.fold
     (fun t targetints ->
-      Targetint.Set.add (Imm.to_targetint t.value) targetints)
-    set Targetint.Set.empty
+      Targetint_32_64.Set.add (Imm.to_targetint t.value) targetints)
+    set Targetint_32_64.Set.empty
 
 let all_bools = Set.of_list [bool_true; bool_false]
 

--- a/middle_end/flambda/compilenv_deps/targetint_31_63.mli
+++ b/middle_end/flambda/compilenv_deps/targetint_31_63.mli
@@ -104,13 +104,13 @@ module Imm : sig
   (** Convert the given ocaml target integer to a 64-bit integer (type [int64]). *)
   val to_int64 : t -> int64
 
-  (** Convert the given target native integer (type [Targetint.t]) to an ocaml
+  (** Convert the given target native integer (type [Targetint_32_64.t]) to an ocaml
       target integer, modulo the size of an ocaml target integer. *)
-  val of_targetint : Targetint.t -> t
+  val of_targetint : Targetint_32_64.t -> t
 
   (** Convert the given ocaml target integer (type [t]) to a target native
-      integer (type [Targetint.t]). *)
-  val to_targetint : t -> Targetint.t
+      integer (type [Targetint_32_64.t]). *)
+  val to_targetint : t -> Targetint_32_64.t
 
   (** Convert the given floating-point number to an ocaml target integer,
       discarding the fractional part (truncate towards 0). The result of the
@@ -159,12 +159,12 @@ module Imm : sig
       32-bit platform and [61] on a 64-bit platform. *)
   val shift_left : t -> int -> t
 
-  (** [Targetint.shift_right x y] shifts [x] to the right by [y] bits. This is
+  (** [Targetint_32_64.shift_right x y] shifts [x] to the right by [y] bits. This is
       an arithmetic shift: the sign bit of [x] is replicated and inserted in the
       vacated bits. The result is unspecified if [y < 0] or [y >= bitsize]. *)
   val shift_right : t -> int -> t
 
-  (** [Targetint.shift_right_logical x y] shifts [x] to the right by [y] bits.
+  (** [Targetint_32_64.shift_right_logical x y] shifts [x] to the right by [y] bits.
       This is a logical shift: zeroes are inserted in the vacated bits
       regardless of the sign of [x]. The result is unspecified if [y < 0] or
       [y >= bitsize]. *)
@@ -224,11 +224,11 @@ val is_non_negative : t -> bool
 (* CR mshinwell: bad names *)
 val to_targetint : t -> Imm.t
 
-val to_targetint' : t -> Targetint.t
+val to_targetint' : t -> Targetint_32_64.t
 
 val set_to_targetint_set : Set.t -> Imm.Set.t
 
-val set_to_targetint_set' : Set.t -> Targetint.Set.t
+val set_to_targetint_set' : Set.t -> Targetint_32_64.Set.t
 
 val neg : t -> t
 

--- a/middle_end/flambda/compilenv_deps/targetint_32_64.ml
+++ b/middle_end/flambda/compilenv_deps/targetint_32_64.ml
@@ -110,7 +110,7 @@ module Int32 = struct
     | 64 ->
         fun n ->
           if n < Int32.(to_int min_int) || n > Int32.(to_int max_int) then
-            Misc.fatal_errorf "Targetint.of_int_exn: 0x%x out of range" n
+            Misc.fatal_errorf "Targetint_32_64.of_int_exn: 0x%x out of range" n
           else
             Int32.of_int n
     | _ ->

--- a/middle_end/flambda/compilenv_deps/targetint_32_64.ml
+++ b/middle_end/flambda/compilenv_deps/targetint_32_64.ml
@@ -1,0 +1,234 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                        Nicolas Ojeda Bar, LexiFi                       *)
+(*                    Mark Shinwell, Jane Street Europe                   *)
+(*                                                                        *)
+(*   Copyright 2016 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*   Copyright 2017--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+type repr =
+  | Int32 of int32
+  | Int64 of int64
+
+type num_bits =
+  | Thirty_two
+  | Sixty_four
+
+module type S = sig
+  type t
+  type targetint = t
+
+  val num_bits : num_bits
+  val repr: t -> repr
+
+  include Identifiable.S with type t := t
+
+  val zero : t
+  val one : t
+  val minus_one : t
+
+  val neg : t -> t
+  val add : t -> t -> t
+  val sub : t -> t -> t
+  val mul : t -> t -> t
+  val div : t -> t -> t
+
+  val shift_left : t -> int -> t
+  val shift_right : t -> int -> t
+  val shift_right_logical : t -> int -> t
+
+  val min: t -> t -> t
+  val max: t -> t -> t
+
+  val get_least_significant_16_bits_then_byte_swap : t -> t
+
+  module Pair : sig
+    type nonrec t = t * t
+    include Identifiable.S with type t := t
+  end
+
+  val cross_product : Set.t -> Set.t -> Pair.Set.t
+
+  val max_int : t
+  val min_int : t
+
+  val rem : t -> t -> t
+  val succ : t -> t
+  val pred : t -> t
+  val abs : t -> t
+  val logand : t -> t -> t
+  val logor : t -> t -> t
+  val logxor : t -> t -> t
+  val lognot : t -> t
+
+  val swap_byte_endianness : t -> t
+
+  val of_int_exn : int -> t
+
+  val of_int : int -> t
+  val of_int32 : int32 -> t
+  val of_int64 : int64 -> t
+  val of_float : float -> t
+  val of_string : string -> t
+
+  val to_int : t -> int
+  val to_int32 : t -> int32
+  val to_int64 : t -> int64
+  val to_float : t -> float
+  val to_string : t -> string
+
+  val unsigned_div : t -> t -> t
+  val unsigned_rem : t -> t -> t
+  val unsigned_compare : t -> t -> int
+
+  module Targetint_set = Set
+end
+
+let size = Sys.word_size
+(* Later, this will be set by the configure script
+   in order to support cross-compilation. *)
+
+module Int32 = struct
+  include Int32
+
+  type targetint = t
+
+  let of_int_exn =
+    match Sys.word_size with (* size of [int] *)
+    | 32 ->
+        Int32.of_int
+    | 64 ->
+        fun n ->
+          if n < Int32.(to_int min_int) || n > Int32.(to_int max_int) then
+            Misc.fatal_errorf "Targetint.of_int_exn: 0x%x out of range" n
+          else
+            Int32.of_int n
+    | _ ->
+        assert false
+
+  let num_bits = Thirty_two
+  let of_int32 x = x
+  let to_int32 x = x
+  let of_int64 = Int64.to_int32
+  let to_int64 = Int64.of_int32
+  let repr x = Int32 x
+
+  include Identifiable.Make (struct
+    type nonrec t = t
+    let compare = Int32.compare
+    let equal = Int32.equal
+    let hash = Hashtbl.hash
+    let print ppf t = Format.fprintf ppf "%ld" t
+    let output chan t =
+      print (Format.formatter_of_out_channel chan) t
+  end)
+
+  let min t1 t2 =
+    if compare t1 t2 <= 0 then t1 else t2
+
+  let max t1 t2 =
+    if compare t1 t2 <= 0 then t2 else t1
+
+  module Targetint_set = Set
+
+  module Pair = struct
+    type nonrec t = t * t
+
+    module T_pair = Identifiable.Pair (T) (T)
+
+    include Identifiable.Make (T_pair)
+  end
+
+  let cross_product set1 set2 =
+    Set.fold (fun elt1 result ->
+        Set.fold (fun elt2 result ->
+            Pair.Set.add (elt1, elt2) result)
+          set2
+          result)
+      set1
+      Pair.Set.empty
+
+  let get_least_significant_16_bits_then_byte_swap t =
+    let least_significant_byte = Int32.logand t 0xffl in
+    let second_to_least_significant_byte =
+      shift_right_logical (Int32.logand t 0xff00l) 8
+    in
+    Int32.logor second_to_least_significant_byte
+      (shift_left least_significant_byte 8)
+
+  external swap_byte_endianness : t -> t = "%bswap_int32"
+end
+
+module Int64 = struct
+  include Int64
+
+  type targetint = t
+
+  let num_bits = Sixty_four
+  let of_int_exn = Int64.of_int
+  let of_int64 x = x
+  let to_int64 x = x
+  let repr x = Int64 x
+
+  let min t1 t2 =
+    if compare t1 t2 <= 0 then t1 else t2
+
+  let max t1 t2 =
+    if compare t1 t2 <= 0 then t2 else t1
+
+  include Identifiable.Make (struct
+    type nonrec t = t
+    let compare = Int64.compare
+    let equal t1 t2 = (compare t1 t2 = 0)
+    let hash = Hashtbl.hash
+    let print ppf t = Format.fprintf ppf "%Ld" t
+    let output chan t =
+      print (Format.formatter_of_out_channel chan) t
+  end)
+
+  module Targetint_set = Set
+
+  module Pair = struct
+    type nonrec t = t * t
+
+    module T_pair = Identifiable.Pair (T) (T)
+
+    include Identifiable.Make (T_pair)
+  end
+
+  let cross_product set1 set2 =
+    Set.fold (fun elt1 result ->
+        Set.fold (fun elt2 result ->
+            Pair.Set.add (elt1, elt2) result)
+          set2
+          result)
+      set1
+      Pair.Set.empty
+
+  let get_least_significant_16_bits_then_byte_swap t =
+    let least_significant_byte = Int64.logand t 0xffL in
+    let second_to_least_significant_byte =
+      Int64.shift_right_logical (Int64.logand t 0xff00L) 8
+    in
+    Int64.logor second_to_least_significant_byte
+      (Int64.shift_left least_significant_byte 8)
+
+  external swap_byte_endianness : t -> t = "%bswap_int64"
+end
+
+include (val
+          (match size with
+           | 32 -> (module Int32)
+           | 64 -> (module Int64)
+           | _ -> assert false
+          ) : S)

--- a/middle_end/flambda/compilenv_deps/targetint_32_64.mli
+++ b/middle_end/flambda/compilenv_deps/targetint_32_64.mli
@@ -1,0 +1,232 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                        Nicolas Ojeda Bar, LexiFi                       *)
+(*                    Mark Shinwell, Jane Street Europe                   *)
+(*                                                                        *)
+(*   Copyright 2016 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*   Copyright 2017--2019 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Target processor-native integers.
+
+   This module provides operations on the type of
+   signed 32-bit integers (on 32-bit target platforms) or
+   signed 64-bit integers (on 64-bit target platforms).
+   This integer type has exactly the same width as that of a
+   pointer type in the C compiler.  All arithmetic operations over
+   are taken modulo 2{^32} or 2{^64} depending
+   on the word size of the target architecture.
+
+  {b Warning:} this module is unstable and part of
+  {{!Compiler_libs}compiler-libs}.
+
+*)
+
+type t
+(** The type of target integers. *)
+
+type targetint = t
+
+val zero : t
+(** The target integer 0.*)
+
+val one : t
+(** The target integer 1.*)
+
+val minus_one : t
+(** The target integer -1.*)
+
+val neg : t -> t
+(** Unary negation. *)
+
+val add : t -> t -> t
+(** Addition. *)
+
+val sub : t -> t -> t
+(** Subtraction. *)
+
+val mul : t -> t -> t
+(** Multiplication. *)
+
+val div : t -> t -> t
+(** Integer division.  Raise [Division_by_zero] if the second
+   argument is zero.  This division rounds the real quotient of
+   its arguments towards zero, as specified for {!Stdlib.(/)}. *)
+
+val unsigned_div : t -> t -> t
+(** Same as {!div}, except that arguments and result are interpreted as {e
+    unsigned} integers. *)
+
+val rem : t -> t -> t
+(** Integer remainder.  If [y] is not zero, the result
+   of [Targetint.rem x y] satisfies the following properties:
+   [Targetint.zero <= Nativeint.rem x y < Targetint.abs y] and
+   [x = Targetint.add (Targetint.mul (Targetint.div x y) y)
+                      (Targetint.rem x y)].
+   If [y = 0], [Targetint.rem x y] raises [Division_by_zero]. *)
+
+val unsigned_rem : t -> t -> t
+(** Same as {!rem}, except that arguments and result are interpreted as {e
+    unsigned} integers. *)
+
+val succ : t -> t
+(** Successor.
+   [Targetint.succ x] is [Targetint.add x Targetint.one]. *)
+
+val pred : t -> t
+(** Predecessor.
+   [Targetint.pred x] is [Targetint.sub x Targetint.one]. *)
+
+val abs : t -> t
+(** Return the absolute value of its argument. *)
+
+val size : int
+(** The size in bits of a target native integer. *)
+
+type num_bits =
+  | Thirty_two
+  | Sixty_four (**)
+(** The possible numbers of bits of a target native integer. *)
+
+val num_bits : num_bits
+(* The number of bits of a target native integer. *)
+
+val max_int : t
+(** The greatest representable target integer,
+    either 2{^31} - 1 on a 32-bit platform,
+    or 2{^63} - 1 on a 64-bit platform. *)
+
+val min_int : t
+(** The smallest representable target integer,
+   either -2{^31} on a 32-bit platform,
+   or -2{^63} on a 64-bit platform. *)
+
+val logand : t -> t -> t
+(** Bitwise logical and. *)
+
+val logor : t -> t -> t
+(** Bitwise logical or. *)
+
+val logxor : t -> t -> t
+(** Bitwise logical exclusive or. *)
+
+val lognot : t -> t
+(** Bitwise logical negation. *)
+
+val shift_left : t -> int -> t
+(** [Targetint.shift_left x y] shifts [x] to the left by [y] bits.
+    The result is unspecified if [y < 0] or [y >= bitsize],
+    where [bitsize] is [32] on a 32-bit platform and
+    [64] on a 64-bit platform. *)
+
+val shift_right : t -> int -> t
+(** [Targetint.shift_right x y] shifts [x] to the right by [y] bits.
+    This is an arithmetic shift: the sign bit of [x] is replicated
+    and inserted in the vacated bits.
+    The result is unspecified if [y < 0] or [y >= bitsize]. *)
+
+val shift_right_logical : t -> int -> t
+(** [Targetint.shift_right_logical x y] shifts [x] to the right
+    by [y] bits.
+    This is a logical shift: zeroes are inserted in the vacated bits
+    regardless of the sign of [x].
+    The result is unspecified if [y < 0] or [y >= bitsize]. *)
+
+val of_int : int -> t
+(** Convert the given integer (type [int]) to a target integer
+    (type [t]), modulo the target word size. *)
+
+val of_int_exn : int -> t
+(** Convert the given integer (type [int]) to a target integer
+    (type [t]).  Raises a fatal error if the conversion is not exact. *)
+
+val to_int : t -> int
+(** Convert the given target integer (type [t]) to an
+    integer (type [int]).  The high-order bit is lost during
+    the conversion. *)
+
+val of_float : float -> t
+(** Convert the given floating-point number to a target integer,
+   discarding the fractional part (truncate towards 0).
+   The result of the conversion is undefined if, after truncation,
+   the number is outside the range
+   \[{!Targetint.min_int}, {!Targetint.max_int}\]. *)
+
+val to_float : t -> float
+(** Convert the given target integer to a floating-point number. *)
+
+val of_int32 : int32 -> t
+(** Convert the given 32-bit integer (type [int32])
+    to a target integer. *)
+
+val to_int32 : t -> int32
+(** Convert the given target integer to a
+    32-bit integer (type [int32]).  On 64-bit platforms,
+    the 64-bit native integer is taken modulo 2{^32},
+    i.e. the top 32 bits are lost.  On 32-bit platforms,
+    the conversion is exact. *)
+
+val of_int64 : int64 -> t
+(** Convert the given 64-bit integer (type [int64])
+    to a target integer, modulo the target word size. *)
+
+val to_int64 : t -> int64
+(** Convert the given target integer to a
+    64-bit integer (type [int64]). *)
+
+val of_string : string -> t
+(** Convert the given string to a target integer.
+    The string is read in decimal (by default) or in hexadecimal,
+    octal or binary if the string begins with [0x], [0o] or [0b]
+    respectively.
+    Raise [Failure "int_of_string"] if the given string is not
+    a valid representation of an integer, or if the integer represented
+    exceeds the range of integers representable in type [nativeint]. *)
+
+val to_string : t -> string
+(** Return the string representation of its argument, in decimal. *)
+
+val unsigned_compare: t -> t -> int
+(** Same as {!compare}, except that arguments are interpreted as {e unsigned}
+    integers. *)
+
+type repr =
+  | Int32 of int32
+  | Int64 of int64
+
+val repr : t -> repr
+(** The concrete representation of a native integer. *)
+
+val min : t -> t -> t
+(** Returns the smaller integer. *)
+
+val max : t -> t -> t
+(** Returns the larger integer. *)
+
+val get_least_significant_16_bits_then_byte_swap : t -> t
+(** Extract the least significant 16 bits from the given target integer,
+    exchange the order of the two bytes extracted, then form a new target
+    integer by zero-extending those two bytes. *)
+
+val swap_byte_endianness : t -> t
+
+include Identifiable.S with type t := t
+
+module Targetint_set = Set
+
+module Pair : sig
+  type nonrec t = t * t
+
+  include Identifiable.S with type t := t
+end
+
+val cross_product : Set.t -> Set.t -> Pair.Set.t

--- a/middle_end/flambda/compilenv_deps/targetint_32_64.mli
+++ b/middle_end/flambda/compilenv_deps/targetint_32_64.mli
@@ -68,11 +68,11 @@ val unsigned_div : t -> t -> t
 
 val rem : t -> t -> t
 (** Integer remainder.  If [y] is not zero, the result
-   of [Targetint.rem x y] satisfies the following properties:
-   [Targetint.zero <= Nativeint.rem x y < Targetint.abs y] and
-   [x = Targetint.add (Targetint.mul (Targetint.div x y) y)
-                      (Targetint.rem x y)].
-   If [y = 0], [Targetint.rem x y] raises [Division_by_zero]. *)
+   of [Targetint_32_64.rem x y] satisfies the following properties:
+   [Targetint_32_64.zero <= Nativeint.rem x y < Targetint_32_64.abs y] and
+   [x = Targetint_32_64.add (Targetint_32_64.mul (Targetint_32_64.div x y) y)
+                      (Targetint_32_64.rem x y)].
+   If [y = 0], [Targetint_32_64.rem x y] raises [Division_by_zero]. *)
 
 val unsigned_rem : t -> t -> t
 (** Same as {!rem}, except that arguments and result are interpreted as {e
@@ -80,11 +80,11 @@ val unsigned_rem : t -> t -> t
 
 val succ : t -> t
 (** Successor.
-   [Targetint.succ x] is [Targetint.add x Targetint.one]. *)
+   [Targetint_32_64.succ x] is [Targetint_32_64.add x Targetint_32_64.one]. *)
 
 val pred : t -> t
 (** Predecessor.
-   [Targetint.pred x] is [Targetint.sub x Targetint.one]. *)
+   [Targetint_32_64.pred x] is [Targetint_32_64.sub x Targetint_32_64.one]. *)
 
 val abs : t -> t
 (** Return the absolute value of its argument. *)
@@ -123,19 +123,19 @@ val lognot : t -> t
 (** Bitwise logical negation. *)
 
 val shift_left : t -> int -> t
-(** [Targetint.shift_left x y] shifts [x] to the left by [y] bits.
+(** [Targetint_32_64.shift_left x y] shifts [x] to the left by [y] bits.
     The result is unspecified if [y < 0] or [y >= bitsize],
     where [bitsize] is [32] on a 32-bit platform and
     [64] on a 64-bit platform. *)
 
 val shift_right : t -> int -> t
-(** [Targetint.shift_right x y] shifts [x] to the right by [y] bits.
+(** [Targetint_32_64.shift_right x y] shifts [x] to the right by [y] bits.
     This is an arithmetic shift: the sign bit of [x] is replicated
     and inserted in the vacated bits.
     The result is unspecified if [y < 0] or [y >= bitsize]. *)
 
 val shift_right_logical : t -> int -> t
-(** [Targetint.shift_right_logical x y] shifts [x] to the right
+(** [Targetint_32_64.shift_right_logical x y] shifts [x] to the right
     by [y] bits.
     This is a logical shift: zeroes are inserted in the vacated bits
     regardless of the sign of [x].
@@ -159,7 +159,7 @@ val of_float : float -> t
    discarding the fractional part (truncate towards 0).
    The result of the conversion is undefined if, after truncation,
    the number is outside the range
-   \[{!Targetint.min_int}, {!Targetint.max_int}\]. *)
+   \[{!Targetint_32_64.min_int}, {!Targetint_32_64.max_int}\]. *)
 
 val to_float : t -> float
 (** Convert the given target integer to a floating-point number. *)

--- a/middle_end/flambda/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion.ml
@@ -98,7 +98,7 @@ let rec declare_const acc (const : Lambda.structured_constant)
     register_const acc (Boxed_int64 (Const c)) "int64"
   | Const_base (Const_nativeint c) ->
     (* CR pchambart: this should be pushed further to lambda *)
-    let c = Targetint.of_int64 (Int64.of_nativeint c) in
+    let c = Targetint_32_64.of_int64 (Int64.of_nativeint c) in
     register_const acc (Boxed_nativeint (Const c)) "nativeint"
   | Const_immstring c ->
     register_const acc (Immutable_string c) "immstring"
@@ -220,7 +220,7 @@ let close_c_call acc ~let_bound_var (prim : Primitive.description)
          primitive on 64-bit systems.  (There is no easy way here of
          detecting just the specific ARM case in question.) *)
       when
-        begin match Targetint.num_bits with
+        begin match Targetint_32_64.num_bits with
         | Thirty_two -> false
         | Sixty_four -> true
         end

--- a/middle_end/flambda/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda/from_lambda/lambda_to_flambda_primitives.ml
@@ -77,7 +77,7 @@ let max_with_zero ~size_int x =
                     x, register_bitsize_minus_one))
   in
   let minus_one =
-    H.Simple (Simple.const (Reg_width_const.naked_nativeint (Targetint.of_int (-1))))
+    H.Simple (Simple.const (Reg_width_const.naked_nativeint (Targetint_32_64.of_int (-1))))
   in
   let sign_negation =
     H.Prim (Binary (Int_arith (Naked_nativeint, Xor),
@@ -757,7 +757,7 @@ let convert_lprim ~backend (prim : L.primitive) (args : Simple.t list)
         Binary (Phys_equal (K.naked_nativeint, Neq), unbox_bint Pnativeint arg2,
                 Simple
                   (Simple.const
-                     (Reg_width_const.naked_nativeint Targetint.zero)));
+                     (Reg_width_const.naked_nativeint Targetint_32_64.zero)));
       ];
       failure = Division_by_zero;
       dbg;
@@ -772,7 +772,7 @@ let convert_lprim ~backend (prim : L.primitive) (args : Simple.t list)
         Binary (Phys_equal (K.naked_nativeint, Neq), unbox_bint Pnativeint arg2,
                 Simple
                   (Simple.const
-                     (Reg_width_const.naked_nativeint Targetint.zero)));
+                     (Reg_width_const.naked_nativeint Targetint_32_64.zero)));
       ];
       failure = Division_by_zero;
       dbg;

--- a/middle_end/flambda/inlining/metrics/code_size.ml
+++ b/middle_end/flambda/inlining/metrics/code_size.ml
@@ -23,8 +23,8 @@ let equal a b = a = b
 let (+) (a : t) (b : t) : t = a + b
 let ( <= ) a b = a <= b
 
-let arch32 = Targetint.size = 32 (* are we compiling for a 32-bit arch *)
-let arch64 = Targetint.size = 64 (* are we compiling for a 64-bit arch *)
+let arch32 = Targetint_32_64.size = 32 (* are we compiling for a 32-bit arch *)
+let arch64 = Targetint_32_64.size = 64 (* are we compiling for a 64-bit arch *)
 
 (* Constants *)
 (* CR-soon mshinwell: Investigate revised size numbers. *)

--- a/middle_end/flambda/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda/parser/fexpr_to_flambda.ml
@@ -213,9 +213,9 @@ let find_var env v =
 let find_code_id env code_id =
   find_with ~descr:"code id" ~find:DM.find_opt env.code_ids code_id
 
-let targetint (i:Fexpr.targetint) : Targetint.t = Targetint.of_int64 i
+let targetint (i:Fexpr.targetint) : Targetint_32_64.t = Targetint_32_64.of_int64 i
 let immediate i =
-  i |> Targetint.of_string |> Targetint_31_63.Imm.of_targetint |> Targetint_31_63.int
+  i |> Targetint_32_64.of_string |> Targetint_31_63.Imm.of_targetint |> Targetint_31_63.int
 let float f = f |> Numbers.Float_by_bit_pattern.create
 
 let value_kind_with_subkind (k : Fexpr.kind_with_subkind)
@@ -311,7 +311,7 @@ let field_of_block env (v:Fexpr.field_of_block)
   | Symbol s ->
     Symbol (get_symbol env s)
   | Tagged_immediate i ->
-    let i = Targetint.of_string i in
+    let i = Targetint_32_64.of_string i in
     Tagged_immediate
       (Targetint_31_63.int (Targetint_31_63.Imm.of_targetint i))
   | Dynamically_computed var ->

--- a/middle_end/flambda/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda/parser/flambda_to_fexpr.ml
@@ -289,14 +289,14 @@ let name env n =
     ~symbol:(fun s : Fexpr.name -> Symbol (Env.find_symbol_exn env s))
 
 let float f = f |> Numbers.Float_by_bit_pattern.to_float
-let targetint i = i |> Targetint.to_int64
+let targetint i = i |> Targetint_32_64.to_int64
 
 let const c : Fexpr.const =
   match Reg_width_things.Const.descr c with
   | Naked_immediate imm ->
-    Naked_immediate (imm |> Targetint_31_63.to_targetint' |> Targetint.to_string)
+    Naked_immediate (imm |> Targetint_31_63.to_targetint' |> Targetint_32_64.to_string)
   | Tagged_immediate imm ->
-    Tagged_immediate (imm |> Targetint_31_63.to_targetint' |> Targetint.to_string)
+    Tagged_immediate (imm |> Targetint_31_63.to_targetint' |> Targetint_32_64.to_string)
   | Naked_float f ->
     Naked_float (f |> float)
   | Naked_int32 i ->
@@ -490,7 +490,7 @@ let field_of_block env (field : Flambda.Static_const.Field_of_block.t)
   | Symbol symbol ->
     Symbol (Env.find_symbol_exn env symbol)
   | Tagged_immediate imm ->
-    Tagged_immediate (imm |> Targetint_31_63.to_targetint' |> Targetint.to_string)
+    Tagged_immediate (imm |> Targetint_31_63.to_targetint' |> Targetint_32_64.to_string)
   | Dynamically_computed var ->
     Dynamically_computed (Env.find_var_exn env var)
 
@@ -898,7 +898,7 @@ and switch_expr env switch : Fexpr.expr =
   let scrutinee = simple env (Switch_expr.scrutinee switch) in
   let cases =
     List.map (fun (imm, app_cont) ->
-      let tag = imm |> Targetint_31_63.to_targetint' |> Targetint.to_int in
+      let tag = imm |> Targetint_31_63.to_targetint' |> Targetint_32_64.to_int in
       let app_cont = apply_cont env app_cont in
       tag, app_cont
     ) (Switch_expr.arms switch |> Targetint_31_63.Map.bindings)

--- a/middle_end/flambda/simplify/rebuilt_static_const.mli
+++ b/middle_end/flambda/simplify/rebuilt_static_const.mli
@@ -75,7 +75,7 @@ val create_boxed_int64
 
 val create_boxed_nativeint
    : Are_rebuilding_terms.t
-  -> Targetint.t Or_variable.t
+  -> Targetint_32_64.t Or_variable.t
   -> t
 
 val create_immutable_float_block

--- a/middle_end/flambda/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda/simplify/simplify_binary_primitive.ml
@@ -445,7 +445,7 @@ end = struct
     let rhs = Targetint_31_63.to_targetint rhs in
     match op with
     | Lsl | Lsr | Asr ->
-      (* Shifting either way by [Targetint.size] or above, or by a negative
+      (* Shifting either way by [Targetint_32_64.size] or above, or by a negative
          amount, is undefined.
          However note that we cannot produce [Invalid] unless the code is
          type unsafe, which it is not here.  (Otherwise a GADT match might
@@ -458,7 +458,7 @@ end = struct
         : Num.t binary_arith_outcome_for_one_side_only =
     (* In these cases we are giving a semantics for some cases where the
        right-hand side may be less than zero or greater than or equal to
-       [Targetint.size].  These cases have undefined semantics, as above;
+       [Targetint_32_64.size].  These cases have undefined semantics, as above;
        however, it seems fine to give them a semantics since there is benefit
        to doing so in this particular case.  (This is not the case for
        the situation in [op_lhs_unknown], above, where there would be no

--- a/middle_end/flambda/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda/simplify/simplify_unary_primitive.ml
@@ -321,9 +321,9 @@ module Make_simplify_int_conv (N : A.Number_kind) = struct
         | Naked_nativeint ->
           let is =
             Num.Set.fold (fun i is ->
-                Targetint.Set.add (Num.to_naked_nativeint i) is)
+                Targetint_32_64.Set.add (Num.to_naked_nativeint i) is)
               is
-              Targetint.Set.empty
+              Targetint_32_64.Set.empty
           in
           let ty = T.these_naked_nativeints is in
           let env_extension = TEE.one_equation result ty in

--- a/middle_end/flambda/simplify/typing_helpers/number_adjuncts.ml
+++ b/middle_end/flambda/simplify/typing_helpers/number_adjuncts.ml
@@ -52,7 +52,7 @@ module type Num_common = sig
   val to_naked_float : t -> Numbers.Float_by_bit_pattern.t
   val to_naked_int32 : t -> Numbers.Int32.t
   val to_naked_int64 : t -> Numbers.Int64.t
-  val to_naked_nativeint : t -> Targetint.t
+  val to_naked_nativeint : t -> Targetint_32_64.t
 end
 
 module type Number_kind_common = sig
@@ -276,7 +276,7 @@ module For_floats : Boxable_number_kind = struct
 
     (* CR mshinwell: We need to validate that the backend compiles
        the [Int_of_float] primitive in the same way as
-       [Targetint.of_float].  Ditto for [Float_of_int].  (For the record,
+       [Targetint_32_64.of_float].  Ditto for [Float_of_int].  (For the record,
        [Pervasives.int_of_float] and [Nativeint.of_float] on [nan] produce
        wildly different results). *)
     let to_immediate t =
@@ -285,7 +285,7 @@ module For_floats : Boxable_number_kind = struct
     let to_naked_float t = t
     let to_naked_int32 t = Int32.of_float (to_float t)
     let to_naked_int64 t = Int64.of_float (to_float t)
-    let to_naked_nativeint t = Targetint.of_float (to_float t)
+    let to_naked_nativeint t = Targetint_32_64.of_float (to_float t)
   end
 
   let kind : K.Standard_int_or_float.t = Naked_float
@@ -349,7 +349,7 @@ module For_int32s : Boxable_int_number_kind = struct
     let to_naked_float t = Float_by_bit_pattern.create (Int32.to_float t)
     let to_naked_int32 t = t
     let to_naked_int64 t = Int64.of_int32 t
-    let to_naked_nativeint t = Targetint.of_int32 t
+    let to_naked_nativeint t = Targetint_32_64.of_int32 t
   end
 
   let kind : K.Standard_int_or_float.t = Naked_int32
@@ -413,7 +413,7 @@ module For_int64s : Boxable_int_number_kind = struct
     let to_naked_float t = Float_by_bit_pattern.create (Int64.to_float t)
     let to_naked_int32 t = Int64.to_int32 t
     let to_naked_int64 t = t
-    let to_naked_nativeint t = Targetint.of_int64 t
+    let to_naked_nativeint t = Targetint_32_64.of_int64 t
   end
 
   let kind : K.Standard_int_or_float.t = Naked_int64
@@ -438,7 +438,7 @@ end
 
 module For_nativeints : Boxable_int_number_kind = struct
   module Num = struct
-    include Targetint
+    include Targetint_32_64
 
     let compare_unsigned _t1 _t2 =
       Misc.fatal_error "Not yet implemented (waiting on upstream stdlib change)"
@@ -467,9 +467,9 @@ module For_nativeints : Boxable_int_number_kind = struct
     let to_const t = Reg_width_const.naked_nativeint t
 
     let to_immediate t = Targetint_31_63.int (Targetint_31_63.Imm.of_targetint t)
-    let to_naked_float t = Float_by_bit_pattern.create (Targetint.to_float t)
-    let to_naked_int32 t = Targetint.to_int32 t
-    let to_naked_int64 t = Targetint.to_int64 t
+    let to_naked_float t = Float_by_bit_pattern.create (Targetint_32_64.to_float t)
+    let to_naked_int32 t = Targetint_32_64.to_int32 t
+    let to_naked_int64 t = Targetint_32_64.to_int64 t
     let to_naked_nativeint t = t
   end
 

--- a/middle_end/flambda/simplify/typing_helpers/number_adjuncts.mli
+++ b/middle_end/flambda/simplify/typing_helpers/number_adjuncts.mli
@@ -46,7 +46,7 @@ module type Num_common = sig
   val to_naked_float : t -> Numbers.Float_by_bit_pattern.t
   val to_naked_int32 : t -> Numbers.Int32.t
   val to_naked_int64 : t -> Numbers.Int64.t
-  val to_naked_nativeint : t -> Targetint.t
+  val to_naked_nativeint : t -> Targetint_32_64.t
 end
 
 module type Number_kind_common = sig

--- a/middle_end/flambda/terms/flambda.mli
+++ b/middle_end/flambda/terms/flambda.mli
@@ -517,7 +517,7 @@ end and Static_const : sig
     | Boxed_float of Numbers.Float_by_bit_pattern.t Or_variable.t
     | Boxed_int32 of Int32.t Or_variable.t
     | Boxed_int64 of Int64.t Or_variable.t
-    | Boxed_nativeint of Targetint.t Or_variable.t
+    | Boxed_nativeint of Targetint_32_64.t Or_variable.t
     | Immutable_float_block of Numbers.Float_by_bit_pattern.t Or_variable.t list
     | Immutable_float_array of Numbers.Float_by_bit_pattern.t Or_variable.t list
     | Mutable_string of { initial_value : string; }

--- a/middle_end/flambda/terms/named.rec.ml
+++ b/middle_end/flambda/terms/named.rec.ml
@@ -174,7 +174,7 @@ let dummy_value (kind : K.t) : t =
     | Naked_number Naked_int64 ->
       Simple.const (Reg_width_const.naked_int64 Int64.zero)
     | Naked_number Naked_nativeint ->
-      Simple.const (Reg_width_const.naked_nativeint Targetint.zero)
+      Simple.const (Reg_width_const.naked_nativeint Targetint_32_64.zero)
     | Fabricated -> Misc.fatal_error "[Fabricated] kind not expected here"
     | Rec_info -> Misc.fatal_error "[Rec_info] kind not expected here"
   in

--- a/middle_end/flambda/terms/static_const.rec.ml
+++ b/middle_end/flambda/terms/static_const.rec.ml
@@ -99,7 +99,7 @@ type t =
   | Boxed_float of Numbers.Float_by_bit_pattern.t Or_variable.t
   | Boxed_int32 of Int32.t Or_variable.t
   | Boxed_int64 of Int64.t Or_variable.t
-  | Boxed_nativeint of Targetint.t Or_variable.t
+  | Boxed_nativeint of Targetint_32_64.t Or_variable.t
   | Immutable_float_block of Numbers.Float_by_bit_pattern.t Or_variable.t list
   | Immutable_float_array of Numbers.Float_by_bit_pattern.t Or_variable.t list
   | Mutable_string of { initial_value : string; }
@@ -149,7 +149,7 @@ let print_with_cache ~cache ppf t =
     fprintf ppf "@[<hov 1>(@<0>%sBoxed_nativeint@<0>%s@ %a)@]"
       (Flambda_colours.static_part ())
       (Flambda_colours.normal ())
-      (Or_variable.print Targetint.print) or_var
+      (Or_variable.print Targetint_32_64.print) or_var
   | Immutable_float_block fields ->
     fprintf ppf "@[<hov 1>(@<0>%sImmutable_float_block@<0>%s@ @[[| %a |]@])@]"
       (Flambda_colours.static_part ())
@@ -202,7 +202,7 @@ include Identifiable.Make (struct
     | Boxed_int64 or_var1, Boxed_int64 or_var2 ->
       Or_variable.compare Numbers.Int64.compare or_var1 or_var2
     | Boxed_nativeint or_var1, Boxed_nativeint or_var2 ->
-      Or_variable.compare Targetint.compare or_var1 or_var2
+      Or_variable.compare Targetint_32_64.compare or_var1 or_var2
     | Immutable_float_block fields1, Immutable_float_array fields2 ->
       Misc.Stdlib.List.compare
         (Or_variable.compare Numbers.Float_by_bit_pattern.compare)

--- a/middle_end/flambda/terms/static_const.rec.mli
+++ b/middle_end/flambda/terms/static_const.rec.mli
@@ -43,7 +43,7 @@ type t =
   | Boxed_float of Numbers.Float_by_bit_pattern.t Or_variable.t
   | Boxed_int32 of Int32.t Or_variable.t
   | Boxed_int64 of Int64.t Or_variable.t
-  | Boxed_nativeint of Targetint.t Or_variable.t
+  | Boxed_nativeint of Targetint_32_64.t Or_variable.t
   | Immutable_float_block of Numbers.Float_by_bit_pattern.t Or_variable.t list
   | Immutable_float_array of Numbers.Float_by_bit_pattern.t Or_variable.t list
   | Mutable_string of { initial_value : string; }

--- a/middle_end/flambda/to_cmm/un_cps.ml
+++ b/middle_end/flambda/to_cmm/un_cps.ml
@@ -42,12 +42,12 @@ let typ_void = Cmm.typ_void
 let typ_float = Cmm.typ_float
 let typ_int64 = C.typ_int64
 
-(* CR gbury: {Targetint.to_int} should raise an error when converting
+(* CR gbury: {Targetint_32_64.to_int} should raise an error when converting
    an out-of-range integer. *)
 let int_of_targetint t =
-  let i = Targetint.to_int t in
-  let t' = Targetint.of_int i in
-  if not (Targetint.equal t t') then
+  let i = Targetint_32_64.to_int t in
+  let t' = Targetint_32_64.of_int i in
+  if not (Targetint_32_64.equal t t') then
     Misc.fatal_errorf "Cannot translate targetint to caml int";
   i
 
@@ -67,7 +67,7 @@ let name env name =
 
 (* Constants *)
 
-let tag_targetint t = Targetint.(add (shift_left t 1) one)
+let tag_targetint t = Targetint_32_64.(add (shift_left t 1) one)
 let targetint_of_imm i = Targetint_31_63.Imm.to_targetint i.Targetint_31_63.value
 
 let const _env cst =
@@ -1505,7 +1505,7 @@ let unit (middle_end_result : Flambda_middle_end.middle_end_result) =
     in
     let body, res = expr env R.empty (Flambda_unit.body unit) in
     let body =
-      let unit_value = C.targetint Targetint.one in
+      let unit_value = C.targetint Targetint_32_64.one in
       C.ccatch
         ~rec_flag:false ~body
         ~handlers:[C.handler return_cont return_cont_params unit_value]

--- a/middle_end/flambda/to_cmm/un_cps_helper.ml
+++ b/middle_end/flambda/to_cmm/un_cps_helper.ml
@@ -35,7 +35,7 @@ let exttype_of_kind k =
   | Naked_number Naked_int64 -> Cmm.XInt64
   | Naked_number Naked_int32 -> Cmm.XInt32
   | Naked_number (Naked_immediate | Naked_nativeint) ->
-    begin match Targetint.num_bits with
+    begin match Targetint_32_64.num_bits with
     | Thirty_two -> Cmm.XInt32
     | Sixty_four -> Cmm.XInt64
     end
@@ -91,7 +91,7 @@ let nativeint ?(dbg=Debuginfo.none) i =
   natint_const_untagged dbg i
 
 let targetint ?(dbg=Debuginfo.none) t =
-  match Targetint.repr t with
+  match Targetint_32_64.repr t with
   | Int32 i -> int32 ~dbg i
   | Int64 i -> int64 ~dbg i
 

--- a/middle_end/flambda/to_cmm/un_cps_helper.mli
+++ b/middle_end/flambda/to_cmm/un_cps_helper.mli
@@ -73,7 +73,7 @@ val int32 : ?dbg:Debuginfo.t -> int32 -> Cmm.expression
 val int64 : ?dbg:Debuginfo.t -> int64 -> Cmm.expression
 (** Create a constant int expression from an int64. *)
 
-val targetint : ?dbg:Debuginfo.t -> Targetint.t -> Cmm.expression
+val targetint : ?dbg:Debuginfo.t -> Targetint_32_64.t -> Cmm.expression
 (** Create a constant int expression from a targetint. *)
 
 val nativeint : ?dbg:Debuginfo.t -> Nativeint.t -> Cmm.expression

--- a/middle_end/flambda/to_cmm/un_cps_static.ml
+++ b/middle_end/flambda/to_cmm/un_cps_static.ml
@@ -34,12 +34,12 @@ module R = Un_cps_result
 let symbol s =
   Linkage_name.to_string (Symbol.linkage_name s)
 
-let tag_targetint t = Targetint.(add (shift_left t 1) one)
+let tag_targetint t = Targetint_32_64.(add (shift_left t 1) one)
 
 let targetint_of_imm i = Targetint_31_63.Imm.to_targetint i.Targetint_31_63.value
 
 let nativeint_of_targetint t =
-  match Targetint.repr t with
+  match Targetint_32_64.repr t with
   | Int32 i -> Nativeint.of_int32 i
   | Int64 i -> Int64.to_nativeint i
 
@@ -339,7 +339,7 @@ let static_const0 env r ~updates ~params_and_body
       in
       env, r, updates
   | Block_like s, Boxed_nativeint v ->
-      let default = Targetint.zero in
+      let default = Targetint_32_64.zero in
       let transl = nativeint_of_targetint in
       let r, updates =
         static_boxed_number

--- a/middle_end/flambda/types/flambda_type.mli
+++ b/middle_end/flambda/types/flambda_type.mli
@@ -334,13 +334,13 @@ val this_tagged_immediate : Targetint_31_63.t -> t
 val this_boxed_float : Numbers.Float_by_bit_pattern.t -> t
 val this_boxed_int32 : Int32.t -> t
 val this_boxed_int64 : Int64.t -> t
-val this_boxed_nativeint : Targetint.t -> t
+val this_boxed_nativeint : Targetint_32_64.t -> t
 
 val these_tagged_immediates : Targetint_31_63.Set.t -> t
 val these_boxed_floats : Numbers.Float_by_bit_pattern.Set.t -> t
 val these_boxed_int32s : Int32.Set.t -> t
 val these_boxed_int64s : Int64.Set.t -> t
-val these_boxed_nativeints : Targetint.Set.t -> t
+val these_boxed_nativeints : Targetint_32_64.Set.t -> t
 
 (** Building of types representing untagged / unboxed values from
     specified constants. *)
@@ -348,7 +348,7 @@ val this_naked_immediate : Targetint_31_63.t -> t
 val this_naked_float : Numbers.Float_by_bit_pattern.t -> t
 val this_naked_int32 : Int32.t -> t
 val this_naked_int64 : Int64.t -> t
-val this_naked_nativeint : Targetint.t -> t
+val this_naked_nativeint : Targetint_32_64.t -> t
 
 val this_rec_info : Rec_info_expr.t -> t
 
@@ -356,7 +356,7 @@ val these_naked_immediates : Targetint_31_63.Set.t -> t
 val these_naked_floats : Numbers.Float_by_bit_pattern.Set.t -> t
 val these_naked_int32s : Int32.Set.t -> t
 val these_naked_int64s : Int64.Set.t -> t
-val these_naked_nativeints : Targetint.Set.t -> t
+val these_naked_nativeints : Targetint_32_64.Set.t -> t
 
 val boxed_float_alias_to : naked_float:Variable.t -> t
 val boxed_int32_alias_to : naked_int32:Variable.t -> t
@@ -517,7 +517,7 @@ val prove_naked_int32s : Typing_env.t -> t -> Numbers.Int32.Set.t proof
 
 val prove_naked_int64s : Typing_env.t -> t -> Numbers.Int64.Set.t proof
 
-val prove_naked_nativeints : Typing_env.t -> t -> Targetint.Set.t proof
+val prove_naked_nativeints : Typing_env.t -> t -> Targetint_32_64.Set.t proof
 
 type variant_like_proof = private {
   const_ctors : Targetint_31_63.Set.t Or_unknown.t;
@@ -569,7 +569,7 @@ val prove_is_a_boxed_nativeint
 val prove_boxed_floats : Typing_env.t -> t -> Float.Set.t proof
 val prove_boxed_int32s : Typing_env.t -> t -> Numbers.Int32.Set.t proof
 val prove_boxed_int64s : Typing_env.t -> t -> Numbers.Int64.Set.t proof
-val prove_boxed_nativeints : Typing_env.t -> t -> Targetint.Set.t proof
+val prove_boxed_nativeints : Typing_env.t -> t -> Targetint_32_64.Set.t proof
 
 val prove_tags_and_sizes
    : Typing_env.t
@@ -686,7 +686,7 @@ type to_lift = (* private *) (* CR mshinwell: resurrect *)
   | Boxed_float of Float.t
   | Boxed_int32 of Int32.t
   | Boxed_int64 of Int64.t
-  | Boxed_nativeint of Targetint.t
+  | Boxed_nativeint of Targetint_32_64.t
 
 type reification_result = private
   | Lift of to_lift  (* CR mshinwell: rename? *)

--- a/middle_end/flambda/types/kinds/flambda_kind.ml
+++ b/middle_end/flambda/types/kinds/flambda_kind.ml
@@ -29,7 +29,7 @@ type naked_immediate = empty_naked_immediate * Targetint_31_63.Set.t
 type naked_float = empty_naked_float * Numbers.Float_by_bit_pattern.Set.t
 type naked_int32 = empty_naked_int32 * Numbers.Int32.Set.t
 type naked_int64 = empty_naked_int64 * Numbers.Int64.Set.t
-type naked_nativeint = empty_naked_nativeint * Targetint.Set.t
+type naked_nativeint = empty_naked_nativeint * Targetint_32_64.Set.t
 
 module Naked_number_kind = struct
   type t =

--- a/middle_end/flambda/types/kinds/flambda_kind.mli
+++ b/middle_end/flambda/types/kinds/flambda_kind.mli
@@ -31,7 +31,7 @@ type naked_immediate = empty_naked_immediate * Targetint_31_63.Set.t
 type naked_float = empty_naked_float * Numbers.Float_by_bit_pattern.Set.t
 type naked_int32 = empty_naked_int32 * Numbers.Int32.Set.t
 type naked_int64 = empty_naked_int64 * Numbers.Int64.Set.t
-type naked_nativeint = empty_naked_nativeint * Targetint.Set.t
+type naked_nativeint = empty_naked_nativeint * Targetint_32_64.Set.t
 type fabricated = private Fabricated
 type rec_info = private Rec_info
 

--- a/middle_end/flambda/types/template/flambda_type.templ.ml
+++ b/middle_end/flambda/types/template/flambda_type.templ.ml
@@ -279,11 +279,11 @@ let prove_naked_nativeints env t : _ proof =
     Misc.fatal_errorf "Kind error: expected [Naked_nativeint]:@ %a" print t
   in
   match expand_head t env with
-  | Const (Naked_nativeint i) -> Proved (Targetint.Set.singleton i)
+  | Const (Naked_nativeint i) -> Proved (Targetint_32_64.Set.singleton i)
   | Const (Naked_immediate _ | Tagged_immediate _ | Naked_float _
     | Naked_int32 _ | Naked_int64 _) -> wrong_kind ()
   | Naked_nativeint (Ok is) ->
-    if Targetint.Set.is_empty is then Invalid
+    if Targetint_32_64.Set.is_empty is then Invalid
     else Proved is
   | Naked_nativeint Unknown -> Unknown
   | Naked_nativeint Bottom -> Invalid
@@ -967,7 +967,7 @@ type to_lift =
   | Boxed_float of Float.t
   | Boxed_int32 of Int32.t
   | Boxed_int64 of Int64.t
-  | Boxed_nativeint of Targetint.t
+  | Boxed_nativeint of Targetint_32_64.t
 
 type reification_result =
   | Lift of to_lift
@@ -1248,7 +1248,7 @@ let reify ?allowed_if_free_vars_defined_in ?additional_free_var_criterion
       | Some n -> Simple (Simple.const (Reg_width_const.naked_int64 n))
       end
     | Naked_nativeint (Ok ns) ->
-      begin match Targetint.Set.get_singleton ns with
+      begin match Targetint_32_64.Set.get_singleton ns with
       | None -> try_canonical_simple ()
       | Some n -> Simple (Simple.const (Reg_width_const.naked_nativeint n))
       end
@@ -1284,7 +1284,7 @@ let reify ?allowed_if_free_vars_defined_in ?additional_free_var_criterion
       | Unknown -> try_canonical_simple ()
       | Invalid -> Invalid
       | Proved ns ->
-        match Targetint.Set.get_singleton ns with
+        match Targetint_32_64.Set.get_singleton ns with
         | None -> try_canonical_simple ()
         | Some n -> Lift (Boxed_nativeint n)
       end

--- a/middle_end/flambda/types/type_grammar.rec.ml
+++ b/middle_end/flambda/types/type_grammar.rec.ml
@@ -409,10 +409,10 @@ let these_naked_int64s0 ~no_alias is =
     else Naked_int64 (T_N64.create_no_alias (Ok is))
 
 let these_naked_nativeints0 ~no_alias is =
-  match Targetint.Set.get_singleton is with
+  match Targetint_32_64.Set.get_singleton is with
   | Some i when not no_alias -> this_naked_nativeint i
   | _ ->
-    if Targetint.Set.is_empty is then bottom K.naked_nativeint
+    if Targetint_32_64.Set.is_empty is then bottom K.naked_nativeint
     else Naked_nativeint (T_NN.create_no_alias (Ok is))
 
 let this_naked_immediate_without_alias i =
@@ -428,7 +428,7 @@ let this_naked_int64_without_alias i =
   these_naked_int64s0 ~no_alias:true (Int64.Set.singleton i)
 
 let this_naked_nativeint_without_alias i =
-  these_naked_nativeints0 ~no_alias:true (Targetint.Set.singleton i)
+  these_naked_nativeints0 ~no_alias:true (Targetint_32_64.Set.singleton i)
 
 let these_naked_immediates is = these_naked_immediates0 ~no_alias:false is
 let these_naked_floats fs = these_naked_floats0 ~no_alias:false fs

--- a/middle_end/flambda/types/type_grammar.rec.mli
+++ b/middle_end/flambda/types/type_grammar.rec.mli
@@ -77,14 +77,14 @@ val this_tagged_immediate : Targetint_31_63.t -> t
 val this_boxed_float : Numbers.Float_by_bit_pattern.t -> t
 val this_boxed_int32 : Int32.t -> t
 val this_boxed_int64 : Int64.t -> t
-val this_boxed_nativeint : Targetint.t -> t
+val this_boxed_nativeint : Targetint_32_64.t -> t
 
 val these_tagged_immediates : Targetint_31_63.Set.t -> t
 val these_naked_immediates : Targetint_31_63.Set.t -> t
 val these_boxed_floats : Numbers.Float_by_bit_pattern.Set.t -> t
 val these_boxed_int32s : Int32.Set.t -> t
 val these_boxed_int64s : Int64.Set.t -> t
-val these_boxed_nativeints : Targetint.Set.t -> t
+val these_boxed_nativeints : Targetint_32_64.Set.t -> t
 
 val this_rec_info : Rec_info_expr.t -> t
 
@@ -92,19 +92,19 @@ val this_naked_immediate : Targetint_31_63.t -> t
 val this_naked_float : Numbers.Float_by_bit_pattern.t -> t
 val this_naked_int32 : Int32.t -> t
 val this_naked_int64 : Int64.t -> t
-val this_naked_nativeint : Targetint.t -> t
+val this_naked_nativeint : Targetint_32_64.t -> t
 
 val this_tagged_immediate_without_alias : Targetint_31_63.t -> t
 val this_naked_immediate_without_alias : Targetint_31_63.t -> t
 val this_naked_float_without_alias : Numbers.Float_by_bit_pattern.t -> t
 val this_naked_int32_without_alias : Int32.t -> t
 val this_naked_int64_without_alias : Int64.t -> t
-val this_naked_nativeint_without_alias : Targetint.t -> t
+val this_naked_nativeint_without_alias : Targetint_32_64.t -> t
 
 val these_naked_floats : Numbers.Float_by_bit_pattern.Set.t -> t
 val these_naked_int32s : Int32.Set.t -> t
 val these_naked_int64s : Int64.Set.t -> t
-val these_naked_nativeints : Targetint.Set.t -> t
+val these_naked_nativeints : Targetint_32_64.Set.t -> t
 
 val boxed_float_alias_to : naked_float:Variable.t -> t
 val boxed_int32_alias_to : naked_int32:Variable.t -> t

--- a/middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.ml
+++ b/middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.ml
@@ -18,10 +18,10 @@
 
 module TEE = Typing_env_extension
 
-type t = Targetint.Set.t
+type t = Targetint_32_64.Set.t
 
 let print ppf t =
-  Format.fprintf ppf "@[(Naked_nativeints@ (%a))@]" Targetint.Set.print t
+  Format.fprintf ppf "@[(Naked_nativeints@ (%a))@]" Targetint_32_64.Set.print t
 
 let print_with_cache ~cache:_ ppf t = print ppf t
 
@@ -38,9 +38,9 @@ let apply_coercion t coercion : _ Or_bottom.t =
 let eviscerate _ : _ Or_unknown.t = Unknown
 
 let meet _env t1 t2 : _ Or_bottom.t =
-  let t = Targetint.Set.inter t1 t2 in
-  if Targetint.Set.is_empty t then Bottom
+  let t = Targetint_32_64.Set.inter t1 t2 in
+  if Targetint_32_64.Set.is_empty t then Bottom
   else Ok (t, TEE.empty ())
 
 let join _env t1 t2 : _ Or_unknown.t =
-  Known (Targetint.Set.union t1 t2)
+  Known (Targetint_32_64.Set.union t1 t2)

--- a/middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.mli
+++ b/middle_end/flambda/types/type_of_kind/type_of_kind_naked_nativeint0.rec.mli
@@ -16,7 +16,7 @@
 
 [@@@ocaml.warning "+a-30-40-41-42"]
 
-type t = Targetint.Set.t
+type t = Targetint_32_64.Set.t
 
 include Type_head_intf.S
   with type t := t

--- a/middle_end/flambda/unboxing/unboxers.ml
+++ b/middle_end/flambda/unboxing/unboxers.ml
@@ -122,7 +122,7 @@ module Nativeint = struct
 
   let unboxer = {
     var_name = "unboxed_nativeint";
-    invalid_const = Const.naked_nativeint Targetint.zero;
+    invalid_const = Const.naked_nativeint Targetint_32_64.zero;
     unboxing_prim;
     prove_simple = T.prove_boxed_nativeint_containing_simple;
   }


### PR DESCRIPTION
This makes an Flambda-local copy of `Targetint`, with our various additions, called `Targetint_32_64` (matching up with the recently-added `Targetint_31_63`).  This will mean that the version in `utils/` can be reverted to match upstream (after a couple more PRs).  There are no actual code changes here.