### PR TITLE
Introduce Container_types, superseding Identifiable

### DIFF
--- a/.depend
+++ b/.depend
@@ -3858,19 +3858,26 @@ middle_end/flambda/compilenv_deps/coercion.cmi : \
 middle_end/flambda/compilenv_deps/compilation_unit.cmo : \
     utils/misc.cmi \
     middle_end/flambda/compilenv_deps/linkage_name.cmi \
-    utils/identifiable.cmi \
     typing/ident.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi
 middle_end/flambda/compilenv_deps/compilation_unit.cmx : \
     utils/misc.cmx \
     middle_end/flambda/compilenv_deps/linkage_name.cmx \
-    utils/identifiable.cmx \
     typing/ident.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi
 middle_end/flambda/compilenv_deps/compilation_unit.cmi : \
     middle_end/flambda/compilenv_deps/linkage_name.cmi \
-    utils/identifiable.cmi \
-    typing/ident.cmi
+    typing/ident.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi
+middle_end/flambda/compilenv_deps/container_types.cmo : \
+    utils/misc.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi
+middle_end/flambda/compilenv_deps/container_types.cmx : \
+    utils/misc.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmi
+middle_end/flambda/compilenv_deps/container_types.cmi :
 middle_end/flambda/compilenv_deps/flambda_colours.cmo : \
     utils/misc.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi
@@ -3886,13 +3893,13 @@ middle_end/flambda/compilenv_deps/flambda_features.cmx : \
     middle_end/flambda/compilenv_deps/flambda_features.cmi
 middle_end/flambda/compilenv_deps/flambda_features.cmi :
 middle_end/flambda/compilenv_deps/linkage_name.cmo : \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/compilenv_deps/linkage_name.cmi
 middle_end/flambda/compilenv_deps/linkage_name.cmx : \
-    utils/identifiable.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/compilenv_deps/linkage_name.cmi
 middle_end/flambda/compilenv_deps/linkage_name.cmi : \
-    utils/identifiable.cmi
+    middle_end/flambda/compilenv_deps/container_types.cmi
 middle_end/flambda/compilenv_deps/lmap.cmo : \
     utils/misc.cmi \
     middle_end/flambda/compilenv_deps/lmap.cmi
@@ -3902,14 +3909,14 @@ middle_end/flambda/compilenv_deps/lmap.cmx : \
 middle_end/flambda/compilenv_deps/lmap.cmi :
 middle_end/flambda/compilenv_deps/numeric_types.cmo : \
     utils/misc.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/compilenv_deps/numeric_types.cmi
 middle_end/flambda/compilenv_deps/numeric_types.cmx : \
     utils/misc.cmx \
-    utils/identifiable.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/compilenv_deps/numeric_types.cmi
 middle_end/flambda/compilenv_deps/numeric_types.cmi : \
-    utils/identifiable.cmi
+    middle_end/flambda/compilenv_deps/container_types.cmi
 middle_end/flambda/compilenv_deps/one_bit_fewer.cmo : \
     middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/one_bit_fewer.cmi
@@ -3922,17 +3929,17 @@ middle_end/flambda/compilenv_deps/patricia_tree.cmo : \
     middle_end/flambda/compilenv_deps/numeric_types.cmi \
     utils/misc.cmi \
     utils/int_replace_polymorphic_compare.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/compilenv_deps/patricia_tree.cmi
 middle_end/flambda/compilenv_deps/patricia_tree.cmx : \
     middle_end/flambda/compilenv_deps/numeric_types.cmx \
     utils/misc.cmx \
     utils/int_replace_polymorphic_compare.cmx \
-    utils/identifiable.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/compilenv_deps/patricia_tree.cmi
 middle_end/flambda/compilenv_deps/patricia_tree.cmi : \
     middle_end/flambda/compilenv_deps/numeric_types.cmi \
-    utils/identifiable.cmi
+    middle_end/flambda/compilenv_deps/container_types.cmi
 middle_end/flambda/compilenv_deps/printing_cache.cmo : \
     middle_end/flambda/compilenv_deps/printing_cache.cmi
 middle_end/flambda/compilenv_deps/printing_cache.cmx : \
@@ -3940,16 +3947,16 @@ middle_end/flambda/compilenv_deps/printing_cache.cmx : \
 middle_end/flambda/compilenv_deps/printing_cache.cmi :
 middle_end/flambda/compilenv_deps/rec_info.cmo : \
     utils/misc.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/compilenv_deps/rec_info.cmi
 middle_end/flambda/compilenv_deps/rec_info.cmx : \
     utils/misc.cmx \
-    utils/identifiable.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/compilenv_deps/rec_info.cmi
 middle_end/flambda/compilenv_deps/rec_info.cmi : \
-    utils/identifiable.cmi
+    middle_end/flambda/compilenv_deps/container_types.cmi
 middle_end/flambda/compilenv_deps/reg_width_things.cmo : \
     middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
@@ -3959,8 +3966,8 @@ middle_end/flambda/compilenv_deps/reg_width_things.cmo : \
     utils/misc.cmi \
     middle_end/flambda/compilenv_deps/linkage_name.cmi \
     utils/int_replace_polymorphic_compare.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/compilenv_deps/coercion.cmi \
     middle_end/flambda/compilenv_deps/reg_width_things.cmi
@@ -3973,8 +3980,8 @@ middle_end/flambda/compilenv_deps/reg_width_things.cmx : \
     utils/misc.cmx \
     middle_end/flambda/compilenv_deps/linkage_name.cmx \
     utils/int_replace_polymorphic_compare.cmx \
-    utils/identifiable.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
     middle_end/flambda/compilenv_deps/coercion.cmx \
     middle_end/flambda/compilenv_deps/reg_width_things.cmi
@@ -3984,21 +3991,21 @@ middle_end/flambda/compilenv_deps/reg_width_things.cmi : \
     middle_end/flambda/compilenv_deps/table_by_int_id.cmi \
     middle_end/flambda/compilenv_deps/numeric_types.cmi \
     middle_end/flambda/compilenv_deps/linkage_name.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/compilenv_deps/coercion.cmi
 middle_end/flambda/compilenv_deps/strongly_connected_components_flambda2.cmo : \
     utils/numbers.cmi \
     utils/misc.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/compilenv_deps/strongly_connected_components_flambda2.cmi
 middle_end/flambda/compilenv_deps/strongly_connected_components_flambda2.cmx : \
     utils/numbers.cmx \
     utils/misc.cmx \
-    utils/identifiable.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/compilenv_deps/strongly_connected_components_flambda2.cmi
 middle_end/flambda/compilenv_deps/strongly_connected_components_flambda2.cmi : \
-    utils/identifiable.cmi
+    middle_end/flambda/compilenv_deps/container_types.cmi
 middle_end/flambda/compilenv_deps/symbol.cmo : \
     middle_end/flambda/compilenv_deps/reg_width_things.cmi \
     utils/misc.cmi \
@@ -4028,25 +4035,25 @@ middle_end/flambda/compilenv_deps/tag.cmo : \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     middle_end/flambda/compilenv_deps/numeric_types.cmi \
     utils/misc.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/compilenv_deps/tag.cmi
 middle_end/flambda/compilenv_deps/tag.cmx : \
     middle_end/flambda/compilenv_deps/targetint_32_64.cmx \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmx \
     middle_end/flambda/compilenv_deps/numeric_types.cmx \
     utils/misc.cmx \
-    utils/identifiable.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/compilenv_deps/tag.cmi
 middle_end/flambda/compilenv_deps/tag.cmi : \
     middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
-    utils/identifiable.cmi
+    middle_end/flambda/compilenv_deps/container_types.cmi
 middle_end/flambda/compilenv_deps/targetint_31_63.cmo : \
     middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/one_bit_fewer.cmi \
     middle_end/flambda/compilenv_deps/numeric_types.cmi \
     utils/misc.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     utils/config.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi
 middle_end/flambda/compilenv_deps/targetint_31_63.cmx : \
@@ -4054,22 +4061,22 @@ middle_end/flambda/compilenv_deps/targetint_31_63.cmx : \
     middle_end/flambda/compilenv_deps/one_bit_fewer.cmx \
     middle_end/flambda/compilenv_deps/numeric_types.cmx \
     utils/misc.cmx \
-    utils/identifiable.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     utils/config.cmx \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi
 middle_end/flambda/compilenv_deps/targetint_31_63.cmi : \
     middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
-    utils/identifiable.cmi
+    middle_end/flambda/compilenv_deps/container_types.cmi
 middle_end/flambda/compilenv_deps/targetint_32_64.cmo : \
     utils/misc.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/compilenv_deps/targetint_32_64.cmi
 middle_end/flambda/compilenv_deps/targetint_32_64.cmx : \
     utils/misc.cmx \
-    utils/identifiable.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/compilenv_deps/targetint_32_64.cmi
 middle_end/flambda/compilenv_deps/targetint_32_64.cmi : \
-    utils/identifiable.cmi
+    middle_end/flambda/compilenv_deps/container_types.cmi
 middle_end/flambda/compilenv_deps/variable.cmo : \
     middle_end/flambda/compilenv_deps/reg_width_things.cmi \
     utils/misc.cmi \
@@ -4138,25 +4145,25 @@ middle_end/flambda/basic/apply_cont_rewrite_id.cmx : \
     middle_end/flambda/compilenv_deps/numeric_types.cmx \
     middle_end/flambda/basic/apply_cont_rewrite_id.cmi
 middle_end/flambda/basic/apply_cont_rewrite_id.cmi : \
-    utils/identifiable.cmi
+    middle_end/flambda/compilenv_deps/container_types.cmi
 middle_end/flambda/basic/closure_id.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/compilenv_deps/lmap.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/basic/closure_id.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
     middle_end/flambda/compilenv_deps/lmap.cmx \
-    utils/identifiable.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
     middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/basic/closure_id.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/compilenv_deps/lmap.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi
 middle_end/flambda/basic/closure_origin.cmo : \
     middle_end/flambda/basic/closure_id.cmi \
@@ -4165,7 +4172,7 @@ middle_end/flambda/basic/closure_origin.cmx : \
     middle_end/flambda/basic/closure_id.cmx \
     middle_end/flambda/basic/closure_origin.cmi
 middle_end/flambda/basic/closure_origin.cmi : \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/basic/code_id.cmo : \
@@ -4175,8 +4182,8 @@ middle_end/flambda/basic/code_id.cmo : \
     middle_end/flambda/compilenv_deps/numeric_types.cmi \
     middle_end/flambda/compilenv_deps/lmap.cmi \
     middle_end/flambda/compilenv_deps/linkage_name.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/basic/code_id.cmi
 middle_end/flambda/basic/code_id.cmx : \
@@ -4186,30 +4193,30 @@ middle_end/flambda/basic/code_id.cmx : \
     middle_end/flambda/compilenv_deps/numeric_types.cmx \
     middle_end/flambda/compilenv_deps/lmap.cmx \
     middle_end/flambda/compilenv_deps/linkage_name.cmx \
-    utils/identifiable.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
     middle_end/flambda/basic/code_id.cmi
 middle_end/flambda/basic/code_id.cmi : \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/compilenv_deps/lmap.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi
 middle_end/flambda/basic/code_id_or_symbol.cmo : \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     utils/misc.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/basic/code_id_or_symbol.cmi
 middle_end/flambda/basic/code_id_or_symbol.cmx : \
     middle_end/flambda/compilenv_deps/symbol.cmx \
     utils/misc.cmx \
-    utils/identifiable.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/basic/code_id_or_symbol.cmi
 middle_end/flambda/basic/code_id_or_symbol.cmi : \
     middle_end/flambda/compilenv_deps/symbol.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/basic/code_id.cmi
 middle_end/flambda/basic/coeffects.cmo : \
@@ -4222,8 +4229,8 @@ middle_end/flambda/basic/continuation.cmo : \
     middle_end/flambda/compilenv_deps/table_by_int_id.cmi \
     middle_end/flambda/compilenv_deps/patricia_tree.cmi \
     middle_end/flambda/compilenv_deps/numeric_types.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/basic/continuation.cmi
 middle_end/flambda/basic/continuation.cmx : \
@@ -4231,15 +4238,15 @@ middle_end/flambda/basic/continuation.cmx : \
     middle_end/flambda/compilenv_deps/table_by_int_id.cmx \
     middle_end/flambda/compilenv_deps/patricia_tree.cmx \
     middle_end/flambda/compilenv_deps/numeric_types.cmx \
-    utils/identifiable.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
     middle_end/flambda/basic/continuation.cmi
 middle_end/flambda/basic/continuation.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/compilenv_deps/table_by_int_id.cmi \
     middle_end/flambda/compilenv_deps/printing_cache.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi
 middle_end/flambda/basic/continuation_extra_params_and_args.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
@@ -4288,10 +4295,10 @@ middle_end/flambda/basic/exn_continuation.cmo : \
     middle_end/flambda/naming/name_occurrences.cmi \
     utils/misc.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/basic/continuation.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/basic/exn_continuation.cmi
 middle_end/flambda/basic/exn_continuation.cmx : \
     middle_end/flambda/basic/simple.cmx \
@@ -4299,31 +4306,31 @@ middle_end/flambda/basic/exn_continuation.cmx : \
     middle_end/flambda/naming/name_occurrences.cmx \
     utils/misc.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
-    utils/identifiable.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/basic/continuation.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/basic/exn_continuation.cmi
 middle_end/flambda/basic/exn_continuation.cmi : \
     middle_end/flambda/basic/simple.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/types/kinds/flambda_arity.cmi \
     middle_end/flambda/basic/expr_std.cmo \
     middle_end/flambda/basic/continuation.cmi \
-    middle_end/flambda/cmx/contains_ids.cmo
+    middle_end/flambda/cmx/contains_ids.cmo \
+    middle_end/flambda/compilenv_deps/container_types.cmi
 middle_end/flambda/basic/export_id.cmo : \
-    utils/identifiable.cmi \
     middle_end/flambda/basic/id_types.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/basic/export_id.cmi
 middle_end/flambda/basic/export_id.cmx : \
-    utils/identifiable.cmx \
     middle_end/flambda/basic/id_types.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
     middle_end/flambda/basic/export_id.cmi
 middle_end/flambda/basic/export_id.cmi : \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi
 middle_end/flambda/basic/expr_std.cmo : \
     middle_end/flambda/compilenv_deps/printing_cache.cmi \
@@ -4341,14 +4348,14 @@ middle_end/flambda/basic/function_decl_intf.cmx : \
     middle_end/flambda/basic/code_id.cmx
 middle_end/flambda/basic/id_types.cmo : \
     utils/int_replace_polymorphic_compare.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/basic/id_types.cmi
 middle_end/flambda/basic/id_types.cmx : \
     utils/int_replace_polymorphic_compare.cmx \
-    utils/identifiable.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/basic/id_types.cmi
 middle_end/flambda/basic/id_types.cmi : \
-    utils/identifiable.cmi
+    middle_end/flambda/compilenv_deps/container_types.cmi
 middle_end/flambda/basic/inline_attribute.cmo : \
     middle_end/flambda/basic/inline_attribute.cmi
 middle_end/flambda/basic/inline_attribute.cmx : \
@@ -4407,9 +4414,9 @@ middle_end/flambda/basic/kinded_parameter.cmo : \
     middle_end/flambda/basic/name.cmi \
     utils/misc.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi
 middle_end/flambda/basic/kinded_parameter.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
@@ -4420,9 +4427,9 @@ middle_end/flambda/basic/kinded_parameter.cmx : \
     middle_end/flambda/basic/name.cmx \
     utils/misc.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
-    utils/identifiable.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/basic/kinded_parameter.cmi
 middle_end/flambda/basic/kinded_parameter.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
@@ -4445,20 +4452,20 @@ middle_end/flambda/basic/name.cmo : \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/compilenv_deps/reg_width_things.cmi \
     utils/misc.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/basic/name.cmi
 middle_end/flambda/basic/name.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
     middle_end/flambda/compilenv_deps/symbol.cmx \
     middle_end/flambda/compilenv_deps/reg_width_things.cmx \
     utils/misc.cmx \
