### PR TITLE
Revert Map and Set stdlib modules to 4.12, etc

### DIFF
--- a/middle_end/flambda/compilenv_deps/container_types.mli
+++ b/middle_end/flambda/compilenv_deps/container_types.mli
@@ -50,6 +50,8 @@ module type Set = sig
 
   val union_list : t list -> t
   val intersection_is_empty : t -> t -> bool
+
+  val get_singleton : t -> elt option
 end
 
 module type Map = sig
@@ -98,6 +100,13 @@ module type Map = sig
 
   val inter : (key -> 'a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
   val inter_domain_is_non_empty : 'a t -> 'a t -> bool
+
+  val get_singleton : 'a t -> (key * 'a) option
+  val get_singleton_exn : 'a t -> key * 'a
+
+  val replace: key -> ('a -> 'a) -> 'a t -> 'a t
+
+  val map_sharing : ('a -> 'a) -> 'a t -> 'a t
 end
 
 module type Tbl = sig

--- a/stdlib/buffer.mli
+++ b/stdlib/buffer.mli
@@ -54,7 +54,7 @@ val contents : t -> string
 val to_bytes : t -> bytes
 (** Return a copy of the current contents of the buffer.
     The buffer itself is unchanged.
-   @since 4.02 *)
+    @since 4.02 *)
 
 val sub : t -> int -> int -> string
 (** [Buffer.sub b off len] returns a copy of [len] bytes from the

--- a/stdlib/map.ml
+++ b/stdlib/map.ml
@@ -27,7 +27,6 @@ module type S =
     val is_empty: 'a t -> bool
     val mem:  key -> 'a t -> bool
     val add: key -> 'a -> 'a t -> 'a t
-    val replace: key -> ('a -> 'a) -> 'a t -> 'a t
     val update: key -> ('a option -> 'a option) -> 'a t -> 'a t
     val singleton: key -> 'a -> 'a t
     val remove: key -> 'a t -> 'a t
@@ -58,11 +57,8 @@ module type S =
     val find_first_opt: (key -> bool) -> 'a t -> (key * 'a) option
     val find_last: (key -> bool) -> 'a t -> key * 'a
     val find_last_opt: (key -> bool) -> 'a t -> (key * 'a) option
-    val get_singleton : 'a t -> (key * 'a) option
-    val get_singleton_exn : 'a t -> key * 'a
     val map: ('a -> 'b) -> 'a t -> 'b t
     val mapi: (key -> 'a -> 'b) -> 'a t -> 'b t
-    val map_sharing: ('a -> 'a) -> 'a t -> 'a t
     val to_seq : 'a t -> (key * 'a) Seq.t
     val to_rev_seq : 'a t -> (key * 'a) Seq.t
     val to_seq_from : key -> 'a t -> (key * 'a) Seq.t
@@ -224,16 +220,6 @@ module Make(Ord: OrderedType) = struct
           if c = 0 then Some d
           else find_opt x (if c < 0 then l else r)
 
-    let get_singleton t =
-      match t with
-      | Node { l = Empty; v; d; r = Empty; } -> Some (v, d)
-      | Empty | Node _ -> None
-
-    let get_singleton_exn t =
-      match t with
-      | Node { l = Empty; v; d; r = Empty; } -> v, d
-      | Empty | Node _ -> raise Not_found
-
     let rec mem x = function
         Empty ->
           false
@@ -285,20 +271,6 @@ module Make(Ord: OrderedType) = struct
           else
             let rr = remove x r in if r == rr then m else bal l v d rr
 
-    let rec replace x f = function
-        Empty -> Empty
-      | Node {l; v; d; r; h} as m ->
-          let c = Ord.compare x v in
-          if c = 0 then begin
-            let data = f d in
-            if d == data then m else Node{l; v=x; d=data; r; h}
-          end else if c < 0 then
-            let ll = replace x f l in
-            if l == ll then m else bal ll v d r
-          else
-            let rr = replace x f r in
-            if r == rr then m else bal l v d rr
-
     let rec update x f = function
         Empty ->
           begin match f None with
