### PR TITLE
Sort out colour handling

### DIFF
--- a/middle_end/flambda/compilenv_deps/flambda_colours.ml
+++ b/middle_end/flambda/compilenv_deps/flambda_colours.ml
@@ -14,57 +14,74 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
-module C = Misc.Color
+let colour_enabled = lazy (
+  (* This avoids having to alter misc.ml *)
+  let buf = Buffer.create 10 in
+  let ppf = Format.formatter_of_buffer buf in
+  Misc.Color.set_color_tag_handling ppf;
+  Format.fprintf ppf "@{<error>@}%!";
+  String.length (Buffer.contents buf) > 0
+)
 
-let normal () = C.reset ()
+let normal () =
+  if Lazy.force colour_enabled then "\x1b[0m"
+  else ""
 
-let prim_constructive () = C.fg_256 163
-let prim_destructive () = C.fg_256 62
-let prim_neither () = C.fg_256 130
+let fg_256 n =
+  if Lazy.force colour_enabled then Printf.sprintf "\x1b[38;5;%d;1m" n
+  else ""
 
-let naked_number () = C.fg_256 70
-let tagged_immediate () = C.fg_256 70
-let constructor () = C.fg_256 69
+let bg_256 n =
+  if Lazy.force colour_enabled then Printf.sprintf "\x1b[48;5;%d;1m" n
+  else ""
 
-let kind () = C.fg_256 37
-let subkind () = C.fg_256 39
+let prim_constructive () = fg_256 163
+let prim_destructive () = fg_256 62
+let prim_neither () = fg_256 130
 
-let top_or_bottom_type () = C.fg_256 37
+let naked_number () = fg_256 70
+let tagged_immediate () = fg_256 70
+let constructor () = fg_256 69
 
-let debuginfo () = C.fg_256 243
+let kind () = fg_256 37
+let subkind () = fg_256 39
 
-let discriminant () = C.fg_256 111
-let name () = C.fg_256 111
-let parameter () = C.fg_256 198
-let symbol () = C.fg_256 98
-let variable () = C.fg_256 111
+let top_or_bottom_type () = fg_256 37
 
-let closure_element () = C.fg_256 31
-let closure_var () = C.fg_256 43
+let debuginfo () = fg_256 243
 
-let code_id () = C.fg_256 169
+let discriminant () = fg_256 111
+let name () = fg_256 111
+let parameter () = fg_256 198
+let symbol () = fg_256 98
+let variable () = fg_256 111
 
-let expr_keyword () = C.fg_256 51
-let static_keyword () = (C.fg_256 255) ^ (C.bg_256 240)
+let closure_element () = fg_256 31
+let closure_var () = fg_256 43
 
-let static_part () = (C.fg_256 255) ^ (C.bg_256 237)
+let code_id () = fg_256 169
 
-let continuation () = C.fg_256 35
-let continuation_definition () = C.bg_256 237
-let continuation_annotation () = (C.fg_256 202) ^ (C.bg_256 237)
+let expr_keyword () = fg_256 51
+let static_keyword () = (fg_256 255) ^ (bg_256 240)
 
-let name_abstraction () = C.fg_256 172
+let static_part () = (fg_256 255) ^ (bg_256 237)
 
-let rec_info () = C.fg_256 249
+let continuation () = fg_256 35
+let continuation_definition () = bg_256 237
+let continuation_annotation () = (fg_256 202) ^ (bg_256 237)
 
-let coercion () = C.fg_256 249
+let name_abstraction () = fg_256 172
 
-let depth_variable () = C.fg_256 214
+let rec_info () = fg_256 249
 
-let error () = C.fg_256 160
+let coercion () = fg_256 249
 
-let elide () = C.fg_256 243
+let depth_variable () = fg_256 214
 
-let each_file () = C.fg_256 51
+let error () = fg_256 160
+
+let elide () = fg_256 243
+
+let each_file () = fg_256 51
 
 let lambda () = expr_keyword ()