-    utils/identifiable.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/basic/name.cmi
 middle_end/flambda/basic/name.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/compilenv_deps/symbol.cmi \
     middle_end/flambda/compilenv_deps/reg_width_things.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi
 middle_end/flambda/basic/num_continuation_uses.cmo : \
     middle_end/flambda/basic/num_continuation_uses.cmi
@@ -4506,28 +4513,28 @@ middle_end/flambda/basic/scope.cmo : \
     middle_end/flambda/compilenv_deps/patricia_tree.cmi \
     middle_end/flambda/compilenv_deps/numeric_types.cmi \
     utils/misc.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/basic/scope.cmi
 middle_end/flambda/basic/scope.cmx : \
     middle_end/flambda/compilenv_deps/patricia_tree.cmx \
     middle_end/flambda/compilenv_deps/numeric_types.cmx \
     utils/misc.cmx \
-    utils/identifiable.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/basic/scope.cmi
 middle_end/flambda/basic/scope.cmi : \
-    utils/identifiable.cmi
+    middle_end/flambda/compilenv_deps/container_types.cmi
 middle_end/flambda/basic/set_of_closures_origin.cmo : \
-    utils/identifiable.cmi \
     middle_end/flambda/basic/id_types.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/basic/set_of_closures_origin.cmi
 middle_end/flambda/basic/set_of_closures_origin.cmx : \
-    utils/identifiable.cmx \
     middle_end/flambda/basic/id_types.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
     middle_end/flambda/basic/set_of_closures_origin.cmi
 middle_end/flambda/basic/set_of_closures_origin.cmi : \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi
 middle_end/flambda/basic/simple.cmo : \
     middle_end/flambda/naming/renaming.cmi \
@@ -4537,8 +4544,8 @@ middle_end/flambda/basic/simple.cmo : \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/basic/name.cmi \
     utils/misc.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/compilenv_deps/coercion.cmi \
     middle_end/flambda/basic/simple.cmi
 middle_end/flambda/basic/simple.cmx : \
@@ -4549,8 +4556,8 @@ middle_end/flambda/basic/simple.cmx : \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/basic/name.cmx \
     utils/misc.cmx \
-    utils/identifiable.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/compilenv_deps/coercion.cmx \
     middle_end/flambda/basic/simple.cmi
 middle_end/flambda/basic/simple.cmi : \
@@ -4561,9 +4568,9 @@ middle_end/flambda/basic/simple.cmi : \
     middle_end/flambda/basic/reg_width_const.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/basic/name.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/naming/contains_names.cmo \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/compilenv_deps/coercion.cmi
 middle_end/flambda/basic/symbol_scoping_rule.cmo : \
     middle_end/flambda/basic/symbol_scoping_rule.cmi
@@ -4591,19 +4598,19 @@ middle_end/flambda/basic/trap_action.cmi : \
     middle_end/flambda/basic/continuation.cmi
 middle_end/flambda/basic/var_within_closure.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/basic/var_within_closure.cmi
 middle_end/flambda/basic/var_within_closure.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
-    utils/identifiable.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
     middle_end/flambda/basic/var_within_closure.cmi
 middle_end/flambda/basic/var_within_closure.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi
 middle_end/flambda/cmx/contains_ids.cmo : \
     middle_end/flambda/cmx/ids_for_export.cmi
@@ -5510,16 +5517,16 @@ middle_end/flambda/naming/bindable.cmo : \
     middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/compilenv_deps/printing_cache.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/naming/contains_names.cmo \
-    middle_end/flambda/cmx/contains_ids.cmo
+    middle_end/flambda/cmx/contains_ids.cmo \
+    middle_end/flambda/compilenv_deps/container_types.cmi
 middle_end/flambda/naming/bindable.cmx : \
     middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/compilenv_deps/printing_cache.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
-    utils/identifiable.cmx \
     middle_end/flambda/naming/contains_names.cmx \
-    middle_end/flambda/cmx/contains_ids.cmx
+    middle_end/flambda/cmx/contains_ids.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx
 middle_end/flambda/naming/bindable_continuation.cmo : \
     middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
@@ -5559,7 +5566,7 @@ middle_end/flambda/naming/bindable_let_bound.cmo : \
     middle_end/flambda/naming/name_mode.cmi \
     utils/misc.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/terms/bound_symbols.cmi \
     middle_end/flambda/naming/bindable_let_bound.cmi
 middle_end/flambda/naming/bindable_let_bound.cmx : \
@@ -5571,7 +5578,7 @@ middle_end/flambda/naming/bindable_let_bound.cmx : \
     middle_end/flambda/naming/name_mode.cmx \
     utils/misc.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
-    utils/identifiable.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/terms/bound_symbols.cmx \
     middle_end/flambda/naming/bindable_let_bound.cmi
 middle_end/flambda/naming/bindable_let_bound.cmi : \
@@ -5656,7 +5663,7 @@ middle_end/flambda/naming/name_in_binding_pos.cmo : \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/basic/name.cmi \
     utils/misc.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/naming/name_in_binding_pos.cmi
 middle_end/flambda/naming/name_in_binding_pos.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
@@ -5665,7 +5672,7 @@ middle_end/flambda/naming/name_in_binding_pos.cmx : \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/basic/name.cmx \
     utils/misc.cmx \
-    utils/identifiable.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/naming/name_in_binding_pos.cmi
 middle_end/flambda/naming/name_in_binding_pos.cmi : \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
@@ -5673,17 +5680,17 @@ middle_end/flambda/naming/name_in_binding_pos.cmi : \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/basic/name.cmi \
-    utils/identifiable.cmi
+    middle_end/flambda/compilenv_deps/container_types.cmi
 middle_end/flambda/naming/name_mode.cmo : \
     utils/misc.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/naming/name_mode.cmi
 middle_end/flambda/naming/name_mode.cmx : \
     utils/misc.cmx \
-    utils/identifiable.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/naming/name_mode.cmi
 middle_end/flambda/naming/name_mode.cmi : \
-    utils/identifiable.cmi
+    middle_end/flambda/compilenv_deps/container_types.cmi
 middle_end/flambda/naming/name_occurrences.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/var_within_closure.cmi \
@@ -5692,8 +5699,8 @@ middle_end/flambda/naming/name_occurrences.cmo : \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/basic/name.cmi \
     utils/misc.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/basic/continuation.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/basic/code_id_or_symbol.cmi \
     middle_end/flambda/basic/code_id.cmi \
     utils/clflags.cmi \
@@ -5706,8 +5713,8 @@ middle_end/flambda/naming/name_occurrences.cmx : \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/basic/name.cmx \
     utils/misc.cmx \
-    utils/identifiable.cmx \
     middle_end/flambda/basic/continuation.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/basic/code_id_or_symbol.cmx \
     middle_end/flambda/basic/code_id.cmx \
     utils/clflags.cmx \
@@ -5729,13 +5736,13 @@ middle_end/flambda/naming/num_occurrences.cmx : \
     middle_end/flambda/naming/num_occurrences.cmi
 middle_end/flambda/naming/num_occurrences.cmi :
 middle_end/flambda/naming/permutation.cmo : \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/naming/permutation.cmi
 middle_end/flambda/naming/permutation.cmx : \
-    utils/identifiable.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/naming/permutation.cmi
 middle_end/flambda/naming/permutation.cmi : \
-    utils/identifiable.cmi
+    middle_end/flambda/compilenv_deps/container_types.cmi
 middle_end/flambda/naming/renaming.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/var_within_closure.cmi \
@@ -5775,7 +5782,7 @@ middle_end/flambda/naming/var_in_binding_pos.cmo : \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     utils/misc.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/naming/var_in_binding_pos.cmi
 middle_end/flambda/naming/var_in_binding_pos.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
@@ -5784,14 +5791,14 @@ middle_end/flambda/naming/var_in_binding_pos.cmx : \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     utils/misc.cmx \
-    utils/identifiable.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/naming/var_in_binding_pos.cmi
 middle_end/flambda/naming/var_in_binding_pos.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/naming/name_mode.cmi \
-    utils/identifiable.cmi \
-    middle_end/flambda/naming/contains_names.cmo
+    middle_end/flambda/naming/contains_names.cmo \
+    middle_end/flambda/compilenv_deps/container_types.cmi
 middle_end/flambda/naming/with_delayed_permutation.cmo : \
     middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/compilenv_deps/printing_cache.cmi \
@@ -5985,7 +5992,6 @@ middle_end/flambda/parser/flambda_to_fexpr.cmo : \
     middle_end/flambda/compilenv_deps/linkage_name.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/inlining/inlining_state.cmi \
-    utils/identifiable.cmi \
     typing/ident.cmi \
     middle_end/flambda/terms/function_declarations.cmi \
     middle_end/flambda/terms/function_declaration.cmi \
@@ -5997,6 +6003,7 @@ middle_end/flambda/parser/flambda_to_fexpr.cmo : \
     middle_end/flambda/parser/fexpr.cmo \
     middle_end/flambda/basic/exn_continuation.cmi \
     middle_end/flambda/basic/continuation.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/inlining/metrics/code_size.cmi \
     middle_end/flambda/basic/code_id.cmi \
@@ -6028,7 +6035,6 @@ middle_end/flambda/parser/flambda_to_fexpr.cmx : \
     middle_end/flambda/compilenv_deps/linkage_name.cmx \
     middle_end/flambda/basic/kinded_parameter.cmx \
     middle_end/flambda/inlining/inlining_state.cmx \
-    utils/identifiable.cmx \
     typing/ident.cmx \
     middle_end/flambda/terms/function_declarations.cmx \
     middle_end/flambda/terms/function_declaration.cmx \
@@ -6040,6 +6046,7 @@ middle_end/flambda/parser/flambda_to_fexpr.cmx : \
     middle_end/flambda/parser/fexpr.cmx \
     middle_end/flambda/basic/exn_continuation.cmx \
     middle_end/flambda/basic/continuation.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
     middle_end/flambda/inlining/metrics/code_size.cmx \
     middle_end/flambda/basic/code_id.cmx \
@@ -6105,12 +6112,12 @@ middle_end/flambda/simplify/common_subexpression_elimination.cmo : \
     middle_end/flambda/basic/name.cmi \
     utils/misc.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/types/flambda_type.cmi \
     middle_end/flambda/terms/flambda_primitive.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/basic/continuation_extra_params_and_args.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/basic/apply_cont_rewrite_id.cmi \
     middle_end/flambda/types/env/aliases.cmi \
     middle_end/flambda/simplify/common_subexpression_elimination.cmi
@@ -6123,12 +6130,12 @@ middle_end/flambda/simplify/common_subexpression_elimination.cmx : \
     middle_end/flambda/basic/name.cmx \
     utils/misc.cmx \
     middle_end/flambda/basic/kinded_parameter.cmx \
-    utils/identifiable.cmx \
     middle_end/flambda/types/flambda_type.cmx \
     middle_end/flambda/terms/flambda_primitive.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
     middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/basic/continuation_extra_params_and_args.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/basic/apply_cont_rewrite_id.cmx \
     middle_end/flambda/types/env/aliases.cmx \
     middle_end/flambda/simplify/common_subexpression_elimination.cmi
@@ -6504,10 +6511,10 @@ middle_end/flambda/simplify/simplify_binary_primitive.cmo : \
     middle_end/flambda/simplify/typing_helpers/number_adjuncts.cmi \
     middle_end/flambda/basic/name.cmi \
     utils/misc.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/types/flambda_type.cmi \
     middle_end/flambda/compilenv_deps/flambda_features.cmi \
     lambda/debuginfo.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/simplify/simplify_binary_primitive.cmi
 middle_end/flambda/simplify/simplify_binary_primitive.cmx : \
     middle_end/flambda/naming/var_in_binding_pos.cmx \
@@ -6523,10 +6530,10 @@ middle_end/flambda/simplify/simplify_binary_primitive.cmx : \
     middle_end/flambda/simplify/typing_helpers/number_adjuncts.cmx \
     middle_end/flambda/basic/name.cmx \
     utils/misc.cmx \
-    utils/identifiable.cmx \
     middle_end/flambda/types/flambda_type.cmx \
     middle_end/flambda/compilenv_deps/flambda_features.cmx \
     lambda/debuginfo.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/simplify/simplify_binary_primitive.cmi
 middle_end/flambda/simplify/simplify_binary_primitive.cmi : \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
@@ -7713,10 +7720,10 @@ middle_end/flambda/simplify/typing_helpers/number_adjuncts.cmo : \
     middle_end/flambda/basic/reg_width_const.cmi \
     middle_end/flambda/compilenv_deps/numeric_types.cmi \
     utils/misc.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/types/flambda_type.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/terms/flambda.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/simplify/typing_helpers/number_adjuncts.cmi
 middle_end/flambda/simplify/typing_helpers/number_adjuncts.cmx : \
     middle_end/flambda/compilenv_deps/targetint_32_64.cmx \
@@ -7725,20 +7732,20 @@ middle_end/flambda/simplify/typing_helpers/number_adjuncts.cmx : \
     middle_end/flambda/basic/reg_width_const.cmx \
     middle_end/flambda/compilenv_deps/numeric_types.cmx \
     utils/misc.cmx \
-    utils/identifiable.cmx \
     middle_end/flambda/types/flambda_type.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
     middle_end/flambda/terms/flambda.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/simplify/typing_helpers/number_adjuncts.cmi
 middle_end/flambda/simplify/typing_helpers/number_adjuncts.cmi : \
     middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     middle_end/flambda/basic/reg_width_const.cmi \
     middle_end/flambda/compilenv_deps/numeric_types.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/types/flambda_type.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
-    middle_end/flambda/terms/flambda.cmi
+    middle_end/flambda/terms/flambda.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi
 middle_end/flambda/simplify/typing_helpers/one_continuation_use.cmo : \
     middle_end/flambda/types/flambda_type.cmi \
     middle_end/flambda/simplify/env/downwards_env.cmi \
@@ -7763,10 +7770,10 @@ middle_end/flambda/terms/apply_cont_expr.cmo : \
     middle_end/flambda/naming/name_occurrences.cmi \
     utils/misc.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     lambda/debuginfo.cmi \
     middle_end/flambda/basic/continuation.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/terms/apply_cont_expr.cmi
 middle_end/flambda/terms/apply_cont_expr.cmx : \
     middle_end/flambda/basic/trap_action.cmx \
@@ -7775,19 +7782,19 @@ middle_end/flambda/terms/apply_cont_expr.cmx : \
     middle_end/flambda/naming/name_occurrences.cmx \
     utils/misc.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
-    utils/identifiable.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     lambda/debuginfo.cmx \
     middle_end/flambda/basic/continuation.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/terms/apply_cont_expr.cmi
 middle_end/flambda/terms/apply_cont_expr.cmi : \
     middle_end/flambda/basic/trap_action.cmi \
     middle_end/flambda/basic/simple.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/basic/expr_std.cmo \
     lambda/debuginfo.cmi \
     middle_end/flambda/basic/continuation.cmi \
-    middle_end/flambda/cmx/contains_ids.cmo
+    middle_end/flambda/cmx/contains_ids.cmo \
+    middle_end/flambda/compilenv_deps/container_types.cmi
 middle_end/flambda/terms/apply_expr.cmo : \
     middle_end/flambda/basic/simple.cmi \
     middle_end/flambda/naming/renaming.cmi \
@@ -7797,13 +7804,13 @@ middle_end/flambda/terms/apply_expr.cmo : \
     middle_end/flambda/inlining/inlining_state.cmi \
     middle_end/flambda/basic/inline_attribute.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/types/kinds/flambda_arity.cmi \
     middle_end/flambda/basic/exn_continuation.cmi \
     lambda/debuginfo.cmi \
     middle_end/flambda/basic/continuation.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/terms/call_kind.cmi \
     middle_end/flambda/terms/apply_expr.cmi
 middle_end/flambda/terms/apply_expr.cmx : \
@@ -7815,13 +7822,13 @@ middle_end/flambda/terms/apply_expr.cmx : \
     middle_end/flambda/inlining/inlining_state.cmx \
     middle_end/flambda/basic/inline_attribute.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