@@ -341,16 +313,6 @@ module Make(Ord: OrderedType) = struct
           let d' = f v d in
           let r' = mapi f r in
           Node{l=l'; v; d=d'; r=r'; h}
-
-    let rec map_sharing f = function
-        Empty ->
-          Empty
-      | (Node {l; v; d; r; h}) as t ->
-          let l' = map_sharing f l in
-          let d' = f d in
-          let r' = map_sharing f r in
-          if l == l' && d == d' && r == r' then t
-          else Node{l=l'; v; d=d'; r=r'; h}
 
     let rec fold f m accu =
       match m with

--- a/stdlib/map.mli
+++ b/stdlib/map.mli
@@ -89,8 +89,6 @@ module type S =
        of [key] in [m] disappears.
        @before 4.03 Physical equality was not ensured. *)
 
-    val replace: key -> ('a -> 'a) -> 'a t -> 'a t
-
     val update: key -> ('a option -> 'a option) -> 'a t -> 'a t
     (** [update key f m] returns a map containing the same bindings as
         [m], except for the binding of [key]. Depending on the value of
@@ -322,10 +320,6 @@ module type S =
         @since 4.05
        *)
 
-    val get_singleton : 'a t -> (key * 'a) option
-
-    val get_singleton_exn : 'a t -> key * 'a
-
     val map: ('a -> 'b) -> 'a t -> 'b t
     (** [map f m] returns a map with same domain as [m], where the
        associated value [a] of all bindings of [m] has been
@@ -336,11 +330,6 @@ module type S =
     val mapi: (key -> 'a -> 'b) -> 'a t -> 'b t
     (** Same as {!S.map}, but the function receives as arguments both the
        key and the associated value for each binding of the map. *)
-
-    val map_sharing: ('a -> 'a) -> 'a t -> 'a t
-    (** Like [map], but the returned map will be physically equal to the input
-        map if every call [f a] made during the mapping returns a value
-        physically equal to [a]. *)
 
     (** {1 Iterators} *)
 

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -604,9 +604,6 @@ module Map : sig
          of [key] in [m] disappears.
          @before 4.03 Physical equality was not ensured. *)
 
-
-      val replace: key:key -> f:('a -> 'a) -> 'a t -> 'a t
-
       val update: key:key -> f:('a option -> 'a option) -> 'a t -> 'a t
       (** [update ~key ~f m] returns a map containing the same bindings as
           [m], except for the binding of [key]. Depending on the value of
@@ -838,9 +835,6 @@ module Map : sig
           @since 4.05
          *)
 
-      val get_singleton : 'a t -> (key * 'a) option
-      val get_singleton_exn : 'a t -> key * 'a
-
       val map: f:('a -> 'b) -> 'a t -> 'b t
       (** [map ~f m] returns a map with same domain as [m], where the
          associated value [a] of all bindings of [m] has been
@@ -852,8 +846,6 @@ module Map : sig
       (** Same as {!S.map}, but the function receives as arguments both the
          key and the associated value for each binding of the map. *)
 
-      val map_sharing: ('a -> 'a) -> 'a t -> 'a t
-      
       (** {1 Iterators} *)
 
       val to_seq : 'a t -> (key * 'a) Seq.t
@@ -1155,8 +1147,6 @@ module Set : sig
           except perhaps for lists with many duplicated elements.
           @since 4.02.0 *)
 
-      val get_singleton : t -> elt option
-      
       (** {1 Iterators} *)
 
       val to_seq_from : elt -> t -> elt Seq.t

--- a/stdlib/set.ml
+++ b/stdlib/set.ml
@@ -62,7 +62,6 @@ module type S =
     val find_last: (elt -> bool) -> t -> elt
     val find_last_opt: (elt -> bool) -> t -> elt option
     val of_list: elt list -> t
-    val get_singleton : t -> elt option
     val to_seq_from : elt -> t -> elt Seq.t
     val to_seq : t -> elt Seq.t
     val to_rev_seq : t -> elt Seq.t
@@ -513,11 +512,6 @@ module Make(Ord: OrderedType) =
           let c = Ord.compare x v in
           if c = 0 then Some v
           else find_opt x (if c < 0 then l else r)