--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -54,7 +54,7 @@ val contents : t -> string
 val to_bytes : t -> bytes
 (** Return a copy of the current contents of the buffer.
     The buffer itself is unchanged.
-    @since 4.02 *)
+   @since 4.02 *)
 
 val sub : t -> int -> int -> string
 (** [Buffer.sub b off len] returns a copy of [len] bytes from the

--- a/testsuite/tests/parsetree/locations_test.compilers.reference
+++ b/testsuite/tests/parsetree/locations_test.compilers.reference
@@ -593,6 +593,7 @@ Ptop_def
                 Pexp_constant PConst_int (4,None)
       ]
   ]
+
 Line 2, characters 12-13:
 2 | let x = M.( 3; 4 );;
                 ^

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -13,180 +13,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* Color handling *)
-module Color = struct
-  (* use ANSI color codes, see https://en.wikipedia.org/wiki/ANSI_escape_code *)
-  type color =
-    | Black
-    | Red
-    | Green
-    | Yellow
-    | Blue
-    | Magenta
-    | Cyan
-    | White
-  ;;
-
-  type style =
-    | FG of color (* foreground *)
-    | BG of color (* background *)
-    | Bold
-    | Underline
-    | Reset
-
-  let ansi_of_color = function
-    | Black -> "0"
-    | Red -> "1"
-    | Green -> "2"
-    | Yellow -> "3"
-    | Blue -> "4"
-    | Magenta -> "5"
-    | Cyan -> "6"
-    | White -> "7"
-
-  let code_of_style = function
-    | FG c -> "3" ^ ansi_of_color c
-    | BG c -> "4" ^ ansi_of_color c
-    | Bold -> "1"
-    | Underline -> "4"
-    | Reset -> "0"
-
-  let ansi_of_style_l l =
-    let s = match l with
-      | [] -> code_of_style Reset
-      | [s] -> code_of_style s
-      | _ -> String.concat ";" (List.map code_of_style l)
-    in
-    "\x1b[" ^ s ^ "m"
-
-  type styles = {
-    error: style list;
-    warning: style list;
-    loc: style list;
-  }
-
-  let default_styles = {
-    warning = [Bold; FG Magenta];
-    error = [Bold; FG Red];
-    loc = [Bold];
-  }
-
-  let cur_styles = ref default_styles
-  let get_styles () = !cur_styles
-  let set_styles s = cur_styles := s
-
-  (* map a tag to a style, if the tag is known.
-     @raise Not_found otherwise *)
-  let style_of_tag s = match s with
-    | Format.String_tag "error" -> (!cur_styles).error
-    | Format.String_tag "warning" -> (!cur_styles).warning
-    | Format.String_tag "loc" -> (!cur_styles).loc
-    | _ -> raise Not_found
-
-  let color_enabled = ref true
-
-  let fg_256 n =
-    if !color_enabled then
-      (Printf.sprintf "\x1b[38;5;%dm" n) ^ (ansi_of_style_l [Bold])
-    else ""
-
-  let bg_256 n =
-    if !color_enabled then
-      (Printf.sprintf "\x1b[48;5;%dm" n) ^ (ansi_of_style_l [Bold])
-    else ""
-
-  let bold_red () =
-    if !color_enabled then ansi_of_style_l [FG Red; Bold] else ""
-
-  let bold_green () =
-    if !color_enabled then ansi_of_style_l [FG Green; Bold] else ""
-
-  let bold_cyan () =
-    if !color_enabled then ansi_of_style_l [FG Cyan; Bold] else ""
-
-  let bold_white () =
-    if !color_enabled then ansi_of_style_l [FG White; Bold] else ""
-
-  let bold_yellow () =
-    if !color_enabled then ansi_of_style_l [FG Yellow; Bold] else ""
-
-  let bold_blue () =
-    if !color_enabled then ansi_of_style_l [FG Blue; Bold] else ""
-
-  let bold_magenta () =
-    if !color_enabled then ansi_of_style_l [FG Magenta; Bold] else ""
-
-  (* CR mshinwell: Consider adding a mode which doesn't have colour but does
-     have underlining *)
-
-  let underline () =
-    if !color_enabled then ansi_of_style_l [Underline] else ""
-
-  let reset () =
-    if !color_enabled then ansi_of_style_l [Reset] else ""
-
-  (* either prints the tag of [s] or delegates to [or_else] *)
-  let mark_open_tag ~or_else s =
-    try
-      let style = style_of_tag s in
-      if !color_enabled then ansi_of_style_l style else ""
-    with Not_found -> or_else s
-
-  let mark_close_tag ~or_else s =
-    try
-      let _ = style_of_tag s in
-      if !color_enabled then ansi_of_style_l [Reset] else ""
-    with Not_found -> or_else s
-
-  (* add color handling to formatter [ppf] *)
-  let set_color_tag_handling ppf =
-    let open Format in
-    let functions = pp_get_formatter_stag_functions ppf () in
-    let functions' = {functions with
-      mark_open_stag=(mark_open_tag ~or_else:functions.mark_open_stag);
-      mark_close_stag=(mark_close_tag ~or_else:functions.mark_close_stag);
-    } in
-    pp_set_mark_tags ppf true; (* enable tags *)
-    pp_set_formatter_stag_functions ppf functions';
-    (* also setup margins *)
-    pp_set_margin ppf (pp_get_margin std_formatter());
-    ()
-
-  external isatty : out_channel -> bool = "caml_sys_isatty"
-
-  (* reasonable heuristic on whether colors should be enabled *)
-  let should_enable_color () =
-    let term = try Sys.getenv "TERM" with Not_found -> "" in
-    term <> "dumb"
-    && term <> ""
-    && isatty stderr
-
-  type setting = Auto | Always | Never
-
-  let default_setting = Auto
-
-  let setup =
-    let first = ref true in (* initialize only once *)
-    let formatter_l =
-      [Format.std_formatter; Format.err_formatter; Format.str_formatter]
-    in
-    let enable_color = function
-      | Auto -> should_enable_color ()
-      | Always -> true
-      | Never -> false
-    in
-    fun o ->
-      if !first then (
-        first := false;
-        Format.set_mark_tags true;
-        List.iter set_color_tag_handling formatter_l;
-        color_enabled := (match o with
-          | Some s -> enable_color s
-          | None -> enable_color default_setting)
-      );
-      ()
-end
-
 (* Errors *)
 
 exception Fatal_error