-    utils/identifiable.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/types/kinds/flambda_arity.cmx \
     middle_end/flambda/basic/exn_continuation.cmx \
     lambda/debuginfo.cmx \
     middle_end/flambda/basic/continuation.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/terms/call_kind.cmx \
     middle_end/flambda/terms/apply_expr.cmi
 middle_end/flambda/terms/apply_expr.cmi : \
@@ -7829,13 +7836,13 @@ middle_end/flambda/terms/apply_expr.cmi : \
     middle_end/flambda/inlining/inlining_state.cmi \
     middle_end/flambda/inlining/inlining_arguments.cmi \
     middle_end/flambda/basic/inline_attribute.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/basic/expr_std.cmo \
     middle_end/flambda/basic/exn_continuation.cmi \
     lambda/debuginfo.cmi \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/naming/contains_names.cmo \
     middle_end/flambda/cmx/contains_ids.cmo \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/terms/call_kind.cmi
 middle_end/flambda/terms/bound_symbols.cmo : \
     middle_end/flambda/compilenv_deps/symbol.cmi \
@@ -8124,7 +8131,6 @@ middle_end/flambda/terms/flambda.cmo : \
     middle_end/flambda/basic/invalid_term_semantics.cmi \
     middle_end/flambda/inlining/inlining_arguments.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/terms/function_declarations.cmi \
     middle_end/flambda/terms/function_declaration.cmi \
     middle_end/flambda/types/flambda_type.cmi \
@@ -8138,6 +8144,7 @@ middle_end/flambda/terms/flambda.cmo : \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/naming/contains_names.cmo \
     middle_end/flambda/cmx/contains_ids.cmo \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/inlining/metrics/code_size.cmi \
     middle_end/flambda/terms/code_intf.cmo \
     middle_end/flambda/basic/code_id.cmi \
@@ -8185,7 +8192,6 @@ middle_end/flambda/terms/flambda.cmx : \
     middle_end/flambda/basic/invalid_term_semantics.cmx \
     middle_end/flambda/inlining/inlining_arguments.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
-    utils/identifiable.cmx \
     middle_end/flambda/terms/function_declarations.cmx \
     middle_end/flambda/terms/function_declaration.cmx \
     middle_end/flambda/types/flambda_type.cmx \
@@ -8199,6 +8205,7 @@ middle_end/flambda/terms/flambda.cmx : \
     middle_end/flambda/basic/continuation.cmx \
     middle_end/flambda/naming/contains_names.cmx \
     middle_end/flambda/cmx/contains_ids.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/inlining/metrics/code_size.cmx \
     middle_end/flambda/terms/code_intf.cmx \
     middle_end/flambda/basic/code_id.cmx \
@@ -8239,7 +8246,6 @@ middle_end/flambda/terms/flambda.cmi : \
     middle_end/flambda/inlining/inlining_arguments.cmi \
     middle_end/flambda/basic/inline_attribute.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/terms/function_declarations.cmi \
     middle_end/flambda/terms/function_declaration.cmi \
     middle_end/flambda/terms/flambda_primitive.cmi \
@@ -8251,6 +8257,7 @@ middle_end/flambda/terms/flambda.cmi : \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/naming/contains_names.cmo \
     middle_end/flambda/cmx/contains_ids.cmo \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/inlining/metrics/code_size.cmi \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/basic/closure_id.cmi \
@@ -8271,10 +8278,10 @@ middle_end/flambda/terms/flambda_primitive.cmo : \
     lambda/lambda.cmi \
     middle_end/flambda/basic/invariant_env.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/basic/effects.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/basic/coeffects.cmi \
     middle_end/flambda/basic/closure_id.cmi \
     utils/clflags.cmi \
@@ -8292,10 +8299,10 @@ middle_end/flambda/terms/flambda_primitive.cmx : \
     lambda/lambda.cmx \
     middle_end/flambda/basic/invariant_env.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
-    utils/identifiable.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/basic/effects.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/basic/coeffects.cmx \
     middle_end/flambda/basic/closure_id.cmx \
     utils/clflags.cmx \
@@ -8310,11 +8317,11 @@ middle_end/flambda/terms/flambda_primitive.cmi : \
     middle_end/flambda/basic/mutability.cmi \
     lambda/lambda.cmi \
     middle_end/flambda/basic/invariant_env.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/basic/effects.cmi \
     middle_end/flambda/naming/contains_names.cmo \
     middle_end/flambda/cmx/contains_ids.cmo \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/basic/coeffects.cmi \
     middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/terms/flambda_unit.cmo : \
@@ -8631,9 +8638,9 @@ middle_end/flambda/terms/set_of_closures.cmo : \
     middle_end/flambda/naming/name_occurrences.cmi \
     utils/misc.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/terms/function_declarations.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/terms/set_of_closures.cmi
 middle_end/flambda/terms/set_of_closures.cmx : \
     middle_end/flambda/basic/var_within_closure.cmx \
@@ -8643,18 +8650,18 @@ middle_end/flambda/terms/set_of_closures.cmx : \
     middle_end/flambda/naming/name_occurrences.cmx \
     utils/misc.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
-    utils/identifiable.cmx \
     middle_end/flambda/terms/function_declarations.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/terms/set_of_closures.cmi
 middle_end/flambda/terms/set_of_closures.cmi : \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/basic/simple.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/terms/function_declarations.cmi \
     middle_end/flambda/terms/function_declaration.cmi \
     middle_end/flambda/basic/expr_std.cmo \
     middle_end/flambda/cmx/contains_ids.cmo \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/terms/static_const.rec.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
@@ -8672,10 +8679,10 @@ middle_end/flambda/terms/static_const.rec.cmo : \
     middle_end/flambda/basic/mutability.cmi \
     utils/misc.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/terms/function_declarations.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/basic/closure_id.cmi \
     middle_end/flambda/terms/bound_symbols.cmi \
@@ -8696,10 +8703,10 @@ middle_end/flambda/terms/static_const.rec.cmx : \
     middle_end/flambda/basic/mutability.cmx \
     utils/misc.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
-    utils/identifiable.cmx \
     middle_end/flambda/terms/function_declarations.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/basic/closure_id.cmx \
     middle_end/flambda/terms/bound_symbols.cmx \
@@ -8715,9 +8722,9 @@ middle_end/flambda/terms/static_const.rec.cmi : \
     middle_end/flambda/basic/or_variable.cmi \
     middle_end/flambda/compilenv_deps/numeric_types.cmi \
     middle_end/flambda/basic/mutability.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/naming/contains_names.cmo \
     middle_end/flambda/cmx/contains_ids.cmo \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/basic/closure_id.cmi \
     middle_end/flambda/terms/bound_symbols.cmi
@@ -9199,7 +9206,6 @@ middle_end/flambda/types/flambda_type.cmo : \
     utils/misc.cmi \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/types/kinds/flambda_arity.cmi \
@@ -9207,6 +9213,7 @@ middle_end/flambda/types/flambda_type.cmo : \
     middle_end/flambda/simplify/env/continuation_use_kind.cmi \
     middle_end/flambda/naming/contains_names.cmo \
     middle_end/flambda/cmx/contains_ids.cmo \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/compilenv_deps/coercion.cmi \
     middle_end/flambda/basic/code_id.cmi \
@@ -9254,7 +9261,6 @@ middle_end/flambda/types/flambda_type.cmx : \
     utils/misc.cmx \
     middle_end/flambda/basic/kinded_parameter.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
-    utils/identifiable.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/types/kinds/flambda_arity.cmx \
@@ -9262,6 +9268,7 @@ middle_end/flambda/types/flambda_type.cmx : \
     middle_end/flambda/simplify/env/continuation_use_kind.cmx \
     middle_end/flambda/naming/contains_names.cmx \
     middle_end/flambda/cmx/contains_ids.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
     middle_end/flambda/compilenv_deps/coercion.cmx \
     middle_end/flambda/basic/code_id.cmx \
@@ -9472,25 +9479,25 @@ middle_end/flambda/types/type_head_intf.cmx : \
 middle_end/flambda/types/basic/closure_id_and_var_within_closure_set.cmo : \
     middle_end/flambda/types/basic/var_within_closure_set.cmi \
     middle_end/flambda/basic/var_within_closure.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/basic/closure_id.cmi \
     middle_end/flambda/types/basic/closure_id_and_var_within_closure_set.cmi
 middle_end/flambda/types/basic/closure_id_and_var_within_closure_set.cmx : \
     middle_end/flambda/types/basic/var_within_closure_set.cmx \
     middle_end/flambda/basic/var_within_closure.cmx \
-    utils/identifiable.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/basic/closure_id.cmx \
     middle_end/flambda/types/basic/closure_id_and_var_within_closure_set.cmi
 middle_end/flambda/types/basic/closure_id_and_var_within_closure_set.cmi : \
     middle_end/flambda/types/basic/var_within_closure_set.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/basic/closure_id.cmi
  \
     middle_end/flambda/types/basic/closure_id_or_unknown_and_var_within_closure_set.cmo : \
     middle_end/flambda/types/basic/var_within_closure_set.cmi \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/basic/closure_id.cmi \
     middle_end/flambda/types/basic/closure_id_or_unknown_and_var_within_closure_set.cmi
  \
@@ -9498,28 +9505,28 @@ middle_end/flambda/types/basic/closure_id_and_var_within_closure_set.cmi : \
     middle_end/flambda/types/basic/var_within_closure_set.cmx \
     middle_end/flambda/basic/var_within_closure.cmx \
     middle_end/flambda/types/basic/or_unknown.cmx \
-    utils/identifiable.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/basic/closure_id.cmx \
     middle_end/flambda/types/basic/closure_id_or_unknown_and_var_within_closure_set.cmi
  \
     middle_end/flambda/types/basic/closure_id_or_unknown_and_var_within_closure_set.cmi : \
     middle_end/flambda/types/basic/var_within_closure_set.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/types/basic/closure_id_set.cmo : \
     middle_end/flambda/naming/name_occurrences.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/basic/closure_id.cmi \
     middle_end/flambda/types/basic/closure_id_set.cmi
 middle_end/flambda/types/basic/closure_id_set.cmx : \
     middle_end/flambda/naming/name_occurrences.cmx \
-    utils/identifiable.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/basic/closure_id.cmx \
     middle_end/flambda/types/basic/closure_id_set.cmi
 middle_end/flambda/types/basic/closure_id_set.cmi : \
-    utils/identifiable.cmi \
     middle_end/flambda/naming/contains_names.cmo \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/types/basic/meet_or_join_op.cmo : \
     middle_end/flambda/types/basic/meet_or_join_op.cmi
@@ -9535,23 +9542,23 @@ middle_end/flambda/types/basic/or_unknown.cmo : \
     middle_end/flambda/naming/name_occurrences.cmi \
     utils/misc.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     utils/clflags.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi
 middle_end/flambda/types/basic/or_unknown.cmx : \
     middle_end/flambda/naming/name_occurrences.cmx \
     utils/misc.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
-    utils/identifiable.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     utils/clflags.cmx \
     middle_end/flambda/types/basic/or_unknown.cmi
 middle_end/flambda/types/basic/or_unknown.cmi : \
     middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
-    utils/identifiable.cmi
+    middle_end/flambda/compilenv_deps/container_types.cmi
 middle_end/flambda/types/basic/or_unknown_or_bottom.cmo : \
     middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/types/basic/or_unknown_or_bottom.cmi
@@ -9563,69 +9570,69 @@ middle_end/flambda/types/basic/or_unknown_or_bottom.cmi : \
 middle_end/flambda/types/basic/string_info.cmo : \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     utils/misc.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/types/basic/string_info.cmi
 middle_end/flambda/types/basic/string_info.cmx : \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmx \
     utils/misc.cmx \
-    utils/identifiable.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/types/basic/string_info.cmi
 middle_end/flambda/types/basic/string_info.cmi : \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
-    utils/identifiable.cmi
+    middle_end/flambda/compilenv_deps/container_types.cmi
 middle_end/flambda/types/basic/tag_and_size.cmo : \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     middle_end/flambda/compilenv_deps/tag.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/types/basic/tag_and_size.cmi
 middle_end/flambda/types/basic/tag_and_size.cmx : \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmx \
     middle_end/flambda/compilenv_deps/tag.cmx \
-    utils/identifiable.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/types/basic/tag_and_size.cmi
 middle_end/flambda/types/basic/tag_and_size.cmi : \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     middle_end/flambda/compilenv_deps/tag.cmi \
-    utils/identifiable.cmi
+    middle_end/flambda/compilenv_deps/container_types.cmi
 middle_end/flambda/types/basic/tag_or_unknown_and_size.cmo : \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     middle_end/flambda/compilenv_deps/tag.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/types/basic/tag_or_unknown_and_size.cmi
 middle_end/flambda/types/basic/tag_or_unknown_and_size.cmx : \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmx \
     middle_end/flambda/compilenv_deps/tag.cmx \
     middle_end/flambda/types/basic/or_unknown.cmx \
-    utils/identifiable.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/types/basic/tag_or_unknown_and_size.cmi
 middle_end/flambda/types/basic/tag_or_unknown_and_size.cmi : \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     middle_end/flambda/compilenv_deps/tag.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
-    utils/identifiable.cmi
+    middle_end/flambda/compilenv_deps/container_types.cmi
 middle_end/flambda/types/basic/unit.cmo : \
     middle_end/flambda/naming/name_occurrences.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/types/basic/unit.cmi
 middle_end/flambda/types/basic/unit.cmx : \
     middle_end/flambda/naming/name_occurrences.cmx \
-    utils/identifiable.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/types/basic/unit.cmi
 middle_end/flambda/types/basic/unit.cmi : \
-    utils/identifiable.cmi \
-    middle_end/flambda/naming/contains_names.cmo
+    middle_end/flambda/naming/contains_names.cmo \
+    middle_end/flambda/compilenv_deps/container_types.cmi
 middle_end/flambda/types/basic/var_within_closure_set.cmo : \
     middle_end/flambda/basic/var_within_closure.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/types/basic/var_within_closure_set.cmi
 middle_end/flambda/types/basic/var_within_closure_set.cmx : \
     middle_end/flambda/basic/var_within_closure.cmx \
-    utils/identifiable.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/types/basic/var_within_closure_set.cmi
 middle_end/flambda/types/basic/var_within_closure_set.cmi : \
     middle_end/flambda/basic/var_within_closure.cmi \
-    utils/identifiable.cmi
+    middle_end/flambda/compilenv_deps/container_types.cmi
 middle_end/flambda/types/env/aliases.cmo : \
     middle_end/flambda/compilenv_deps/variable.cmi \
     middle_end/flambda/basic/simple.cmi \
@@ -9666,18 +9673,18 @@ middle_end/flambda/types/env/binding_time.cmo : \
     middle_end/flambda/compilenv_deps/numeric_types.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     utils/misc.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/types/env/binding_time.cmi
 middle_end/flambda/types/env/binding_time.cmx : \
     middle_end/flambda/compilenv_deps/patricia_tree.cmx \
     middle_end/flambda/compilenv_deps/numeric_types.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     utils/misc.cmx \
-    utils/identifiable.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/types/env/binding_time.cmi
 middle_end/flambda/types/env/binding_time.cmi : \
     middle_end/flambda/naming/name_mode.cmi \
-    utils/identifiable.cmi
+    middle_end/flambda/compilenv_deps/container_types.cmi
 middle_end/flambda/types/env/join_env.rec.cmo : \
     middle_end/flambda/types/env/join_env.rec.cmi
 middle_end/flambda/types/env/join_env.rec.cmx : \
@@ -9849,38 +9856,38 @@ middle_end/flambda/types/env/typing_env_level.rec.cmi : \
     middle_end/flambda/basic/apply_cont_rewrite_id.cmi
 middle_end/flambda/types/kinds/flambda_arity.cmo : \
     utils/misc.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/types/kinds/flambda_arity.cmi
 middle_end/flambda/types/kinds/flambda_arity.cmx : \
     utils/misc.cmx \
-    utils/identifiable.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/types/kinds/flambda_arity.cmi
 middle_end/flambda/types/kinds/flambda_arity.cmi : \
