### PR TITLE
ocp-indent: revert match clause indentation to 2

### DIFF
--- a/.ocp-indent
+++ b/.ocp-indent
@@ -1,4 +1,3 @@
 JaneStreet
 max_indent=4
-match_clause=4
 strict_with=auto


### PR DESCRIPTION
This fixes the main remaining issue with `ocp-indent` on the Flambda 2 code base.