@@ -825,6 +651,180 @@ let did_you_mean ppf get_choices =
 let cut_at s c =
   let pos = String.index s c in
   String.sub s 0 pos, String.sub s (pos+1) (String.length s - pos - 1)
+
+(* Color handling *)
+module Color = struct
+  (* use ANSI color codes, see https://en.wikipedia.org/wiki/ANSI_escape_code *)
+  type color =
+    | Black
+    | Red
+    | Green
+    | Yellow
+    | Blue
+    | Magenta
+    | Cyan
+    | White
+  ;;
+
+  type style =
+    | FG of color (* foreground *)
+    | BG of color (* background *)
+    | Bold
+    | Underline
+    | Reset
+
+  let ansi_of_color = function
+    | Black -> "0"
+    | Red -> "1"
+    | Green -> "2"
+    | Yellow -> "3"
+    | Blue -> "4"
+    | Magenta -> "5"
+    | Cyan -> "6"
+    | White -> "7"
+
+  let code_of_style = function
+    | FG c -> "3" ^ ansi_of_color c
+    | BG c -> "4" ^ ansi_of_color c
+    | Bold -> "1"
+    | Underline -> "4"
+    | Reset -> "0"
+
+  let ansi_of_style_l l =
+    let s = match l with
+      | [] -> code_of_style Reset
+      | [s] -> code_of_style s
+      | _ -> String.concat ";" (List.map code_of_style l)
+    in
+    "\x1b[" ^ s ^ "m"
+
+  type styles = {
+    error: style list;
+    warning: style list;
+    loc: style list;
+  }
+
+  let default_styles = {
+    warning = [Bold; FG Magenta];
+    error = [Bold; FG Red];
+    loc = [Bold];
+  }
+
+  let cur_styles = ref default_styles
+  let get_styles () = !cur_styles
+  let set_styles s = cur_styles := s
+
+  (* map a tag to a style, if the tag is known.
+     @raise Not_found otherwise *)
+  let style_of_tag s = match s with
+    | Format.String_tag "error" -> (!cur_styles).error
+    | Format.String_tag "warning" -> (!cur_styles).warning
+    | Format.String_tag "loc" -> (!cur_styles).loc
+    | _ -> raise Not_found
+
+  let color_enabled = ref true
+
+  let fg_256 n =
+    if !color_enabled then
+      (Printf.sprintf "\x1b[38;5;%dm" n) ^ (ansi_of_style_l [Bold])
+    else ""
+
+  let bg_256 n =
+    if !color_enabled then
+      (Printf.sprintf "\x1b[48;5;%dm" n) ^ (ansi_of_style_l [Bold])
+    else ""
+
+  let bold_red () =
+    if !color_enabled then ansi_of_style_l [FG Red; Bold] else ""
+
+  let bold_green () =
+    if !color_enabled then ansi_of_style_l [FG Green; Bold] else ""
+
+  let bold_cyan () =
+    if !color_enabled then ansi_of_style_l [FG Cyan; Bold] else ""
+
+  let bold_white () =
+    if !color_enabled then ansi_of_style_l [FG White; Bold] else ""
+
+  let bold_yellow () =
+    if !color_enabled then ansi_of_style_l [FG Yellow; Bold] else ""
+
+  let bold_blue () =
+    if !color_enabled then ansi_of_style_l [FG Blue; Bold] else ""
+
+  let bold_magenta () =
+    if !color_enabled then ansi_of_style_l [FG Magenta; Bold] else ""
+
+  (* CR mshinwell: Consider adding a mode which doesn't have colour but does
+     have underlining *)
+
+  let underline () =
+    if !color_enabled then ansi_of_style_l [Underline] else ""
+
+  let reset () =
+    if !color_enabled then ansi_of_style_l [Reset] else ""
+
+  (* either prints the tag of [s] or delegates to [or_else] *)
+  let mark_open_tag ~or_else s =
+    try
+      let style = style_of_tag s in
+      if !color_enabled then ansi_of_style_l style else ""
+    with Not_found -> or_else s
+
+  let mark_close_tag ~or_else s =
+    try
+      let _ = style_of_tag s in
+      if !color_enabled then ansi_of_style_l [Reset] else ""
+    with Not_found -> or_else s
+
+  (* add color handling to formatter [ppf] *)
+  let set_color_tag_handling ppf =
+    let open Format in
+    let functions = pp_get_formatter_stag_functions ppf () in
+    let functions' = {functions with
+      mark_open_stag=(mark_open_tag ~or_else:functions.mark_open_stag);
+      mark_close_stag=(mark_close_tag ~or_else:functions.mark_close_stag);
+    } in
+    pp_set_mark_tags ppf true; (* enable tags *)
+    pp_set_formatter_stag_functions ppf functions';
+    (* also setup margins *)
+    pp_set_margin ppf (pp_get_margin std_formatter());
+    ()
+
+  external isatty : out_channel -> bool = "caml_sys_isatty"
+
+  (* reasonable heuristic on whether colors should be enabled *)
+  let should_enable_color () =
+    let term = try Sys.getenv "TERM" with Not_found -> "" in
+    term <> "dumb"
+    && term <> ""
+    && isatty stderr
+
+  type setting = Auto | Always | Never
+
+  let default_setting = Auto
+
+  let setup =
+    let first = ref true in (* initialize only once *)
+    let formatter_l =
+      [Format.std_formatter; Format.err_formatter; Format.str_formatter]
+    in
+    let enable_color = function
+      | Auto -> should_enable_color ()
+      | Always -> true
+      | Never -> false
+    in
+    fun o ->
+      if !first then (
+        first := false;
+        Format.set_mark_tags true;
+        List.iter set_color_tag_handling formatter_l;
+        color_enabled := (match o with
+          | Some s -> enable_color s
+          | None -> enable_color default_setting)
+      );
+      ()
+end
 
 module Error_style = struct
   type setting =

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -722,19 +722,6 @@ module Color = struct
 
   let color_enabled = ref true
 