-    utils/identifiable.cmi \
-    middle_end/flambda/types/kinds/flambda_kind.cmi
+    middle_end/flambda/types/kinds/flambda_kind.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi
 middle_end/flambda/types/kinds/flambda_kind.cmo : \
     middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     middle_end/flambda/compilenv_deps/numeric_types.cmi \
     utils/misc.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi
 middle_end/flambda/types/kinds/flambda_kind.cmx : \
     middle_end/flambda/compilenv_deps/targetint_32_64.cmx \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmx \
     middle_end/flambda/compilenv_deps/numeric_types.cmx \
     utils/misc.cmx \
-    utils/identifiable.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmi
 middle_end/flambda/types/kinds/flambda_kind.cmi : \
     middle_end/flambda/compilenv_deps/targetint_32_64.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
     middle_end/flambda/compilenv_deps/numeric_types.cmi \
-    utils/identifiable.cmi
+    middle_end/flambda/compilenv_deps/container_types.cmi
 middle_end/flambda/types/structures/closures_entry.rec.cmo : \
     middle_end/flambda/compilenv_deps/printing_cache.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
@@ -9995,16 +10002,16 @@ middle_end/flambda/types/structures/product_intf.cmo : \
     middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
     middle_end/flambda/types/basic/or_bottom.cmi \
-    utils/identifiable.cmi \
-    middle_end/flambda/types/kinds/flambda_kind.cmi
+    middle_end/flambda/types/kinds/flambda_kind.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi
 middle_end/flambda/types/structures/product_intf.cmx : \
     middle_end/flambda/types/structures/type_structure_intf.cmx \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmx \
     middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/types/basic/or_unknown.cmx \
     middle_end/flambda/types/basic/or_bottom.cmx \
-    utils/identifiable.cmx \
-    middle_end/flambda/types/kinds/flambda_kind.cmx
+    middle_end/flambda/types/kinds/flambda_kind.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx
 middle_end/flambda/types/structures/row_like.rec.cmo : \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/compilenv_deps/targetint_31_63.cmi \
@@ -10021,9 +10028,9 @@ middle_end/flambda/types/structures/row_like.rec.cmo : \
     middle_end/flambda/naming/name_occurrences.cmi \
     utils/misc.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
-    utils/identifiable.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/basic/closure_id.cmi \
     utils/clflags.cmi \
     middle_end/flambda/types/structures/row_like.rec.cmi
@@ -10043,9 +10050,9 @@ middle_end/flambda/types/structures/row_like.rec.cmx : \
     middle_end/flambda/naming/name_occurrences.cmx \
     utils/misc.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
-    utils/identifiable.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/basic/closure_id.cmx \
     utils/clflags.cmx \
     middle_end/flambda/types/structures/row_like.rec.cmi
@@ -10070,7 +10077,7 @@ middle_end/flambda/types/structures/set_of_closures_contents.cmo : \
     middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
     utils/misc.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/basic/closure_id.cmi \
     middle_end/flambda/types/structures/set_of_closures_contents.cmi
 middle_end/flambda/types/structures/set_of_closures_contents.cmx : \
@@ -10078,14 +10085,14 @@ middle_end/flambda/types/structures/set_of_closures_contents.cmx : \
     middle_end/flambda/naming/renaming.cmx \
     middle_end/flambda/types/basic/or_unknown.cmx \
     utils/misc.cmx \
-    utils/identifiable.cmx \
+    middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/basic/closure_id.cmx \
     middle_end/flambda/types/structures/set_of_closures_contents.cmi
 middle_end/flambda/types/structures/set_of_closures_contents.cmi : \
     middle_end/flambda/basic/var_within_closure.cmi \
     middle_end/flambda/naming/renaming.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi \
-    utils/identifiable.cmi \
+    middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/basic/closure_id.cmi
 middle_end/flambda/types/structures/type_structure_intf.cmo : \
     middle_end/flambda/compilenv_deps/printing_cache.cmi \

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -180,6 +180,7 @@ MIDDLE_END_FLAMBDA_COMPILENV_DEPS=\
   middle_end/flambda/compilenv_deps/printing_cache.cmo \
   middle_end/flambda/compilenv_deps/one_bit_fewer.cmo \
   middle_end/flambda/compilenv_deps/lmap.cmo \
+  middle_end/flambda/compilenv_deps/container_types.cmo \
   middle_end/flambda/compilenv_deps/targetint_32_64.cmo \
   middle_end/flambda/compilenv_deps/numeric_types.cmo \
   middle_end/flambda/compilenv_deps/targetint_31_63.cmo \

--- a/middle_end/flambda/basic/apply_cont_rewrite_id.mli
+++ b/middle_end/flambda/basic/apply_cont_rewrite_id.mli
@@ -18,6 +18,6 @@
 
 type t
 
-include Identifiable.S with type t := t
+include Container_types.S with type t := t
 
 val create : unit -> t

--- a/middle_end/flambda/basic/closure_id.ml
+++ b/middle_end/flambda/basic/closure_id.ml
@@ -23,7 +23,7 @@ type t = {
   (** [name_stamp]s are unique within any given compilation unit. *)
 }
 
-module Self = Identifiable.Make (struct
+module Self = Container_types.Make (struct
   type nonrec t = t
 
   let compare t1 t2 =

--- a/middle_end/flambda/basic/closure_id.mli
+++ b/middle_end/flambda/basic/closure_id.mli
@@ -25,7 +25,7 @@
     unit), that identifies a closure within a particular set of closures
     (viz. [Project_closure]). *)
 
-include Identifiable.S
+include Container_types.S
 
 module Lmap : Lmap.S with type key = t
 

--- a/middle_end/flambda/basic/closure_origin.mli
+++ b/middle_end/flambda/basic/closure_origin.mli
@@ -14,7 +14,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-include Identifiable.S
+include Container_types.S
 
 val create : Closure_id.t -> t
 

--- a/middle_end/flambda/basic/code_id.ml
+++ b/middle_end/flambda/basic/code_id.ml
@@ -125,7 +125,7 @@ end
 
 module Set = Patricia_tree.Make_set (struct let print = print end)
 module Map = Patricia_tree.Make_map (struct let print = print end) (Set)
-module Tbl = Identifiable.Make_tbl (Numeric_types.Int) (Map)
+module Tbl = Container_types.Make_tbl (Numeric_types.Int) (Map)
 module Lmap = Lmap.Make(T)
 
 let invert_map map =

--- a/middle_end/flambda/basic/code_id.mli
+++ b/middle_end/flambda/basic/code_id.mli
@@ -16,7 +16,7 @@
 
 [@@@ocaml.warning "+a-4-9-30-40-41-42"]
 
-include Identifiable.S
+include Container_types.S
 type exported
 
 module Lmap : Lmap.S with type key = t

--- a/middle_end/flambda/basic/code_id_or_symbol.ml
+++ b/middle_end/flambda/basic/code_id_or_symbol.ml
@@ -18,7 +18,7 @@ type t =
   | Code_id of Code_id.t
   | Symbol of Symbol.t
 