-
-    let get_singleton t =
-      match t with
-      | Node { l = Empty; v; r = Empty; } -> Some v
-      | Empty | Node _ -> None
 
     let try_join l v r =
       (* [join l v r] can only be called when (elements of l < v <

--- a/stdlib/set.mli
+++ b/stdlib/set.mli
@@ -283,8 +283,6 @@ module type S =
         except perhaps for lists with many duplicated elements.
         @since 4.02.0 *)
 
-    val get_singleton : t -> elt option
-
     (** {1 Iterators} *)
 
     val to_seq_from : elt -> t -> elt Seq.t

--- a/testsuite/tests/generalized-open/accepted_expect.ml
+++ b/testsuite/tests/generalized-open/accepted_expect.ml
@@ -43,7 +43,6 @@ val find_first_opt : (elt -> bool) -> t -> elt option = <fun>
 val find_last : (elt -> bool) -> t -> elt = <fun>
 val find_last_opt : (elt -> bool) -> t -> elt option = <fun>
 val of_list : elt list -> t = <fun>
-val get_singleton : t -> elt option = <fun>
 val to_seq_from : elt -> t -> elt Seq.t = <fun>
 val to_seq : t -> elt Seq.t = <fun>
 val to_rev_seq : t -> elt Seq.t = <fun>

--- a/testsuite/tests/typing-implicit_unpack/implicit_unpack.ml
+++ b/testsuite/tests/typing-implicit_unpack/implicit_unpack.ml
@@ -308,7 +308,6 @@ module type MapT =
     val is_empty : 'a t -> bool
     val mem : key -> 'a t -> bool
     val add : key -> 'a -> 'a t -> 'a t
-    val replace : key -> ('a -> 'a) -> 'a t -> 'a t
     val update : key -> ('a option -> 'a option) -> 'a t -> 'a t
     val singleton : key -> 'a -> 'a t
     val remove : key -> 'a t -> 'a t
@@ -339,11 +338,8 @@ module type MapT =
     val find_first_opt : (key -> bool) -> 'a t -> (key * 'a) option
     val find_last : (key -> bool) -> 'a t -> key * 'a
     val find_last_opt : (key -> bool) -> 'a t -> (key * 'a) option
-    val get_singleton : 'a t -> (key * 'a) option
-    val get_singleton_exn : 'a t -> key * 'a
     val map : ('a -> 'b) -> 'a t -> 'b t
     val mapi : (key -> 'a -> 'b) -> 'a t -> 'b t
-    val map_sharing : ('a -> 'a) -> 'a t -> 'a t
     val to_seq : 'a t -> (key * 'a) Seq.t
     val to_rev_seq : 'a t -> (key * 'a) Seq.t
     val to_seq_from : key -> 'a t -> (key * 'a) Seq.t
@@ -365,7 +361,6 @@ module SSMap :
     val is_empty : 'a t -> bool
     val mem : key -> 'a t -> bool
     val add : key -> 'a -> 'a t -> 'a t
-    val replace : key -> ('a -> 'a) -> 'a t -> 'a t
     val update : key -> ('a option -> 'a option) -> 'a t -> 'a t
     val singleton : key -> 'a -> 'a t
     val remove : key -> 'a t -> 'a t
@@ -396,11 +391,8 @@ module SSMap :
     val find_first_opt : (key -> bool) -> 'a t -> (key * 'a) option
     val find_last : (key -> bool) -> 'a t -> key * 'a
     val find_last_opt : (key -> bool) -> 'a t -> (key * 'a) option
-    val get_singleton : 'a t -> (key * 'a) option
-    val get_singleton_exn : 'a t -> key * 'a
     val map : ('a -> 'b) -> 'a t -> 'b t
     val mapi : (key -> 'a -> 'b) -> 'a t -> 'b t
-    val map_sharing : ('a -> 'a) -> 'a t -> 'a t
     val to_seq : 'a t -> (key * 'a) Seq.t
     val to_rev_seq : 'a t -> (key * 'a) Seq.t
     val to_seq_from : key -> 'a t -> (key * 'a) Seq.t

