### PR TITLE
Relax signature constraint for SCC functor argument

### DIFF
--- a/middle_end/flambda/compilenv_deps/strongly_connected_components_flambda2.ml
+++ b/middle_end/flambda/compilenv_deps/strongly_connected_components_flambda2.ml
@@ -108,7 +108,33 @@ end = struct
 end
 
 module type S = sig
-  module Id : Container_types.S
+  module Id : sig
+    type t
+
+    module Set : sig
+      type elt = t
+      type t
+
+      val empty : t
+      val add : elt -> t -> t
+      val elements : t -> elt list
+      val iter : (elt -> unit) -> t -> unit
+      val fold : (elt -> 'a -> 'a) -> t -> 'a -> 'a
+    end
+
+    module Map : sig
+      type key = t
+      type 'a t
+
+      val empty : _ t
+      val add : key -> 'a -> 'a t -> 'a t
+      val cardinal : _ t -> int
+      val bindings : 'a t -> (key * 'a) list
+      val find : key -> 'a t -> 'a
+      val iter : (key -> 'a -> unit) -> 'a t -> unit
+      val fold : (key -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
+    end
+  end
 
   type directed_graph = Id.Set.t Id.Map.t
 

--- a/middle_end/flambda/compilenv_deps/strongly_connected_components_flambda2.mli
+++ b/middle_end/flambda/compilenv_deps/strongly_connected_components_flambda2.mli
@@ -22,7 +22,35 @@
 *)
 
 module type S = sig
-  module Id : Container_types.S
+  (* This doesn't use [Container_types] since it needs to work on [Ident]. *)
+
+  module Id : sig
+    type t
+
+    module Set : sig
+      type elt = t
+      type t
+
+      val empty : t
+      val add : elt -> t -> t
+      val elements : t -> elt list
+      val iter : (elt -> unit) -> t -> unit
+      val fold : (elt -> 'a -> 'a) -> t -> 'a -> 'a
+    end
+
+    module Map : sig
+      type key = t
+      type 'a t
+
+      val empty : _ t
+      val add : key -> 'a -> 'a t -> 'a t
+      val cardinal : _ t -> int
+      val bindings : 'a t -> (key * 'a) list
+      val find : key -> 'a t -> 'a
+      val iter : (key -> 'a -> unit) -> 'a t -> unit
+      val fold : (key -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
+    end
+  end
 
   type directed_graph = Id.Set.t Id.Map.t
   (** If (a -> set) belongs to the map, it means that there are edges


### PR DESCRIPTION
This relaxes the signature constraint for the strongly connected components functor argument.  At present `Ident` satisfies the existing constraint, but once `Identifiable` is reverted to the 4.12 version, that will no longer be the case.