-include Identifiable.Make (struct
+include Container_types.Make (struct
   type nonrec t = t
 
   let print ppf t =

--- a/middle_end/flambda/basic/code_id_or_symbol.mli
+++ b/middle_end/flambda/basic/code_id_or_symbol.mli
@@ -18,7 +18,7 @@ type t =
   | Code_id of Code_id.t
   | Symbol of Symbol.t
 
-include Identifiable.S with type t := t
+include Container_types.S with type t := t
 
 val compilation_unit : t -> Compilation_unit.t
 

--- a/middle_end/flambda/basic/continuation.ml
+++ b/middle_end/flambda/basic/continuation.ml
@@ -155,7 +155,7 @@ let name_stamp t = (find_data t).name_stamp
 
 let sort t = (find_data t).sort
 
-include Identifiable.Make (struct
+include Container_types.Make (struct
   type nonrec t = t
 
   let compare t1 t2 =
@@ -181,7 +181,7 @@ end)
 module Set = Patricia_tree.Make_set (struct let print = print end)
 module Map = Patricia_tree.Make_map (struct let print = print end) (Set)
 (* CR mshinwell: The [Tbl]s will still print integers! *)
-module Tbl = Identifiable.Make_tbl (Numeric_types.Int) (Map)
+module Tbl = Container_types.Make_tbl (Numeric_types.Int) (Map)
 
 let print_with_cache ~cache:_ ppf t = print ppf t
 
@@ -202,7 +202,7 @@ let map_compilation_unit f (data : Data.t) : Data.t =
 module With_args = struct
   type nonrec t = t * Variable.t list
 
-  include Identifiable.Make (struct
+  include Container_types.Make (struct
     type nonrec t = t
 
     let compare t1 t2 =

--- a/middle_end/flambda/basic/continuation.mli
+++ b/middle_end/flambda/basic/continuation.mli
@@ -21,7 +21,7 @@
 type t = private Table_by_int_id.Id.t
 type exported
 
-include Identifiable.S with type t := t
+include Container_types.S with type t := t
 
 module Sort : sig
   type t =
@@ -54,7 +54,7 @@ val map_compilation_unit :
 
 module With_args : sig
   type nonrec t = t * Variable.t list
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
 end
 
 val initialise : unit -> unit

--- a/middle_end/flambda/basic/exn_continuation.ml
+++ b/middle_end/flambda/basic/exn_continuation.ml
@@ -21,7 +21,7 @@ type t = {
   extra_args : (Simple.t * Flambda_kind.With_subkind.t) list;
 }
 
-include Identifiable.Make (struct
+include Container_types.Make (struct
   type nonrec t = t
 
   let print_simple_and_kind ppf (simple, kind) =

--- a/middle_end/flambda/basic/exn_continuation.mli
+++ b/middle_end/flambda/basic/exn_continuation.mli
@@ -23,7 +23,7 @@
 type t
 
 (** Printing, invariant checks, name manipulation, etc. *)
-include Identifiable.S with type t := t
+include Container_types.S with type t := t
 include Expr_std.S with type t := t
 include Contains_ids.S with type t := t
 

--- a/middle_end/flambda/basic/export_id.ml
+++ b/middle_end/flambda/basic/export_id.ml
@@ -21,7 +21,7 @@ module Unit_id = Id_types.UnitId (Id) (Compilation_unit)
 
 type t = Unit_id.t
 
-include Identifiable.Make (Unit_id)
+include Container_types.Make (Unit_id)
 
 let create = Unit_id.create
 let get_compilation_unit = Unit_id.unit

--- a/middle_end/flambda/basic/export_id.mli
+++ b/middle_end/flambda/basic/export_id.mli
@@ -21,7 +21,7 @@
    These keys are used to ensure maximal sharing of value descriptions,
    which may be substantial. *)
 
-include Identifiable.S
+include Container_types.S
 
 val create : ?name:string -> Compilation_unit.t -> t
 val name : t -> string option

--- a/middle_end/flambda/basic/id_types.ml
+++ b/middle_end/flambda/basic/id_types.ml
@@ -35,7 +35,7 @@ module type Id = sig
 end
 
 module type UnitId = sig
-  module Compilation_unit : Identifiable.Thing
+  module Compilation_unit : Container_types.Thing
   include BaseId
   val create : ?name:string -> Compilation_unit.t -> t
   val unit : t -> Compilation_unit.t
@@ -63,7 +63,7 @@ module Id(_:sig end) : Id = struct
   let print ppf v = Format.pp_print_string ppf (to_string v)
 end
 
-module UnitId(Innerid:Id)(Compilation_unit:Identifiable.Thing) :
+module UnitId(Innerid:Id)(Compilation_unit:Container_types.Thing) :
   UnitId with module Compilation_unit := Compilation_unit = struct
   type t = {
     id : Innerid.t;

--- a/middle_end/flambda/basic/id_types.mli
+++ b/middle_end/flambda/basic/id_types.mli
@@ -41,7 +41,7 @@ end
 (** Fully qualified identifiers *)
 module type UnitId =
 sig
-  module Compilation_unit : Identifiable.Thing
+  module Compilation_unit : Container_types.Thing
   include BaseId
   val create : ?name:string -> Compilation_unit.t -> t
   val unit : t -> Compilation_unit.t
@@ -54,5 +54,5 @@ module Id : functor (_ : sig end) -> Id
 
 module UnitId :
   functor (_ : Id) ->
-  functor (Compilation_unit : Identifiable.Thing) ->
+  functor (Compilation_unit : Container_types.Thing) ->
     UnitId with module Compilation_unit := Compilation_unit

--- a/middle_end/flambda/basic/kinded_parameter.ml
+++ b/middle_end/flambda/basic/kinded_parameter.ml
@@ -21,7 +21,7 @@ type t = {
   kind : Flambda_kind.With_subkind.t;
 }
 
-include Identifiable.Make (struct
+include Container_types.Make (struct
   type nonrec t = t
 
   let compare

--- a/middle_end/flambda/basic/name.ml
+++ b/middle_end/flambda/basic/name.ml
@@ -106,7 +106,7 @@ let must_be_symbol_opt t =
     ~symbol:(fun sym -> Some sym)
 
 module Pair = struct
-  include Identifiable.Make_pair
+  include Container_types.Make_pair
     (Reg_width_things.Name)
     (Reg_width_things.Name)
 

--- a/middle_end/flambda/basic/name.mli
+++ b/middle_end/flambda/basic/name.mli
@@ -59,6 +59,6 @@ val rename : t -> t
 module Pair : sig
   type nonrec t = t * t
 
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
 end
 

--- a/middle_end/flambda/basic/scope.ml
+++ b/middle_end/flambda/basic/scope.ml
@@ -39,4 +39,4 @@ let max t1 t2 = max t1 t2
 
 module Set = Patricia_tree.Make_set (struct let print = print end)
 module Map = Patricia_tree.Make_map (struct let print = print end) (Set)
-module Tbl = Identifiable.Make_tbl (Numeric_types.Int) (Map)
+module Tbl = Container_types.Make_tbl (Numeric_types.Int) (Map)

--- a/middle_end/flambda/basic/scope.mli
+++ b/middle_end/flambda/basic/scope.mli
@@ -18,7 +18,7 @@
 
 type t
 
-include Identifiable.S with type t := t
+include Container_types.S with type t := t
 
 val initial : t
 

--- a/middle_end/flambda/basic/set_of_closures_origin.ml
+++ b/middle_end/flambda/basic/set_of_closures_origin.ml
@@ -21,7 +21,7 @@ module Unit_id = Id_types.UnitId (Id) (Compilation_unit)
 
 type t = Unit_id.t
 
-include Identifiable.Make (Unit_id)
+include Container_types.Make (Unit_id)
 
 let create = Unit_id.create
 let get_compilation_unit = Unit_id.unit

--- a/middle_end/flambda/basic/set_of_closures_origin.mli
+++ b/middle_end/flambda/basic/set_of_closures_origin.mli
@@ -16,7 +16,7 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
-include Identifiable.S
+include Container_types.S
 
 val create : ?name:string -> Compilation_unit.t -> t
 val name : t -> string option

--- a/middle_end/flambda/basic/simple.ml
+++ b/middle_end/flambda/basic/simple.ml
@@ -117,7 +117,7 @@ let apply_renaming t perm =
 module List = struct
   type nonrec t = t list
 
-  include Identifiable.Make (struct
+  include Container_types.Make (struct
     type nonrec t = t
 
     let compare t1 t2 =
@@ -159,7 +159,7 @@ end
 module With_kind = struct
   type nonrec t = t * Flambda_kind.t
 
-  include Identifiable.Make (struct
+  include Container_types.Make (struct
     type nonrec t = t
 
     let compare (s1, k1) (s2, k2) =

--- a/middle_end/flambda/basic/simple.mli
+++ b/middle_end/flambda/basic/simple.mli
@@ -85,12 +85,12 @@ module List : sig
   type nonrec t = t list
 
   include Contains_names.S with type t := t
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
 end
 
 module With_kind : sig
   type nonrec t = t * Flambda_kind.t
 
   include Contains_names.S with type t := t
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
 end

--- a/middle_end/flambda/basic/var_within_closure.ml
+++ b/middle_end/flambda/basic/var_within_closure.ml
@@ -23,7 +23,7 @@ type t = {
   (** [name_stamp]s are unique within any given compilation unit. *)
 }
 
-module Self = Identifiable.Make (struct
+module Self = Container_types.Make (struct
   type nonrec t = t
 
   let compare t1 t2 =

--- a/middle_end/flambda/basic/var_within_closure.mli
+++ b/middle_end/flambda/basic/var_within_closure.mli
@@ -21,7 +21,7 @@
     [Project_var], and not [Var], nodes are tagged with these
     identifiers. *)
 
-include Identifiable.S
+include Container_types.S
 
 val wrap : Compilation_unit.t -> Variable.t -> t
 

--- a/middle_end/flambda/compilenv_deps/compilation_unit.ml
+++ b/middle_end/flambda/compilenv_deps/compilation_unit.ml
@@ -44,7 +44,7 @@ let compare0 v1 v2 =
 
 let equal0 t1 t2 = (compare0 t1 t2 = 0)
 
-include Identifiable.Make (struct
+include Container_types.Make (struct
   type nonrec t = t
 
   let compare = compare0

--- a/middle_end/flambda/compilenv_deps/compilation_unit.mli
+++ b/middle_end/flambda/compilenv_deps/compilation_unit.mli
@@ -16,7 +16,7 @@
 
 [@@@ocaml.warning "+a-4-9-30-40-41-42"]
 
-include Identifiable.S
+include Container_types.S
 
 (* The [Ident.t] must be persistent.  This function raises an exception
    if that is not the case. *)

--- a/middle_end/flambda/compilenv_deps/container_types.ml
+++ b/middle_end/flambda/compilenv_deps/container_types.ml
@@ -1,0 +1,334 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Pierre Chambart, OCamlPro                        *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2013--2016 OCamlPro SAS                                    *)
+(*   Copyright 2014--2016 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "-55"]
+
+module type Thing = sig
+  type t
+
+  include Hashtbl.HashedType with type t := t
+  include Map.OrderedType with type t := t
+
+  val output : out_channel -> t -> unit
+  val print : Format.formatter -> t -> unit
+end
+
+module type Set = sig
+  module T : Set.OrderedType
+  include Set.S with type elt = T.t
+
+  val output : out_channel -> t -> unit
+  val print : Format.formatter -> t -> unit
+  val to_string : t -> string
+  val of_list : elt list -> t
+  val map : (elt -> elt) -> t -> t
+  val fixpoint : (elt -> t) -> t -> t
+  val union_list : t list -> t
+  val intersection_is_empty : t -> t -> bool
+end
+
+module type Map = sig
+  module T : Map.OrderedType
+  include Map.S with type key = T.t
+
+  module Set : Set with module T := T
+
+  val print_debug :
+    (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
+
+  val of_list : (key * 'a) list -> 'a t
+
+  val disjoint_union :
+    ?eq:('a -> 'a -> bool) -> ?print:(Format.formatter -> 'a -> unit) -> 'a t ->
+    'a t -> 'a t
+
+  val union_right : 'a t -> 'a t -> 'a t
+
+  val union_left : 'a t -> 'a t -> 'a t
+
+  val union_merge : ('a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
+  val rename : key t -> key -> key
+  val map_keys : (key -> key) -> 'a t -> 'a t
+  val keys : 'a t -> Set.t
+  val data : 'a t -> 'a list
+  val of_set : (key -> 'a) -> Set.t -> 'a t
+  val transpose_keys_and_data : key t -> key t
+  val transpose_keys_and_data_set : key t -> Set.t t
+  val print :
+    (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
+  val diff_domains : 'a t -> 'a t -> 'a t
+  val fold2_stop_on_key_mismatch
+      : (key -> 'a -> 'a -> 'b -> 'b)
+        -> 'a t
+        -> 'a t
+        -> 'b
+        -> 'b option
+  val inter : (key -> 'a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
+  val inter_domain_is_non_empty : 'a t -> 'a t -> bool
+end
+
+module type Tbl = sig
+  module T : sig
+    type t
+    include Map.OrderedType with type t := t
+    include Hashtbl.HashedType with type t := t
+  end
+  include Hashtbl.S with type key = T.t
+
+  module Map : Map with module T := T
+
+  val to_list : 'a t -> (T.t * 'a) list
+  val of_list : (T.t * 'a) list -> 'a t
+
+  val to_map : 'a t -> 'a Map.t
+  val of_map : 'a Map.t -> 'a t
+  val memoize : 'a t -> (key -> 'a) -> key -> 'a
+  val map : 'a t -> ('a -> 'b) -> 'b t
+end
+
+module Pair (A : Thing) (B : Thing) : Thing with type t = A.t * B.t = struct
+  type t = A.t * B.t
+
+  let compare (a1, b1) (a2, b2) =
+    let c = A.compare a1 a2 in
+    if c <> 0 then c
+    else B.compare b1 b2
+
+  let output oc (a, b) = Printf.fprintf oc " (%a, %a)" A.output a B.output b
+  let hash (a, b) = Hashtbl.hash (A.hash a, B.hash b)
+  let equal (a1, b1) (a2, b2) = A.equal a1 a2 && B.equal b1 b2
+  let print ppf (a, b) = Format.fprintf ppf " (%a, @ %a)" A.print a B.print b
+end
+
+module Make_map (T : Thing) (Set : Set with module T := T) = struct
+  include (Map.Make [@inlined hint]) (T)
+
+  module Set = Set
+
+  let of_list l =
+    List.fold_left (fun map (id, v) -> add id v map) empty l
+
+  let disjoint_union ?eq ?print m1 m2 =
+    ignore print;
+    union (fun _id v1 v2 ->
+        let ok = match eq with
+          | None -> false
+          | Some eq -> eq v1 v2
+        in
+        if not ok then
+(*
+          let _err =
+            match print with
+            | None ->
+              Format.asprintf "Map.disjoint_union %a" T.print id
+            | Some print ->
+              Format.asprintf "Map.disjoint_union %a => %a <> %a"
+                T.print id print v1 print v2
+          in
+*)
+          invalid_arg "disjoint_union"
+        else Some v1)
+      m1 m2
+
+  let union_right m1 m2 =
+    merge (fun _id x y -> match x, y with
+        | None, None -> None
+        | None, Some v
+        | Some v, None
+        | Some _, Some v -> Some v)
+      m1 m2
+
+  let union_left m1 m2 = union_right m2 m1
+
+  let union_merge f m1 m2 =
+    let aux _ m1 m2 =
+      match m1, m2 with
+      | None, m | m, None -> m
+      | Some m1, Some m2 -> Some (f m1 m2)
+    in
+    merge aux m1 m2
+
+  let rename m v =
+    try find v m
+    with Not_found -> v
+
+  let map_keys f m =
+    of_list (List.map (fun (k, v) -> f k, v) (bindings m))
+
+  let print print_datum ppf t =
+    Misc.print_assoc T.print print_datum ppf (bindings t)
+
+  let print_debug = print
+
+  let keys map = fold (fun k _ set -> Set.add k set) map Set.empty
+
+  let data t = List.map snd (bindings t)
+
+  let of_set f set = Set.fold (fun e map -> add e (f e) map) set empty
+
+  let transpose_keys_and_data map = fold (fun k v m -> add v k m) map empty
+  let transpose_keys_and_data_set map =
+    fold (fun k v m ->
+        let set =
+          match find v m with
+          | exception Not_found ->
+            Set.singleton k
+          | set ->
+            Set.add k set
+        in
+        add v set m)
+      map empty
+
+  let diff_domains t1 t2 =
+    merge (fun _key datum1 datum2 ->
+        match datum1, datum2 with
+        | None, None -> None
+        | Some datum1, None -> Some datum1
+        | None, Some _datum2 -> None
+        | Some _datum1, Some _datum2 -> None)
+      t1 t2
+
+  let fold2_stop_on_key_mismatch f t1 t2 init =
+    (* CR mshinwell: Provide a proper implementation *)
+    if cardinal t1 <> cardinal t2 then None
+    else
+      let t1 = bindings t1 in
+      let t2 = bindings t2 in
+      List.fold_left2 (fun acc (key1, datum1) (key2, datum2) ->
+          match acc with
+          | None -> None
+          | Some acc ->
+             if T.compare key1 key2 <> 0 then None
+             else Some (f key1 datum1 datum2 acc))
+        (Some init) t1 t2
+
+  let inter f t1 t2 =
+    merge (fun key datum1_opt datum2_opt ->
+        match datum1_opt, datum2_opt with
+        | None, None | None, Some _ | Some _, None -> None
+        | Some datum1, Some datum2 -> Some (f key datum1 datum2))
+      t1 t2
+
+  let inter_domain_is_non_empty _ _ = Misc.fatal_error "Not yet implemented"
+end [@@@inline always]
+
+module Make_set (T : Thing) = struct
+  module T0 = struct
+    include (Set.Make [@inlined hint]) (T)
+
+    let output oc s =
+      Printf.fprintf oc " ( ";
+      iter (fun v -> Printf.fprintf oc "%a " T.output v) s;
+      Printf.fprintf oc ")"
+
+    let print ppf s =
+      let elts ppf s = iter (fun e -> Format.fprintf ppf "@ %a" T.print e) s in
+      Format.fprintf ppf "@[<1>{@[%a@ @]}@]" elts s
+
+    let to_string s = Format.asprintf "%a" print s
+
+    let of_list l = match l with
+      | [] -> empty
+      | [t] -> singleton t
+      | t :: q -> List.fold_left (fun acc e -> add e acc) (singleton t) q
+
+    let map f s = of_list (List.map f (elements s))
+  end
+
+  include T0
+
+  let rec union_list ts =
+    match ts with
+    | [] -> empty
+    | t::ts -> union t (union_list ts)
+
+  let intersection_is_empty t1 t2 = is_empty (inter t1 t2)
+
+  let fixpoint f set =
+    let rec aux acc set =
+      if is_empty set then acc else
+        let set' = fold (fun x -> union (f x)) set empty in
+        let acc = union acc set in
+        aux acc (diff set' acc)
+    in
+    aux empty set
+end [@@@inline always]
+
+module Make_tbl (T : Thing) (Map : Map with module T := T) = struct
+  include (Hashtbl.Make [@inlined hint]) (T)
+
+  module Map = Map
+
+  let to_list t =
+    fold (fun key datum elts -> (key, datum)::elts) t []
+
+  let of_list elts =
+    let t = create 42 in
+    List.iter (fun (key, datum) -> add t key datum) elts;
+    t
+
+  let to_map v = fold Map.add v Map.empty
+
+  let of_map m =
+    let t = create (Map.cardinal m) in
+    Map.iter (fun k v -> add t k v) m;
+    t
+
+  let memoize t f = fun key ->
+    try find t key with
+    | Not_found ->
+      let r = f key in
+      add t key r;
+      r
+
+  let map t f =
+    of_map (Map.map f (to_map t))
+end [@@@inline always]
+
+module type S = sig
+  type t
+
+  module T : Thing with type t = t
+  include Thing with type t := T.t
+
+  module Set : Set with module T := T
+  module Map : Map with module T := T with module Set = Set
+  module Tbl : Tbl with module T := T with module Map = Map
+end
+
+module Make (T : Thing) = struct
+  module T = T
+  include T
+
+  module Set = Make_set (T)
+  module Map = Make_map (T) (Set)
+  module Tbl = Make_tbl (T) (Map)
+end [@@@inline always]
+
+module Make_pair (T1 : S) (T2 : S) = struct
+  module Pair = Pair (T1.T) (T2.T)
+
+  include Make (Pair)
+
+  let create_from_cross_product t1_set t2_set =
+    T1.Set.fold (fun t1 result ->
+        T2.Set.fold (fun t2 result ->
+            Set.add (t1, t2) result)
+          t2_set
+          result)
+      t1_set
+      Set.empty
+end

--- a/middle_end/flambda/compilenv_deps/container_types.mli
+++ b/middle_end/flambda/compilenv_deps/container_types.mli
@@ -1,0 +1,142 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Pierre Chambart, OCamlPro                        *)
+(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                                                                        *)
+(*   Copyright 2013--2016 OCamlPro SAS                                    *)
+(*   Copyright 2014--2016 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Uniform interface for common data structures over various things.
+
+  {b Warning:} this module is unstable and part of
+  {{!Compiler_libs}compiler-libs}.
+
+*)
+
+module type Thing = sig
+  type t
+
+  include Hashtbl.HashedType with type t := t
+  include Map.OrderedType with type t := t
+
+  val output : out_channel -> t -> unit
+  val print : Format.formatter -> t -> unit
+end
+
+module Pair : functor (A : Thing) (B : Thing) -> Thing with type t = A.t * B.t
+
+module type Set = sig
+  module T : Set.OrderedType
+  include Set.S
+    with type elt = T.t
+
+  val output : out_channel -> t -> unit
+  val print : Format.formatter -> t -> unit
+  val to_string : t -> string
+  val of_list : elt list -> t
+  val map : (elt -> elt) -> t -> t
+
+  (** [fixpoint f t] repeatedly applies [f] to every element of the set and adds
+      the results to [t], until no new elements are found *)
+  val fixpoint : (elt -> t) -> t -> t
+
+  val union_list : t list -> t
+  val intersection_is_empty : t -> t -> bool
+end
+
+module type Map = sig
+  module T : Map.OrderedType
+  include Map.S with type key = T.t
+
+  module Set : Set with module T := T
+
+  val print_debug :
+    (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
+
+  val of_list : (key * 'a) list -> 'a t
+
+  (** [disjoint_union m1 m2] contains all bindings from [m1] and
+      [m2]. If some binding is present in both and the associated
+      value is not equal, a Fatal_error is raised *)
+  val disjoint_union :
+    ?eq:('a -> 'a -> bool) -> ?print:(Format.formatter -> 'a -> unit) -> 'a t ->
+    'a t -> 'a t
+
+  (** [union_right m1 m2] contains all bindings from [m1] and [m2]. If
+      some binding is present in both, the one from [m2] is taken *)
+  val union_right : 'a t -> 'a t -> 'a t
+
+  (** [union_left m1 m2 = union_right m2 m1] *)
+  val union_left : 'a t -> 'a t -> 'a t
+
+  val union_merge : ('a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
+  val rename : key t -> key -> key
+  val map_keys : (key -> key) -> 'a t -> 'a t
+  val keys : 'a t -> Set.t
+  val data : 'a t -> 'a list
+  val of_set : (key -> 'a) -> Set.t -> 'a t
+  val transpose_keys_and_data : key t -> key t
+  val transpose_keys_and_data_set : key t -> Set.t t
+  val print :
+    (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
+
+  val diff_domains : 'a t -> 'a t -> 'a t
+  val fold2_stop_on_key_mismatch
+      : (key -> 'a -> 'a -> 'b -> 'b)
+        -> 'a t
+        -> 'a t
+        -> 'b
+        -> 'b option
+
+  val inter : (key -> 'a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
+  val inter_domain_is_non_empty : 'a t -> 'a t -> bool
+end
+
+module type Tbl = sig
+  module T : sig
+    type t
+    include Map.OrderedType with type t := t
+    include Hashtbl.HashedType with type t := t
+  end
+  include Hashtbl.S with type key = T.t
+
+  module Map : Map with module T := T
+
+  val to_list : 'a t -> (T.t * 'a) list
+  val of_list : (T.t * 'a) list -> 'a t
+
+  val to_map : 'a t -> 'a Map.t
+  val of_map : 'a Map.t -> 'a t
+  val memoize : 'a t -> (key -> 'a) -> key -> 'a
+  val map : 'a t -> ('a -> 'b) -> 'b t
+end
+
+module Make_tbl (T : Thing) (Map : Map with module T := T)
+  : Tbl with module T := T with module Map = Map
+
+module type S = sig
+  type t
+
+  module T : Thing with type t = t
+  include Thing with type t := T.t
+
+  module Set : Set with module T := T
+  module Map : Map with module T := T with module Set = Set
+  module Tbl : Tbl with module T := T with module Map = Map
+end
+
+module Make (T : Thing) : S with type t := T.t
+
+module Make_pair (T1 : S) (T2 : S) : sig
+  include S with type t := T1.t * T2.t
+
+  val create_from_cross_product : T1.Set.t -> T2.Set.t -> Set.t
+end

--- a/middle_end/flambda/compilenv_deps/linkage_name.ml
+++ b/middle_end/flambda/compilenv_deps/linkage_name.ml
@@ -18,7 +18,7 @@
 
 type t = string
 
-include Identifiable.Make (struct
+include Container_types.Make (struct
   include String
   let hash = Hashtbl.hash
   let print ppf t = Format.pp_print_string ppf t

--- a/middle_end/flambda/compilenv_deps/linkage_name.mli
+++ b/middle_end/flambda/compilenv_deps/linkage_name.mli
@@ -16,7 +16,7 @@
 
 [@@@ocaml.warning "+a-4-9-30-40-41-42"]
 
-include Identifiable.S
+include Container_types.S
 
 val create : string -> t
 val to_string : t -> string

--- a/middle_end/flambda/compilenv_deps/numeric_types.ml
+++ b/middle_end/flambda/compilenv_deps/numeric_types.ml
@@ -14,7 +14,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-module Int_base = Identifiable.Make (struct
+module Int_base = Container_types.Make (struct
   type t = int
 
   let compare = Int.compare
@@ -76,7 +76,7 @@ end
 module Float = struct
   type t = float
 
-  include Identifiable.Make (struct
+  include Container_types.Make (struct
     type t = float
 
     let compare x y = Stdlib.compare x y
@@ -112,11 +112,11 @@ module Float_by_bit_pattern = struct
 
   include T0
 
-  module Self = Identifiable.Make (T0)
+  module Self = Container_types.Make (T0)
   include Self
 
   module Pair = struct
-    include Identifiable.Make_pair
+    include Container_types.Make_pair
       (struct type nonrec t = t include Self end)
       (struct type nonrec t = t include Self end)
 
@@ -169,11 +169,11 @@ module Int32 = struct
     let output chan t = Printf.fprintf chan "%ld" t
   end
 
-  module Self = Identifiable.Make (T0)
+  module Self = Container_types.Make (T0)
   include Self
 
   module Pair = struct
-    include Identifiable.Make_pair
+    include Container_types.Make_pair
       (struct type nonrec t = t include Self end)
       (struct type nonrec t = t include Self end)
 
@@ -198,11 +198,11 @@ module Int64 = struct
     let output chan t = Printf.fprintf chan "%Ld" t
   end
 
-  module Self = Identifiable.Make (T0)
+  module Self = Container_types.Make (T0)
   include Self
 
   module Pair = struct
-    include Identifiable.Make_pair
+    include Container_types.Make_pair
       (struct type nonrec t = t include Self end)
       (struct type nonrec t = t include Self end)
 

--- a/middle_end/flambda/compilenv_deps/numeric_types.mli
+++ b/middle_end/flambda/compilenv_deps/numeric_types.mli
@@ -14,7 +14,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Modules about numbers, some of which satisfy {!Identifiable.S}.
+(** Modules about numbers, some of which satisfy {!Container_types.S}.
 
   {b Warning:} this module is unstable and part of
   {{!Compiler_libs}compiler-libs}.
@@ -22,7 +22,7 @@
 *)
 
 module Int : sig
-  include Identifiable.S with type t = int
+  include Container_types.S with type t = int
 
   (** [zero_to_n n] is the set of numbers \{0, ..., n\} (inclusive). *)
   val zero_to_n : int -> Set.t
@@ -48,7 +48,7 @@ module Int16 : sig
   val to_int : t -> int
 end
 
-module Float : Identifiable.S with type t = float
+module Float : Container_types.S with type t = float
 
 module Float_by_bit_pattern : sig
   (** Floating point numbers whose comparison and equality relations are
@@ -61,7 +61,7 @@ module Float_by_bit_pattern : sig
       depending on which semantics you want.  Likewise for equality.
   *)
 
-  include Identifiable.S
+  include Container_types.S
 
   val create : float -> t
 
@@ -91,29 +91,29 @@ module Float_by_bit_pattern : sig
     val equal : t -> t -> bool
   end
 
-  module Pair : Identifiable.S with type t = t * t
+  module Pair : Container_types.S with type t = t * t
 
   val cross_product : Set.t -> Set.t -> Pair.Set.t
 end
 
 module Int32 : sig
   include module type of struct include Int32 end
-  include Identifiable.S with type t := Int32.t
+  include Container_types.S with type t := Int32.t
 
   val swap_byte_endianness : t -> t
 
-  module Pair : Identifiable.S with type t = t * t
+  module Pair : Container_types.S with type t = t * t
 
   val cross_product : Set.t -> Set.t -> Pair.Set.t
 end
 
 module Int64 : sig
   include module type of struct include Int64 end
-  include Identifiable.S with type t := Int64.t
+  include Container_types.S with type t := Int64.t
 
   val swap_byte_endianness : t -> t
 
-  module Pair : Identifiable.S with type t = t * t
+  module Pair : Container_types.S with type t = t * t
 
   val cross_product : Set.t -> Set.t -> Pair.Set.t
 end

--- a/middle_end/flambda/compilenv_deps/patricia_tree.ml
+++ b/middle_end/flambda/compilenv_deps/patricia_tree.ml
@@ -443,7 +443,7 @@ end) = struct
 
   let fixpoint _ _ = Misc.fatal_error "fixpoint not yet implemented"
 
-  (* CR mshinwell: copied from [Identifiable] *)
+  (* CR mshinwell: copied from [Container_types] *)
 
   let output _ _ = Misc.fatal_error "output not yet implemented"
 
@@ -474,7 +474,7 @@ end [@@@inline always]
 
 module Make_map (Key : sig
   val print : Format.formatter -> int -> unit
-end) (Set : Identifiable.Set with module T := Numeric_types.Int) =
+end) (Set : Container_types.Set with module T := Numeric_types.Int) =
 struct
   type key = int
 
@@ -1108,7 +1108,7 @@ struct
 
   let of_seq _ = Misc.fatal_error "of_seq not yet implemented"
 
-  (* CR mshinwell: copied from [Identifiable] *)
+  (* CR mshinwell: copied from [Container_types] *)
 
   let filter_map f t =
     fold (fun id v map ->

--- a/middle_end/flambda/compilenv_deps/patricia_tree.mli
+++ b/middle_end/flambda/compilenv_deps/patricia_tree.mli
@@ -17,14 +17,14 @@
 module Make_set (_ : sig
   val print : Format.formatter -> int -> unit
 end) : sig
-  include Identifiable.Set
+  include Container_types.Set
     with module T := Numeric_types.Int
 end
 
 module Make_map (_ : sig
   val print : Format.formatter -> int -> unit
-end) (Set : Identifiable.Set with module T := Numeric_types.Int) : sig
-  include Identifiable.Map
+end) (Set : Container_types.Set with module T := Numeric_types.Int) : sig
+  include Container_types.Map
     with module T := Numeric_types.Int
     with module Set = Set
 end

--- a/middle_end/flambda/compilenv_deps/rec_info.ml
+++ b/middle_end/flambda/compilenv_deps/rec_info.ml
@@ -15,7 +15,7 @@
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 type t = unit
 
-include Identifiable.Make (struct
+include Container_types.Make (struct
   type nonrec t = t
 
   let print ppf () =

--- a/middle_end/flambda/compilenv_deps/rec_info.mli
+++ b/middle_end/flambda/compilenv_deps/rec_info.mli
@@ -15,7 +15,7 @@
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 type t
 
-include Identifiable.S with type t := t
+include Container_types.S with type t := t
 
 val initial : t
 

--- a/middle_end/flambda/compilenv_deps/reg_width_things.ml
+++ b/middle_end/flambda/compilenv_deps/reg_width_things.ml
@@ -36,7 +36,7 @@ module Const_data = struct
 
   let flags = const_flags
 
-  include Identifiable.Make (struct
+  include Container_types.Make (struct
     type nonrec t = t
 
     let print ppf (t : t) =
@@ -309,7 +309,7 @@ module Const = struct
   module Set = Patricia_tree.Make_set (struct let print = print end)
   module Map = Patricia_tree.Make_map (struct let print = print end) (Set)
   (* CR mshinwell: The [Tbl]s will still print integers! *)
-  module Tbl = Identifiable.Make_tbl (Numeric_types.Int) (Map)
+  module Tbl = Container_types.Make_tbl (Numeric_types.Int) (Map)
 
   let export t = find_data t
 
@@ -383,7 +383,7 @@ module Variable = struct
 
   module Set = Patricia_tree.Make_set (struct let print = print end)
   module Map = Patricia_tree.Make_map (struct let print = print end) (Set)
-  module Tbl = Identifiable.Make_tbl (Numeric_types.Int) (Map)
+  module Tbl = Container_types.Make_tbl (Numeric_types.Int) (Map)
 
   let export t = find_data t
 
@@ -455,7 +455,7 @@ module Symbol = struct
 
   module Set = Patricia_tree.Make_set (struct let print = print end)
   module Map = Patricia_tree.Make_map (struct let print = print end) (Set)
-  module Tbl = Identifiable.Make_tbl (Numeric_types.Int) (Map)
+  module Tbl = Container_types.Make_tbl (Numeric_types.Int) (Map)
 
   let export t = find_data t
 
@@ -502,7 +502,7 @@ module Name = struct
 
   module Set = Patricia_tree.Make_set (struct let print = print end)
   module Map = Patricia_tree.Make_map (struct let print = print end) (Set)
-  module Tbl = Identifiable.Make_tbl (Numeric_types.Int) (Map)
+  module Tbl = Container_types.Make_tbl (Numeric_types.Int) (Map)
 end
 
 module Simple = struct
@@ -604,7 +604,7 @@ module Simple = struct
 
   module Set = Patricia_tree.Make_set (struct let print = print end)
   module Map = Patricia_tree.Make_map (struct let print = print end) (Set)
-  module Tbl = Identifiable.Make_tbl (Numeric_types.Int) (Map)
+  module Tbl = Container_types.Make_tbl (Numeric_types.Int) (Map)
 
   let export t = find_data t
 

--- a/middle_end/flambda/compilenv_deps/reg_width_things.mli
+++ b/middle_end/flambda/compilenv_deps/reg_width_things.mli
@@ -23,7 +23,7 @@ module Const : sig
   type t = private Table_by_int_id.Id.t
   type exported
 
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
 
   val const_true : t
   val const_false : t
@@ -61,7 +61,7 @@ module Const : sig
       | Naked_int64 of Int64.t
       | Naked_nativeint of Targetint_32_64.t
 
-    include Identifiable.S with type t := t
+    include Container_types.S with type t := t
   end
 
   val descr : t -> Descr.t
@@ -78,7 +78,7 @@ module Variable : sig
   type t = private Table_by_int_id.Id.t
   type exported
 
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
 
   val create : ?user_visible:unit -> string -> t
 
@@ -102,7 +102,7 @@ module Symbol : sig
   type t = private Table_by_int_id.Id.t
   type exported
 
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
 
   val create : Compilation_unit.t -> Linkage_name.t -> t
 
@@ -125,7 +125,7 @@ end
 module Name : sig
   type t = private Table_by_int_id.Id.t
 
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
 
   val var : Variable.t -> t
 
@@ -142,7 +142,7 @@ module Simple : sig
   type t = private Table_by_int_id.Id.t
   type exported
 
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
 
   val name : Name.t -> t
 

--- a/middle_end/flambda/compilenv_deps/strongly_connected_components_flambda2.ml
+++ b/middle_end/flambda/compilenv_deps/strongly_connected_components_flambda2.ml
@@ -108,7 +108,7 @@ end = struct
 end
 
 module type S = sig
-  module Id : Identifiable.S
+  module Id : Container_types.S
 
   type directed_graph = Id.Set.t Id.Map.t
 
@@ -123,7 +123,7 @@ module type S = sig
   val component_graph : directed_graph -> (component * int list) array
 end
 
-module Make (Id : Identifiable.S) = struct
+module Make (Id : Container_types.S) = struct
   type directed_graph = Id.Set.t Id.Map.t
 
   type component =

--- a/middle_end/flambda/compilenv_deps/strongly_connected_components_flambda2.mli
+++ b/middle_end/flambda/compilenv_deps/strongly_connected_components_flambda2.mli
@@ -22,7 +22,7 @@
 *)
 
 module type S = sig
-  module Id : Identifiable.S
+  module Id : Container_types.S
 
   type directed_graph = Id.Set.t Id.Map.t
   (** If (a -> set) belongs to the map, it means that there are edges
@@ -40,4 +40,4 @@ module type S = sig
   val component_graph : directed_graph -> (component * int list) array
 end
 
-module Make (Id : Identifiable.S) : S with module Id := Id
+module Make (Id : Container_types.S) : S with module Id := Id

--- a/middle_end/flambda/compilenv_deps/tag.ml
+++ b/middle_end/flambda/compilenv_deps/tag.ml
@@ -19,7 +19,7 @@
 type t = int
 type tag = t
 
-include Identifiable.Make (struct
+include Container_types.Make (struct
   type nonrec t = t
 
   let compare = Numeric_types.Int.compare
@@ -78,7 +78,7 @@ let arbitrary = max_int
 module Scannable = struct
   type nonrec t = t
 
-  include Identifiable.Make (Numeric_types.Int)
+  include Container_types.Make (Numeric_types.Int)
 
   let create tag =
     if tag < min_tag || tag >= Obj.no_scan_tag then None
@@ -118,7 +118,7 @@ let is_structured_block t =
 module Non_scannable = struct
   type nonrec t = t
 
-  include Identifiable.Make (Numeric_types.Int)
+  include Container_types.Make (Numeric_types.Int)
 
   let create tag =
     if tag < Obj.no_scan_tag then None

--- a/middle_end/flambda/compilenv_deps/tag.mli
+++ b/middle_end/flambda/compilenv_deps/tag.mli
@@ -18,7 +18,7 @@
 
 (** Tags on runtime boxed values. *)
 
-include Identifiable.S
+include Container_types.S
 
 type tag = t
 
@@ -82,7 +82,7 @@ module Scannable : sig
   val zero : t
   val object_tag : t
 
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
 end
 
 val to_scannable_set : Set.t -> Scannable.Set.t
@@ -100,5 +100,5 @@ module Non_scannable : sig
   val to_int : t -> int
   val to_tag : t -> tag
 
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
 end

--- a/middle_end/flambda/compilenv_deps/targetint_31_63.ml
+++ b/middle_end/flambda/compilenv_deps/targetint_31_63.ml
@@ -144,7 +144,7 @@ module Imm = struct
   end
 
   include One_bit_fewer.Make (T0)
-  include Identifiable.Make (T0)
+  include Container_types.Make (T0)
 
   let to_string t = Format.asprintf "%a" print t
 end
@@ -182,12 +182,12 @@ module T0 = struct
   let output chan t = print (Format.formatter_of_out_channel chan) t
 end
 
-module Self = Identifiable.Make (T0)
+module Self = Container_types.Make (T0)
 include Self
 
 module Pair = struct
   include
-    Identifiable.Make_pair
+    Container_types.Make_pair
       (struct
         type nonrec t = t
 

--- a/middle_end/flambda/compilenv_deps/targetint_31_63.mli
+++ b/middle_end/flambda/compilenv_deps/targetint_31_63.mli
@@ -178,7 +178,7 @@ module Imm : sig
 
   (* CR mshinwell: Add an [Array] module *)
 
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
 
   val to_string : t -> string
 end
@@ -195,7 +195,7 @@ type t = private
 type immediate = t
 
 (** The comparison function for type [t] ignores [print_as_char]. *)
-include Identifiable.S with type t := t
+include Container_types.S with type t := t
 
 val one : t
 
@@ -264,7 +264,7 @@ val zero_one_and_minus_one : Set.t
 module Pair : sig
   type nonrec t = t * t
 
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
 end
 
 val cross_product : Set.t -> Set.t -> Pair.Set.t

--- a/middle_end/flambda/compilenv_deps/targetint_32_64.ml
+++ b/middle_end/flambda/compilenv_deps/targetint_32_64.ml
@@ -31,7 +31,7 @@ module type S = sig
   val num_bits : num_bits
   val repr: t -> repr
 
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
 
   val zero : t
   val one : t
@@ -54,7 +54,7 @@ module type S = sig
 
   module Pair : sig
     type nonrec t = t * t
-    include Identifiable.S with type t := t
+    include Container_types.S with type t := t
   end
 
   val cross_product : Set.t -> Set.t -> Pair.Set.t
@@ -123,7 +123,7 @@ module Int32 = struct
   let to_int64 = Int64.of_int32
   let repr x = Int32 x
 
-  include Identifiable.Make (struct
+  include Container_types.Make (struct
     type nonrec t = t
     let compare = Int32.compare
     let equal = Int32.equal
@@ -144,9 +144,9 @@ module Int32 = struct
   module Pair = struct
     type nonrec t = t * t
 
-    module T_pair = Identifiable.Pair (T) (T)
+    module T_pair = Container_types.Pair (T) (T)
 
-    include Identifiable.Make (T_pair)
+    include Container_types.Make (T_pair)
   end
 
   let cross_product set1 set2 =
@@ -186,7 +186,7 @@ module Int64 = struct
   let max t1 t2 =
     if compare t1 t2 <= 0 then t2 else t1
 
-  include Identifiable.Make (struct
+  include Container_types.Make (struct
     type nonrec t = t
     let compare = Int64.compare
     let equal t1 t2 = (compare t1 t2 = 0)
@@ -201,9 +201,9 @@ module Int64 = struct
   module Pair = struct
     type nonrec t = t * t
 
-    module T_pair = Identifiable.Pair (T) (T)
+    module T_pair = Container_types.Pair (T) (T)
 
-    include Identifiable.Make (T_pair)
+    include Container_types.Make (T_pair)
   end
 
   let cross_product set1 set2 =

--- a/middle_end/flambda/compilenv_deps/targetint_32_64.mli
+++ b/middle_end/flambda/compilenv_deps/targetint_32_64.mli
@@ -219,14 +219,14 @@ val get_least_significant_16_bits_then_byte_swap : t -> t
 
 val swap_byte_endianness : t -> t
 
-include Identifiable.S with type t := t
+include Container_types.S with type t := t
 
 module Targetint_set = Set
 
 module Pair : sig
   type nonrec t = t * t
 
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
 end
 
 val cross_product : Set.t -> Set.t -> Pair.Set.t

--- a/middle_end/flambda/naming/bindable.ml
+++ b/middle_end/flambda/naming/bindable.ml
@@ -22,7 +22,7 @@
 module type S = sig
   type t
 
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
   include Contains_names.S with type t := t
   include Contains_ids.S with type t := t
 

--- a/middle_end/flambda/naming/bindable_let_bound.ml
+++ b/middle_end/flambda/naming/bindable_let_bound.ml
@@ -29,7 +29,7 @@ type t =
   (* CR mshinwell: Add a case here for let-code and move it out of
      Symbols *)
 
-include Identifiable.Make (struct
+include Container_types.Make (struct
   type nonrec t = t
 
   let print ppf t =

--- a/middle_end/flambda/naming/name_in_binding_pos.ml
+++ b/middle_end/flambda/naming/name_in_binding_pos.ml
@@ -48,7 +48,7 @@ let to_name t = t.name
 
 let to_simple t = Simple.name t.name
 
-include Identifiable.Make (struct
+include Container_types.Make (struct
   type nonrec t = t
 
   let print ppf { name; name_mode; } =

--- a/middle_end/flambda/naming/name_in_binding_pos.mli
+++ b/middle_end/flambda/naming/name_in_binding_pos.mli
@@ -41,4 +41,4 @@ val rename : t -> t
 
 val is_symbol : t -> bool
 
-include Identifiable.S with type t := t
+include Container_types.S with type t := t

--- a/middle_end/flambda/naming/name_mode.ml
+++ b/middle_end/flambda/naming/name_mode.ml
@@ -92,7 +92,7 @@ let compare_partial_order t1 t2 =
   | Phantom, In_types
   | In_types, Phantom -> None
 
-include Identifiable.Make (struct
+include Container_types.Make (struct
   type nonrec t = t
 
   let print ppf t =
@@ -138,7 +138,7 @@ module Or_absent = struct
     | Absent -> false
     | Present _ -> true
 
-  include Identifiable.Make (struct
+  include Container_types.Make (struct
     type nonrec t = t
 
     let print ppf t =

--- a/middle_end/flambda/naming/name_mode.mli
+++ b/middle_end/flambda/naming/name_mode.mli
@@ -44,7 +44,7 @@ val can_be_in_terms : t -> bool
 
 val max_in_terms : t -> t -> t
 
-include Identifiable.S with type t := t
+include Container_types.S with type t := t
 
 val compare_total_order : t -> t -> int
 val compare_partial_order : t -> t -> int option
@@ -73,7 +73,7 @@ module Or_absent : sig
 
   val is_present : t -> bool
 
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
 
   val compare_total_order : t -> t -> int
   val compare_partial_order : t -> t -> int option

--- a/middle_end/flambda/naming/name_occurrences.ml
+++ b/middle_end/flambda/naming/name_occurrences.ml
@@ -21,7 +21,7 @@
 module Kind = Name_mode
 
 module For_one_variety_of_names (N : sig
-  include Identifiable.S
+  include Container_types.S
   val apply_renaming : t -> Renaming.t -> t
 end) : sig
   type t

--- a/middle_end/flambda/naming/permutation.ml
+++ b/middle_end/flambda/naming/permutation.ml
@@ -18,7 +18,7 @@
 
 let check_invariants = false
 
-module Make (N : Identifiable.S) = struct
+module Make (N : Container_types.S) = struct
   type t = {
     forwards : N.t N.Map.t;
     backwards : N.t N.Map.t;

--- a/middle_end/flambda/naming/permutation.mli
+++ b/middle_end/flambda/naming/permutation.mli
@@ -18,7 +18,7 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
-module Make (N : Identifiable.S) : sig
+module Make (N : Container_types.S) : sig
   type t
 
   val empty : t

--- a/middle_end/flambda/naming/var_in_binding_pos.ml
+++ b/middle_end/flambda/naming/var_in_binding_pos.ml
@@ -41,7 +41,7 @@ let apply_renaming t perm =
 let free_names t =
   Name_occurrences.singleton_variable t.var t.name_mode
 
-include Identifiable.Make (struct
+include Container_types.Make (struct
   type nonrec t = t
 
 (*

--- a/middle_end/flambda/naming/var_in_binding_pos.mli
+++ b/middle_end/flambda/naming/var_in_binding_pos.mli
@@ -30,5 +30,5 @@ val rename : t -> t
 
 val with_name_mode : t -> Name_mode.t -> t
 
-include Identifiable.S with type t := t
+include Container_types.S with type t := t
 include Contains_names.S with type t := t

--- a/middle_end/flambda/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda/parser/flambda_to_fexpr.ml
@@ -4,7 +4,7 @@ module type Convertible_id = sig
   type t
   type fexpr_id
 
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
 
   val desc : string
 

--- a/middle_end/flambda/simplify/common_subexpression_elimination.ml
+++ b/middle_end/flambda/simplify/common_subexpression_elimination.ml
@@ -75,7 +75,7 @@ module Rhs_kind : sig
 
   val bound_to : t -> Simple.t
 
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
 end = struct
   type t =
     | Needs_extra_binding of { bound_to : Simple.t; }
@@ -86,7 +86,7 @@ end = struct
     | Needs_extra_binding { bound_to; }
     | Rhs_in_scope { bound_to; } -> bound_to
 
-  include Identifiable.Make (struct
+  include Container_types.Make (struct
     type nonrec t = t
 
     let print ppf t =

--- a/middle_end/flambda/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda/simplify/simplify_binary_primitive.ml
@@ -30,10 +30,10 @@ type 'a binary_arith_outcome_for_one_side_only =
   | Invalid
 
 module type Binary_arith_like_sig = sig
-  module Lhs : Identifiable.S
-  module Rhs : Identifiable.S
-  module Pair : Identifiable.S with type t = Lhs.t * Rhs.t
-  module Result : Identifiable.S
+  module Lhs : Container_types.S
+  module Rhs : Container_types.S
+  module Pair : Container_types.S with type t = Lhs.t * Rhs.t
+  module Result : Container_types.S
 
   val ok_to_evaluate : DE.t -> bool
 
@@ -85,7 +85,7 @@ end = struct
       | Prim of P.t
       | Exactly of N.Result.t
 
-    include Identifiable.Make (struct
+    include Container_types.Make (struct
       type nonrec t = t
 
       let compare t1 t2 =
@@ -418,7 +418,7 @@ end = struct
      the stdlib *)
   module Pair = struct
     type nonrec t = Lhs.t * Rhs.t
-    include Identifiable.Make_pair (Lhs) (Rhs)
+    include Container_types.Make_pair (Lhs) (Rhs)
   end
 
   let cross_product set1 set2 =

--- a/middle_end/flambda/simplify/typing_helpers/number_adjuncts.ml
+++ b/middle_end/flambda/simplify/typing_helpers/number_adjuncts.ml
@@ -26,12 +26,12 @@ module Int32 = Numeric_types.Int32
 module Int64 = Numeric_types.Int64
 
 module type Num_common = sig
-  include Identifiable.S
+  include Container_types.S
 
   module Pair : sig
     type nonrec t = t * t
 
-    include Identifiable.S with type t := t
+    include Container_types.S with type t := t
   end
 
   val cross_product : Set.t -> Set.t -> Pair.Set.t
@@ -56,7 +56,7 @@ module type Num_common = sig
 end
 
 module type Number_kind_common = sig
-  module Num : Identifiable.S
+  module Num : Container_types.S
 
   val kind : K.Standard_int_or_float.t
 
@@ -97,7 +97,7 @@ module type Int_number_kind = sig
 end
 
 module type Boxable = sig
-  module Num : Identifiable.S
+  module Num : Container_types.S
 
   val boxable_number_kind : K.Boxable_number.t
 

--- a/middle_end/flambda/simplify/typing_helpers/number_adjuncts.mli
+++ b/middle_end/flambda/simplify/typing_helpers/number_adjuncts.mli
@@ -21,11 +21,11 @@
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
 module type Num_common = sig
-  include Identifiable.S
+  include Container_types.S
 
   module Pair : sig
     type nonrec t = t * t
-    include Identifiable.S with type t := t
+    include Container_types.S with type t := t
   end
 
   val cross_product : Set.t -> Set.t -> Pair.Set.t
@@ -50,7 +50,7 @@ module type Num_common = sig
 end
 
 module type Number_kind_common = sig
-  module Num : Identifiable.S
+  module Num : Container_types.S
 
   (* CR mshinwell: Rename to standard_int_or_float_kind? *)
   val kind : Flambda_kind.Standard_int_or_float.t
@@ -94,7 +94,7 @@ module type Int_number_kind = sig
 end
 
 module type Boxable = sig
-  module Num : Identifiable.S
+  module Num : Container_types.S
 
   val boxable_number_kind : Flambda_kind.Boxable_number.t
 

--- a/middle_end/flambda/terms/apply_cont_expr.ml
+++ b/middle_end/flambda/terms/apply_cont_expr.ml
@@ -23,7 +23,7 @@ type t = {
   dbg : Debuginfo.t;
 }
 
-include Identifiable.Make (struct
+include Container_types.Make (struct
   type nonrec t = t
 
   let print ppf { k; args; trap_action; dbg; } =

--- a/middle_end/flambda/terms/apply_cont_expr.mli
+++ b/middle_end/flambda/terms/apply_cont_expr.mli
@@ -64,4 +64,4 @@ val clear_trap_action : t -> t
 
 val to_one_arg_without_trap_action : t -> Simple.t option
 
-include Identifiable.S with type t := t
+include Container_types.S with type t := t

--- a/middle_end/flambda/terms/apply_expr.ml
+++ b/middle_end/flambda/terms/apply_expr.ml
@@ -23,7 +23,7 @@ module Result_continuation = struct
     | Return of Continuation.t
     | Never_returns
 
-  include Identifiable.Make(struct
+  include Container_types.Make(struct
       type nonrec t = t
 
       let compare h1 h2 =

--- a/middle_end/flambda/terms/apply_expr.mli
+++ b/middle_end/flambda/terms/apply_expr.mli
@@ -32,7 +32,7 @@ module Result_continuation : sig
     | Return of Continuation.t
     | Never_returns
 
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
 
   include Contains_names.S with type t := t
 

--- a/middle_end/flambda/terms/flambda.mli
+++ b/middle_end/flambda/terms/flambda.mli
@@ -500,7 +500,7 @@ end and Static_const : sig
         (** The value of the given variable. *)
 
     (** Printing, total ordering, etc. *)
-    include Identifiable.S with type t := t
+    include Container_types.S with type t := t
 
     include Contains_names.S with type t := t
   end
@@ -523,7 +523,7 @@ end and Static_const : sig
     | Mutable_string of { initial_value : string; }
     | Immutable_string of string
 
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
   include Contains_names.S with type t := t
   include Contains_ids.S with type t := t
 

--- a/middle_end/flambda/terms/flambda_primitive.ml
+++ b/middle_end/flambda/terms/flambda_primitive.ml
@@ -1477,7 +1477,7 @@ let classify_for_printing t =
   | Ternary (prim, _, _, _) -> ternary_classify_for_printing prim
   | Variadic (prim, _) -> variadic_classify_for_printing prim
 
-include Identifiable.Make (struct
+include Container_types.Make (struct
   type nonrec t = t
 
   let compare t1 t2 =
@@ -1838,7 +1838,7 @@ module Eligible_for_cse = struct
   let free_names = free_names
   let apply_renaming = apply_renaming
 
-  include Identifiable.Make (struct
+  include Container_types.Make (struct
     type nonrec t = t
 
     let compare = compare

--- a/middle_end/flambda/terms/flambda_primitive.mli
+++ b/middle_end/flambda/terms/flambda_primitive.mli
@@ -436,11 +436,11 @@ module Eligible_for_cse : sig
   val filter_map_args : t -> f:(Simple.t -> Simple.t option) -> t option
 
   (** Total ordering, equality, printing, sets, maps etc. *)
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
 end
 
 (** Total ordering, printing, sets, maps etc. *)
-include Identifiable.S with type t := t
+include Container_types.S with type t := t
 
 val equal : t -> t -> bool
 val equal_nullary_primitive : nullary_primitive -> nullary_primitive -> bool

--- a/middle_end/flambda/terms/set_of_closures.ml
+++ b/middle_end/flambda/terms/set_of_closures.ml
@@ -34,7 +34,7 @@ let print_with_cache ~cache ppf
     (Function_declarations.print_with_cache ~cache) function_decls
     (Var_within_closure.Map.print Simple.print) closure_elements
 
-include Identifiable.Make (struct
+include Container_types.Make (struct
   type nonrec t = t
 
   let print ppf t = print_with_cache ~cache:(Printing_cache.create ()) ppf t

--- a/middle_end/flambda/terms/set_of_closures.mli
+++ b/middle_end/flambda/terms/set_of_closures.mli
@@ -53,4 +53,4 @@ val filter_function_declarations
   -> f:(Closure_id.t -> Function_declaration.t -> bool)
   -> t
 
-include Identifiable.S with type t := t
+include Container_types.S with type t := t

--- a/middle_end/flambda/terms/static_const.rec.ml
+++ b/middle_end/flambda/terms/static_const.rec.ml
@@ -26,7 +26,7 @@ module Field_of_block = struct
     | Tagged_immediate of Targetint_31_63.t
     | Dynamically_computed of Variable.t
 
-  include Identifiable.Make (struct
+  include Container_types.Make (struct
     type nonrec t = t
 
     let compare t1 t2 =
@@ -177,7 +177,7 @@ let print_with_cache ~cache ppf t =
       (Flambda_colours.normal ())
       s
 
-include Identifiable.Make (struct
+include Container_types.Make (struct
   type nonrec t = t
 
   let print ppf t =

--- a/middle_end/flambda/terms/static_const.rec.mli
+++ b/middle_end/flambda/terms/static_const.rec.mli
@@ -29,7 +29,7 @@ module Field_of_block : sig
       (** The value of the given variable. *)
 
   (** Printing, total ordering, etc. *)
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
 
   include Contains_names.S with type t := t
 end
@@ -51,7 +51,7 @@ type t =
 
 type static_const = t
 
-include Identifiable.S with type t := t
+include Container_types.S with type t := t
 include Contains_names.S with type t := t
 include Contains_ids.S with type t := t
 

--- a/middle_end/flambda/types/basic/closure_id_and_var_within_closure_set.ml
+++ b/middle_end/flambda/types/basic/closure_id_and_var_within_closure_set.ml
@@ -18,4 +18,4 @@
 
 type t = Closure_id.t * Var_within_closure.Set.t
 
-include Identifiable.Make_pair (Closure_id) (Var_within_closure_set)
+include Container_types.Make_pair (Closure_id) (Var_within_closure_set)

--- a/middle_end/flambda/types/basic/closure_id_and_var_within_closure_set.mli
+++ b/middle_end/flambda/types/basic/closure_id_and_var_within_closure_set.mli
@@ -18,4 +18,4 @@
 
 type t = Closure_id.t * Var_within_closure_set.t
 
-include Identifiable.S with type t := t
+include Container_types.S with type t := t

--- a/middle_end/flambda/types/basic/closure_id_or_unknown_and_var_within_closure_set.ml
+++ b/middle_end/flambda/types/basic/closure_id_or_unknown_and_var_within_closure_set.ml
@@ -20,4 +20,4 @@ module Closure_id_or_unknown = Or_unknown.Lift (Closure_id)
 
 type t = Closure_id_or_unknown.t * Var_within_closure.Set.t
 
-include Identifiable.Make_pair (Closure_id_or_unknown) (Var_within_closure_set)
+include Container_types.Make_pair (Closure_id_or_unknown) (Var_within_closure_set)

--- a/middle_end/flambda/types/basic/closure_id_or_unknown_and_var_within_closure_set.mli
+++ b/middle_end/flambda/types/basic/closure_id_or_unknown_and_var_within_closure_set.mli
@@ -23,4 +23,4 @@ module Closure_id_or_unknown :
 
 type t = Closure_id_or_unknown.t * Var_within_closure_set.t
 
-include Identifiable.S with type t := t
+include Container_types.S with type t := t

--- a/middle_end/flambda/types/basic/closure_id_set.ml
+++ b/middle_end/flambda/types/basic/closure_id_set.ml
@@ -18,7 +18,7 @@
 
 type t = Closure_id.Set.t
 
-include Identifiable.Make (struct
+include Container_types.Make (struct
   include Closure_id.Set
   let hash = Hashtbl.hash
 end)

--- a/middle_end/flambda/types/basic/closure_id_set.mli
+++ b/middle_end/flambda/types/basic/closure_id_set.mli
@@ -18,7 +18,7 @@
 
 type t = Closure_id.Set.t
 
-include Identifiable.S with type t := t
+include Container_types.S with type t := t
 include Contains_names.S with type t := t
 
 val subset : t -> t -> bool

--- a/middle_end/flambda/types/basic/or_unknown.ml
+++ b/middle_end/flambda/types/basic/or_unknown.ml
@@ -74,10 +74,10 @@ let apply_renaming t renaming rename_contents =
   | Known contents -> Known (rename_contents contents renaming)
   | Unknown -> Unknown
 
-module Lift (I : Identifiable.S) = struct
+module Lift (I : Container_types.S) = struct
   type nonrec t = I.t t
 
-  include Identifiable.Make (struct
+  include Container_types.Make (struct
     type nonrec t = t
 
     let print ppf t = print I.print ppf t

--- a/middle_end/flambda/types/basic/or_unknown.mli
+++ b/middle_end/flambda/types/basic/or_unknown.mli
@@ -44,8 +44,8 @@ val apply_renaming
   -> ('a -> Renaming.t -> 'a)
   -> 'a t
 
-module Lift (I : Identifiable.S) : sig
+module Lift (I : Container_types.S) : sig
   type nonrec t = I.t t
 
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
 end

--- a/middle_end/flambda/types/basic/string_info.ml
+++ b/middle_end/flambda/types/basic/string_info.ml
@@ -33,7 +33,7 @@ let create ~contents ~size =
 let contents t = t.contents
 let size t = t.size
 
-include Identifiable.Make (struct
+include Container_types.Make (struct
   type nonrec t = t
 
   let compare t1 t2 =

--- a/middle_end/flambda/types/basic/string_info.mli
+++ b/middle_end/flambda/types/basic/string_info.mli
@@ -28,4 +28,4 @@ val create : contents:string_contents -> size:Targetint_31_63.Imm.t -> t
 val contents : t -> string_contents
 val size : t -> Targetint_31_63.Imm.t
 
-include Identifiable.S with type t := t
+include Container_types.S with type t := t

--- a/middle_end/flambda/types/basic/tag_and_size.ml
+++ b/middle_end/flambda/types/basic/tag_and_size.ml
@@ -18,4 +18,4 @@
 
 type t = Tag.t * Targetint_31_63.Imm.t
 
-include Identifiable.Make_pair (Tag) (Targetint_31_63.Imm)
+include Container_types.Make_pair (Tag) (Targetint_31_63.Imm)

--- a/middle_end/flambda/types/basic/tag_and_size.mli
+++ b/middle_end/flambda/types/basic/tag_and_size.mli
@@ -18,4 +18,4 @@
 
 type t = Tag.t * Targetint_31_63.Imm.t
 
-include Identifiable.S with type t := t
+include Container_types.S with type t := t

--- a/middle_end/flambda/types/basic/tag_or_unknown_and_size.ml
+++ b/middle_end/flambda/types/basic/tag_or_unknown_and_size.ml
@@ -20,4 +20,4 @@ module Tag_or_unknown = Or_unknown.Lift (Tag)
 
 type t = Tag.t Or_unknown.t * Targetint_31_63.Imm.t
 
-include Identifiable.Make_pair (Tag_or_unknown) (Targetint_31_63.Imm)
+include Container_types.Make_pair (Tag_or_unknown) (Targetint_31_63.Imm)

--- a/middle_end/flambda/types/basic/tag_or_unknown_and_size.mli
+++ b/middle_end/flambda/types/basic/tag_or_unknown_and_size.mli
@@ -16,8 +16,8 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
-module Tag_or_unknown : Identifiable.S with type t = Or_unknown.Lift (Tag).t
+module Tag_or_unknown : Container_types.S with type t = Or_unknown.Lift (Tag).t
 
 type t = Tag.t Or_unknown.t * Targetint_31_63.Imm.t
 
-include Identifiable.S with type t := t
+include Container_types.S with type t := t

--- a/middle_end/flambda/types/basic/unit.ml
+++ b/middle_end/flambda/types/basic/unit.ml
@@ -18,7 +18,7 @@
 
 type t = unit
 
-include Identifiable.Make (struct
+include Container_types.Make (struct
   type nonrec t = t
   let compare () () = 0
   let equal () () = true

--- a/middle_end/flambda/types/basic/unit.mli
+++ b/middle_end/flambda/types/basic/unit.mli
@@ -18,7 +18,7 @@
 
 type t = unit
 
-include Identifiable.S with type t := t
+include Container_types.S with type t := t
 include Contains_names.S with type t := t
 
 val subset : t -> t -> bool

--- a/middle_end/flambda/types/basic/var_within_closure_set.ml
+++ b/middle_end/flambda/types/basic/var_within_closure_set.ml
@@ -20,7 +20,7 @@ type t = Var_within_closure.Set.t
 
 let empty = Var_within_closure.Set.empty
 
-include Identifiable.Make (struct
+include Container_types.Make (struct
   include Var_within_closure.Set
   let hash = Hashtbl.hash
 end)

--- a/middle_end/flambda/types/basic/var_within_closure_set.mli
+++ b/middle_end/flambda/types/basic/var_within_closure_set.mli
@@ -25,4 +25,4 @@ val empty : t
 
 val subset : t -> t -> bool
 
-include Identifiable.S with type t := t
+include Container_types.S with type t := t

--- a/middle_end/flambda/types/env/binding_time.ml
+++ b/middle_end/flambda/types/env/binding_time.ml
@@ -28,7 +28,7 @@ type binding_time = t
 
 module Set = Patricia_tree.Make_set (T)
 module Map = Patricia_tree.Make_map (T) (Set)
-module Tbl = Identifiable.Make_tbl (T) (Map)
+module Tbl = Container_types.Make_tbl (T) (Map)
 
 let strictly_earlier (t : t) ~than =
   t < than

--- a/middle_end/flambda/types/env/binding_time.mli
+++ b/middle_end/flambda/types/env/binding_time.mli
@@ -17,7 +17,7 @@
 type t
 type binding_time = t
 
-include Identifiable.S with type t := t
+include Container_types.S with type t := t
 
 val consts_and_discriminants : t (* CR mshinwell: rename *)
 val symbols : t

--- a/middle_end/flambda/types/kinds/flambda_arity.ml
+++ b/middle_end/flambda/types/kinds/flambda_arity.ml
@@ -24,7 +24,7 @@ let create t = t
 
 let length t = List.length t
 
-include Identifiable.Make (struct
+include Container_types.Make (struct
   type nonrec t = t
 
   let compare t1 t2 = Misc.Stdlib.List.compare Flambda_kind.compare t1 t2
@@ -64,7 +64,7 @@ module With_subkinds = struct
 
   let create t = t
 
-  include Identifiable.Make (struct
+  include Container_types.Make (struct
     type nonrec t = t
 
     let compare t1 t2 =

--- a/middle_end/flambda/types/kinds/flambda_arity.mli
+++ b/middle_end/flambda/types/kinds/flambda_arity.mli
@@ -35,7 +35,7 @@ val is_all_naked_floats : t -> bool
 
 val is_singleton_value : t -> bool
 
-include Identifiable.S with type t := t
+include Container_types.S with type t := t
 
 module With_subkinds : sig
   type arity = t
@@ -51,5 +51,5 @@ module With_subkinds : sig
 
   val compatible : t -> when_used_at:t -> bool
 
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
 end

--- a/middle_end/flambda/types/kinds/flambda_kind.ml
+++ b/middle_end/flambda/types/kinds/flambda_kind.ml
@@ -83,7 +83,7 @@ let unit = Value
 
 let unicode = true  (* CR mshinwell: move elsewhere *)
 
-include Identifiable.Make (struct
+include Container_types.Make (struct
   type nonrec t = t
 
   let compare t1 t2 =
@@ -192,7 +192,7 @@ module Standard_int = struct
     | Naked_int64 -> Naked_number Naked_int64
     | Naked_nativeint -> Naked_number Naked_nativeint
 
-  include Identifiable.Make (struct
+  include Container_types.Make (struct
     type nonrec t = t
 
     let print ppf t =
@@ -249,7 +249,7 @@ module Standard_int_or_float = struct
     | Naked_int64 -> Naked_number Naked_int64
     | Naked_nativeint -> Naked_number Naked_nativeint
 
-  include Identifiable.Make (struct
+  include Container_types.Make (struct
     type nonrec t = t
 
     let print ppf t =
@@ -311,7 +311,7 @@ module Boxable_number = struct
     | Naked_int64 -> Naked_int64
     | Naked_nativeint -> Naked_nativeint
 
-  include Identifiable.Make (struct
+  include Container_types.Make (struct
     type nonrec t = t
 
     let print ppf t =
@@ -376,7 +376,7 @@ module With_subkind = struct
       | Boxed_nativeint
       | Tagged_immediate
 
-    include Identifiable.Make (struct
+    include Container_types.Make (struct
       type nonrec t = t
 
       let print ppf t =
@@ -459,7 +459,7 @@ module With_subkind = struct
     | Naked_int64 -> naked_int64
     | Naked_nativeint -> naked_nativeint
 
-  include Identifiable.Make (struct
+  include Container_types.Make (struct
     type nonrec t = t
 
     let print ppf { kind; subkind; } =

--- a/middle_end/flambda/types/kinds/flambda_kind.mli
+++ b/middle_end/flambda/types/kinds/flambda_kind.mli
@@ -79,7 +79,7 @@ val is_naked_float : t -> bool
 (** The kind of the unit value. *)
 val unit : t
 
-include Identifiable.S with type t := t
+include Container_types.S with type t := t
 
 module Standard_int : sig
   (** These kinds are known as the "standard integer kinds".  They correspond
@@ -99,7 +99,7 @@ module Standard_int : sig
 
   val print_lowercase : Format.formatter -> t -> unit
 
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
 end
 
 module Standard_int_or_float : sig
@@ -116,7 +116,7 @@ module Standard_int_or_float : sig
 
   val print_lowercase : Format.formatter -> t -> unit
 
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
 end
 
 (* CR mshinwell: If the tagging/untagging experiment works, this and various
@@ -141,7 +141,7 @@ module Boxable_number : sig
 
   val print_lowercase_short : Format.formatter -> t -> unit
 
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
 end
 
 (** Witnesses for the naked number kinds, for use when matching on the structure
@@ -167,7 +167,7 @@ module With_subkind : sig
       | Boxed_nativeint
       | Tagged_immediate
 
-    include Identifiable.S with type t := t
+    include Container_types.S with type t := t
   end
 
   type kind = t
@@ -209,5 +209,5 @@ module With_subkind : sig
 
   val compatible : t -> when_used_at:t -> bool
 
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
 end

--- a/middle_end/flambda/types/structures/product_intf.ml
+++ b/middle_end/flambda/types/structures/product_intf.ml
@@ -22,7 +22,7 @@ module type S_base = sig
   type meet_env
   type typing_env_extension
 
-  module Index : Identifiable.S
+  module Index : Container_types.S
 
   val create_top : Flambda_kind.t -> t
 
@@ -55,7 +55,7 @@ module type S = sig
 end
 
 module type Index = sig
-  include Identifiable.S
+  include Container_types.S
 
   val remove_on_import : t -> Renaming.t -> bool
 end

--- a/middle_end/flambda/types/structures/row_like.rec.ml
+++ b/middle_end/flambda/types/structures/row_like.rec.ml
@@ -20,9 +20,9 @@ module Int = Numeric_types.Int
 module TEE = Typing_env_extension
 
 module Make
-  (Tag : Identifiable.S)
+  (Tag : Container_types.S)
   (Index : sig
-     include Identifiable.S
+     include Container_types.S
      val union : t -> t -> t
      val inter : t -> t -> t
      val subset : t -> t -> bool

--- a/middle_end/flambda/types/structures/set_of_closures_contents.ml
+++ b/middle_end/flambda/types/structures/set_of_closures_contents.ml
@@ -21,7 +21,7 @@ type t = {
   closure_vars : Var_within_closure.Set.t;
 }
 
-include Identifiable.Make (struct
+include Container_types.Make (struct
   type nonrec t = t
 
   let print ppf { closures; closure_vars; } =
@@ -86,7 +86,7 @@ let apply_renaming { closures; closure_vars; } renaming =
 module With_closure_id = struct
   type nonrec t = Closure_id.t * t
 
-  include Identifiable.Make (struct
+  include Container_types.Make (struct
     type nonrec t = t
 
     let print ppf (closure_id, contents) =
@@ -111,7 +111,7 @@ end
 module With_closure_id_or_unknown = struct
   type nonrec t = Closure_id.t Or_unknown.t * t
 
-  include Identifiable.Make (struct
+  include Container_types.Make (struct
     type nonrec t = t
 
     let print ppf (closure_id_or_unknown, contents) =

--- a/middle_end/flambda/types/structures/set_of_closures_contents.mli
+++ b/middle_end/flambda/types/structures/set_of_closures_contents.mli
@@ -26,7 +26,7 @@ type t
 
 val create : Closure_id.Set.t -> Var_within_closure.Set.t -> t
 
-include Identifiable.S with type t := t
+include Container_types.S with type t := t
 
 val subset : t -> t -> bool
 val inter : t -> t -> t
@@ -40,11 +40,11 @@ val apply_renaming : t -> Renaming.t -> t
 module With_closure_id : sig
   type nonrec t = Closure_id.t * t
 
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
 end
 
 module With_closure_id_or_unknown : sig
   type nonrec t = Closure_id.t Or_unknown.t * t
 
-  include Identifiable.S with type t := t
+  include Container_types.S with type t := t
 end


### PR DESCRIPTION
This only consists of renames.  To avoid changing the upstream Identifiable, we now have a new module Container_types, which has a better name in any case.