-  let fg_256 n =
-    if !color_enabled then
-      (Printf.sprintf "\x1b[38;5;%dm" n) ^ (ansi_of_style_l [Bold])
-    else ""
-
-  let bg_256 n =
-    if !color_enabled then
-      (Printf.sprintf "\x1b[48;5;%dm" n) ^ (ansi_of_style_l [Bold])
-    else ""
-
-  let reset () =
-    if !color_enabled then ansi_of_style_l [Reset] else ""
-
   (* either prints the tag of [s] or delegates to [or_else] *)
   let mark_open_tag ~or_else s =
     try
@@ -758,8 +745,6 @@ module Color = struct
     } in
     pp_set_mark_tags ppf true; (* enable tags *)
     pp_set_formatter_stag_functions ppf functions';
-    (* also setup margins *)
-    pp_set_margin ppf (pp_get_margin std_formatter());
     ()
 
   external isatty : out_channel -> bool = "caml_sys_isatty"

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -734,33 +734,6 @@ module Color = struct
       (Printf.sprintf "\x1b[48;5;%dm" n) ^ (ansi_of_style_l [Bold])
     else ""
 
-  let bold_red () =
-    if !color_enabled then ansi_of_style_l [FG Red; Bold] else ""
-
-  let bold_green () =
-    if !color_enabled then ansi_of_style_l [FG Green; Bold] else ""
-
-  let bold_cyan () =
-    if !color_enabled then ansi_of_style_l [FG Cyan; Bold] else ""
-
-  let bold_white () =
-    if !color_enabled then ansi_of_style_l [FG White; Bold] else ""
-
-  let bold_yellow () =
-    if !color_enabled then ansi_of_style_l [FG Yellow; Bold] else ""
-
-  let bold_blue () =
-    if !color_enabled then ansi_of_style_l [FG Blue; Bold] else ""
-
-  let bold_magenta () =
-    if !color_enabled then ansi_of_style_l [FG Magenta; Bold] else ""
-
-  (* CR mshinwell: Consider adding a mode which doesn't have colour but does
-     have underlining *)
-
-  let underline () =
-    if !color_enabled then ansi_of_style_l [Underline] else ""
-
   let reset () =
     if !color_enabled then ansi_of_style_l [Reset] else ""
 

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -670,7 +670,6 @@ module Color = struct
     | FG of color (* foreground *)
     | BG of color (* background *)
     | Bold