--- a/testsuite/tests/typing-modules/aliases.ml
+++ b/testsuite/tests/typing-modules/aliases.ml
@@ -316,7 +316,6 @@ module StringSet :
     val find_last : (elt -> bool) -> t -> elt
     val find_last_opt : (elt -> bool) -> t -> elt option
     val of_list : elt list -> t
-    val get_singleton : t -> elt option
     val to_seq_from : elt -> t -> elt Seq.t
     val to_seq : t -> elt Seq.t
     val to_rev_seq : t -> elt Seq.t
@@ -364,7 +363,6 @@ module SSet :
     val find_last : (elt -> bool) -> t -> elt
     val find_last_opt : (elt -> bool) -> t -> elt option
     val of_list : elt list -> t
-    val get_singleton : t -> elt option
     val to_seq_from : elt -> t -> elt Seq.t
     val to_seq : t -> elt Seq.t
     val to_rev_seq : t -> elt Seq.t
@@ -444,7 +442,6 @@ module A :
         val find_last : (elt -> bool) -> t -> elt
         val find_last_opt : (elt -> bool) -> t -> elt option
         val of_list : elt list -> t
-        val get_singleton : t -> elt option
         val to_seq_from : elt -> t -> elt Seq.t
         val to_seq : t -> elt Seq.t
         val to_rev_seq : t -> elt Seq.t
@@ -576,7 +573,6 @@ module SInt :
     val find_last : (elt -> bool) -> t -> elt
     val find_last_opt : (elt -> bool) -> t -> elt option
     val of_list : elt list -> t
-    val get_singleton : t -> elt option
     val to_seq_from : elt -> t -> elt Seq.t
     val to_seq : t -> elt Seq.t
     val to_rev_seq : t -> elt Seq.t

--- a/testsuite/tests/typing-modules/pr7818.ml
+++ b/testsuite/tests/typing-modules/pr7818.ml
@@ -272,7 +272,6 @@ module MkT :
       val find_last : (elt -> bool) -> t -> elt
       val find_last_opt : (elt -> bool) -> t -> elt option
       val of_list : elt list -> t
-      val get_singleton : t -> elt option
       val to_seq_from : elt -> t -> elt Seq.t
       val to_seq : t -> elt Seq.t
       val to_rev_seq : t -> elt Seq.t

--- a/testsuite/tests/typing-short-paths/short-paths.compilers.reference
+++ b/testsuite/tests/typing-short-paths/short-paths.compilers.reference
@@ -19,7 +19,6 @@ module Core :
             val is_empty : 'a t -> bool
             val mem : key -> 'a t -> bool
             val add : key -> 'a -> 'a t -> 'a t
-            val replace : key -> ('a -> 'a) -> 'a t -> 'a t
             val update : key -> ('a option -> 'a option) -> 'a t -> 'a t
             val singleton : key -> 'a -> 'a t
             val remove : key -> 'a t -> 'a t
@@ -52,11 +51,8 @@ module Core :
             val find_first_opt : (key -> bool) -> 'a t -> (key * 'a) option
             val find_last : (key -> bool) -> 'a t -> key * 'a
             val find_last_opt : (key -> bool) -> 'a t -> (key * 'a) option
-            val get_singleton : 'a t -> (key * 'a) option
-            val get_singleton_exn : 'a t -> key * 'a
             val map : ('a -> 'b) -> 'a t -> 'b t
             val mapi : (key -> 'a -> 'b) -> 'a t -> 'b t
-            val map_sharing : ('a -> 'a) -> 'a t -> 'a t
             val to_seq : 'a t -> (key * 'a) Seq.t
             val to_rev_seq : 'a t -> (key * 'a) Seq.t
             val to_seq_from : key -> 'a t -> (key * 'a) Seq.t


### PR DESCRIPTION
1. Moves the extra functionality from the stdlib `Map` and `Set` modules into `Container_types`.  This means that `get_singleton` isn't as fast -- but I've written a version that should not allocate, which is the main concern.

2. Fixes erroneous inlining attributes in `Container_types` that were doing nothing.

3. Reverts the stdlib `Map`, `Set` and `MoreLabels` modules back to their 4.12 state.