-    | Underline
     | Reset
 
   let ansi_of_color = function
@@ -687,7 +686,6 @@ module Color = struct
     | FG c -> "3" ^ ansi_of_color c
     | BG c -> "4" ^ ansi_of_color c
     | Bold -> "1"
-    | Underline -> "4"
     | Reset -> "0"
 
   let ansi_of_style_l l =

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -435,14 +435,6 @@ module Color : sig
   val fg_256 : int -> string
   val bg_256 : int -> string
 
-  val bold_green : unit -> string
-  val bold_red : unit -> string
-  val bold_cyan : unit -> string
-  val bold_white : unit -> string
-  val bold_yellow : unit -> string
-  val bold_blue : unit -> string
-  val bold_magenta : unit -> string
-  val underline : unit -> string
   val reset : unit -> string
 end
 

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -404,7 +404,6 @@ module Color : sig
     | FG of color (* foreground *)
     | BG of color (* background *)
     | Bold
-    | Underline
     | Reset
 
   val ansi_of_style_l : style list -> string

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -430,11 +430,6 @@ module Color : sig
 
   val set_color_tag_handling : Format.formatter -> unit
   (* adds functions to support color tags to the given formatter. *)
-
-  val fg_256 : int -> string
-  val bg_256 : int -> string
-
-  val reset : unit -> string
 end
 
 (* See the -error-style option *)


### PR DESCRIPTION
This allows us to revert the colour-handling code in `Misc` to be the same as upstream.