### PR TITLE
Ordering symbols for closures and code, and closure projection substitution

### DIFF
--- a/middle_end/flambda/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion.ml
@@ -47,6 +47,19 @@ let symbol_for_ident acc env id =
   let symbol = Env.symbol_for_global' env id in
   use_of_symbol_as_simple acc symbol
 
+let register_set_of_closures_as_symbols acc set_of_closures
+      : Acc.t * Symbol.t Closure_id.Lmap.t =
+  let symbols =
+    Set_of_closures.function_decls set_of_closures
+    |> Function_declarations.funs_in_order
+    |> Closure_id.Lmap.mapi (fun closure_id _ ->
+        Symbol.create (Compilation_unit.get_current_exn ())
+          (Linkage_name.create
+             (Variable.unique_name (Closure_id.unwrap closure_id))))
+  in
+  let acc = Acc.add_declared_set_of_closures ~symbols ~set_of_closures acc in
+  acc, symbols
+
 let register_const0 acc constant name =
   match Static_const.Map.find constant (Acc.shareable_constants acc) with
   | exception Not_found ->
@@ -985,15 +998,17 @@ let close_let_rec acc env ~function_declarations
         env)
       function_declarations env
   in
-  let closure_vars =
-    List.fold_left (fun closure_vars decl ->
+  let closure_vars, ident_map =
+    List.fold_left (fun (closure_vars, ident_map) decl ->
+        let ident = Function_decl.let_rec_ident decl in
         let closure_var =
-          VB.create (Env.find_var env (Function_decl.let_rec_ident decl))
+          VB.create (Env.find_var env ident)
             Name_mode.normal
         in
         let closure_id = Function_decl.closure_id decl in
-        Closure_id.Map.add closure_id closure_var closure_vars)
-      Closure_id.Map.empty
+        Closure_id.Map.add closure_id closure_var closure_vars,
+        Closure_id.Map.add closure_id ident ident_map)
+      (Closure_id.Map.empty, Closure_id.Map.empty)
       function_declarations
   in
   let acc, set_of_closures =
@@ -1022,13 +1037,26 @@ let close_let_rec acc env ~function_declarations
           Set_of_closures.function_decls set_of_closures)
         |> Closure_id.Lmap.bindings)
   in
-  let acc, body = body acc env in
-  let named = Named.create_set_of_closures set_of_closures in
-  Let_with_acc.create acc
-    (Bindable_let_bound.set_of_closures ~closure_vars)
-    named
-    ~body ~free_names_of_body:Unknown
-  |> Expr_with_acc.create_let
+  if Set_of_closures.environment_doesn't_mention_variables set_of_closures
+  then
+    let acc, symbols =
+      register_set_of_closures_as_symbols acc set_of_closures
+    in
+    let env =
+      Closure_id.Lmap.fold (fun closure_id symbol env ->
+          let ident = Closure_id.Map.find closure_id ident_map in
+          Env.add_simple_to_substitute env ident (Simple.symbol symbol))
+        symbols
+        env
+    in
+    body acc env
+  else
+    let acc, body = body acc env in
+    Let_with_acc.create acc
+      (Bindable_let_bound.set_of_closures ~closure_vars)
+      (Named.create_set_of_closures set_of_closures)
+      ~body ~free_names_of_body:Unknown
+    |> Expr_with_acc.create_let
 
 let close_program ~backend ~module_ident ~module_block_size_in_words
       ~program ~prog_return_cont ~exn_continuation =
@@ -1132,6 +1160,26 @@ let close_program ~backend ~module_ident ~module_block_size_in_words
       ~cost_metrics_of_handler
   in
   let acc, body =
+    List.fold_left (fun (acc, body) (symbols, set_of_closures) ->
+        let bound_symbols =
+          Bound_symbols.singleton
+            (Bound_symbols.Pattern.set_of_closures symbols)
+        in
+        let defining_expr =
+          Named.create_static_consts
+            (Static_const.Group.create [Set_of_closures set_of_closures])
+        in
+        Let_with_acc.create acc
+          (Bindable_let_bound.symbols bound_symbols Syntactic)
+          defining_expr ~body ~free_names_of_body:Unknown
+        |> Expr_with_acc.create_let
+      )
+      (acc, body)
+      (Acc.declared_static_sets_of_closures acc)
+  in
+  let acc, body =
+    (* CR Keryan: The order of the bindings is important as blocks of code
+       might refer one another. There should be a topological sort here. *)
     Code_id.Map.fold (fun code_id code (acc, body) ->
       let bound_symbols =
           Bound_symbols.singleton (Bound_symbols.Pattern.code code_id)

--- a/middle_end/flambda/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion.ml
@@ -37,6 +37,10 @@ module LC = Lambda_conversions
 module P = Flambda_primitive
 module VB = Var_in_binding_pos
 
+type close_functions_result =
+  | Lifted of Symbol.t Closure_id.Lmap.t
+  | Dynamic of Set_of_closures.t
+
 (* Do not use [Simple.symbol], use this function instead, to ensure that
    we correctly compute the free names of [Code]. *)
 let use_of_symbol_as_simple acc symbol =
@@ -47,18 +51,14 @@ let symbol_for_ident acc env id =
   let symbol = Env.symbol_for_global' env id in
   use_of_symbol_as_simple acc symbol
 
-let register_set_of_closures_as_symbols acc set_of_closures
-      : Acc.t * Symbol.t Closure_id.Lmap.t =
-  let symbols =
-    Set_of_closures.function_decls set_of_closures
-    |> Function_declarations.funs_in_order
-    |> Closure_id.Lmap.mapi (fun closure_id _ ->
-        Symbol.create (Compilation_unit.get_current_exn ())
-          (Linkage_name.create
-             (Variable.unique_name (Closure_id.unwrap closure_id))))
+let declare_symbol_for_closure_ident env ident closure_id
+  : Env.t * Symbol.t =
+  let symbol =
+    Symbol.create (Compilation_unit.get_current_exn ())
+      (Linkage_name.create (Closure_id.to_string closure_id))
   in
-  let acc = Acc.add_declared_set_of_closures ~symbols ~set_of_closures acc in
-  acc, symbols
+  let env = Env.add_simple_to_substitute env ident (Simple.symbol symbol) in
+  env, symbol
 
 let register_const0 acc constant name =
   match Static_const.Map.find constant (Acc.shareable_constants acc) with
@@ -720,8 +720,8 @@ let close_switch acc env scrutinee (sw : IR.switch)
       |> Expr_with_acc.create_let
 
 let close_one_function acc ~external_env ~by_closure_id decl
-      ~var_within_closures_from_idents ~closure_ids_from_idents
-      function_declarations =
+      ~has_lifted_closure ~var_within_closures_from_idents
+      ~closure_ids_from_idents function_declarations =
   let acc = Acc.with_free_names Name_occurrences.empty acc in
   let body = Function_decl.body decl in
   let loc = Function_decl.loc decl in
@@ -762,31 +762,42 @@ let close_one_function acc ~external_env ~by_closure_id decl
       var_within_closures_from_idents
       (Variable.Map.empty, Ident.Map.empty)
   in
+  if has_lifted_closure
+  && not (Variable.Map.is_empty var_within_closures_to_bind)
+  then
+    Misc.fatal_errorf "Variables found in closure when trying \
+        to lift %a in [Closure_conversion]."
+      Ident.print our_let_rec_ident;
   (* CR mshinwell: Remove "project_closure" names *)
   let project_closure_to_bind, vars_for_project_closure =
-    List.fold_left (fun (to_bind, vars_for_idents) function_decl ->
-        let let_rec_ident = Function_decl.let_rec_ident function_decl in
-        let to_bind, var =
-          if Ident.same our_let_rec_ident let_rec_ident && is_curried then
-            (* When the function being compiled is tupled, my_closure
-               points to the curried version but let_rec_ident is called
-               with tuple arguments, so the correct closure to bind
-               is the one in the closure_ids_from_idents map.
-            *)
-            to_bind, my_closure  (* my_closure is already bound *)
-          else
-            let variable =
-              Variable.create_with_same_name_as_ident let_rec_ident
-            in
-            let closure_id =
-              Ident.Map.find let_rec_ident closure_ids_from_idents
-            in
-            Variable.Map.add variable closure_id to_bind, variable
-        in
-        to_bind,
-        Ident.Map.add let_rec_ident var vars_for_idents)
-      (Variable.Map.empty, Ident.Map.empty)
-      (Function_decls.to_list function_declarations)
+    if has_lifted_closure
+    then
+      (* No projection needed *)
+      Variable.Map.empty, Ident.Map.empty
+    else
+      List.fold_left (fun (to_bind, vars_for_idents) function_decl ->
+          let let_rec_ident = Function_decl.let_rec_ident function_decl in
+          let to_bind, var =
+            if Ident.same our_let_rec_ident let_rec_ident && is_curried then
+              (* When the function being compiled is tupled, my_closure
+                 points to the curried version but let_rec_ident is called
+                 with tuple arguments, so the correct closure to bind
+                 is the one in the closure_ids_from_idents map.
+              *)
+              to_bind, my_closure  (* my_closure is already bound *)
+            else
+              let variable =
+                Variable.create_with_same_name_as_ident let_rec_ident
+              in
+              let closure_id =
+                Ident.Map.find let_rec_ident closure_ids_from_idents
+              in
+              Variable.Map.add variable closure_id to_bind, variable
+          in
+          to_bind,
+          Ident.Map.add let_rec_ident var vars_for_idents)
+        (Variable.Map.empty, Ident.Map.empty)
+        (Function_decls.to_list function_declarations)
   in
   let closure_env_without_parameters =
     let empty_env = Env.clear_local_bindings external_env in
@@ -963,6 +974,9 @@ let close_functions acc external_env function_declarations =
       (Function_decls.all_free_idents function_declarations)
       Ident.Map.empty
   in
+  let can_be_lifted =
+    Ident.Map.is_empty var_within_closures_from_idents
+  in
   let func_decl_list = Function_decls.to_list function_declarations in
   let closure_ids_from_idents =
     List.fold_left (fun map decl ->
@@ -972,13 +986,26 @@ let close_functions acc external_env function_declarations =
       Ident.Map.empty
       func_decl_list
   in
+  let external_env, symbol_map =
+    if can_be_lifted
+    then
+      Ident.Map.fold (fun ident closure_id (env, symbol_map) ->
+        let env, symbol =
+          declare_symbol_for_closure_ident env ident closure_id
+        in
+        env,
+        Closure_id.Map.add closure_id symbol symbol_map)
+        closure_ids_from_idents
+        (external_env, Closure_id.Map.empty)
+    else external_env, Closure_id.Map.empty
+  in
   let acc, funs =
     List.fold_left (fun (acc, by_closure_id) function_decl ->
         let _, acc, expr =
           Acc.measure_cost_metrics acc ~f:(fun acc ->
             close_one_function acc ~external_env ~by_closure_id function_decl
-              ~var_within_closures_from_idents ~closure_ids_from_idents
-              function_declarations)
+              ~has_lifted_closure:can_be_lifted ~var_within_closures_from_idents
+              ~closure_ids_from_idents function_declarations)
         in
         acc, expr)
       (acc, Closure_id.Map.empty)
@@ -997,8 +1024,22 @@ let close_functions acc external_env function_declarations =
       var_within_closures_from_idents
       Var_within_closure.Map.empty
   in
-  acc,
-  Set_of_closures.create function_decls ~closure_elements
+  let set_of_closures =
+    Set_of_closures.create function_decls ~closure_elements
+  in
+  if can_be_lifted
+  then
+    let symbols =
+      Closure_id.Lmap.mapi (fun closure_id _ ->
+        Closure_id.Map.find closure_id symbol_map)
+        funs
+    in
+    let acc =
+      Acc.add_declared_set_of_closures ~symbols ~set_of_closures acc
+    in
+    acc, Lifted symbols
+  else
+    acc, Dynamic set_of_closures
 
 let close_let_rec acc env ~function_declarations
   ~(body : Acc.t -> Env.t -> Acc.t * Expr_with_acc.t) =
@@ -1022,37 +1063,11 @@ let close_let_rec acc env ~function_declarations
       (Closure_id.Map.empty, Closure_id.Map.empty)
       function_declarations
   in
-  let acc, set_of_closures =
+  let acc, closed_functions =
     close_functions acc env (Function_decls.create function_declarations)
   in
-  (* CR mshinwell: We should maybe have something more elegant here *)
-  let generated_closures =
-    Closure_id.Set.diff
-      (Closure_id.Map.keys (Function_declarations.funs (
-        Set_of_closures.function_decls set_of_closures)))
-      (Closure_id.Map.keys closure_vars)
-  in
-  let closure_vars =
-    Closure_id.Set.fold (fun closure_id closure_vars ->
-        let closure_var =
-          VB.create (Variable.create "generated") Name_mode.normal
-        in
-        Closure_id.Map.add closure_id closure_var closure_vars)
-      generated_closures
-      closure_vars
-  in
-  let closure_vars =
-    List.map (fun (closure_id, _) ->
-        Closure_id.Map.find closure_id closure_vars)
-      (Function_declarations.funs_in_order (
-          Set_of_closures.function_decls set_of_closures)
-        |> Closure_id.Lmap.bindings)
-  in
-  if Set_of_closures.environment_doesn't_mention_variables set_of_closures
-  then
-    let acc, symbols =
-      register_set_of_closures_as_symbols acc set_of_closures
-    in
+  match closed_functions with
+  | Lifted symbols ->
     let env =
       Closure_id.Lmap.fold (fun closure_id symbol env ->
           let ident = Closure_id.Map.find closure_id ident_map in
@@ -1061,7 +1076,30 @@ let close_let_rec acc env ~function_declarations
         env
     in
     body acc env
-  else
+  | Dynamic set_of_closures ->
+    (* CR mshinwell: We should maybe have something more elegant here *)
+    let generated_closures =
+      Closure_id.Set.diff
+        (Closure_id.Map.keys (Function_declarations.funs (
+             Set_of_closures.function_decls set_of_closures)))
+        (Closure_id.Map.keys closure_vars)
+    in
+    let closure_vars =
+      Closure_id.Set.fold (fun closure_id closure_vars ->
+          let closure_var =
+            VB.create (Variable.create "generated") Name_mode.normal
+          in
+          Closure_id.Map.add closure_id closure_var closure_vars)
+        generated_closures
+        closure_vars
+    in
+    let closure_vars =
+      List.map (fun (closure_id, _) ->
+          Closure_id.Map.find closure_id closure_vars)
+        (Function_declarations.funs_in_order (
+            Set_of_closures.function_decls set_of_closures)
+         |> Closure_id.Lmap.bindings)
+    in
     let acc, body = body acc env in
     Let_with_acc.create acc
       (Bindable_let_bound.set_of_closures ~closure_vars)

--- a/middle_end/flambda/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion_aux.ml
@@ -190,6 +190,8 @@ end
 module Acc = struct
   type t = {
     declared_symbols : (Symbol.t * Flambda.Static_const.t) list;
+    declared_static_sets_of_closures
+      : (Symbol.t Closure_id.Lmap.t * Flambda.Set_of_closures.t) list;
     shareable_constants : Symbol.t Flambda.Static_const.Map.t;
     code : Flambda.Code.t Code_id.Map.t;
     free_names_of_current_function : Name_occurrences.t;
@@ -209,6 +211,7 @@ module Acc = struct
 
   let empty = {
     declared_symbols = [];
+    declared_static_sets_of_closures = [];
     shareable_constants = Flambda.Static_const.Map.empty;
     code = Code_id.Map.empty;
     free_names_of_current_function = Name_occurrences.empty;
@@ -218,6 +221,7 @@ module Acc = struct
   }
 
   let declared_symbols t = t.declared_symbols
+  let declared_static_sets_of_closures t = t.declared_static_sets_of_closures
   let shareable_constants t = t.shareable_constants
   let code t = t.code
   let free_names_of_current_function t = t.free_names_of_current_function
@@ -226,6 +230,11 @@ module Acc = struct
   let add_declared_symbol ~symbol ~constant t =
     let declared_symbols = (symbol, constant) :: t.declared_symbols in
     { t with declared_symbols; }
+
+  let add_declared_set_of_closures ~symbols ~set_of_closures t =
+    { t with
+      declared_static_sets_of_closures =
+        (symbols, set_of_closures) :: t.declared_static_sets_of_closures; }
 
   let add_shareable_constant ~symbol ~constant t =
     let shareable_constants =

--- a/middle_end/flambda/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda/from_lambda/closure_conversion_aux.mli
@@ -119,15 +119,16 @@ module Acc : sig
   val empty : t
 
   val declared_symbols : t -> (Symbol.t * Flambda.Static_const.t) list
-  val declared_static_sets_of_closures
-     : t -> (Symbol.t Closure_id.Lmap.t * Flambda.Set_of_closures.t) list
   val shareable_constants : t -> Symbol.t Flambda.Static_const.Map.t
-  val code : t -> Flambda.Code.t Code_id.Map.t
   val free_names_of_current_function : t -> Name_occurrences.t
   val free_continuations : t -> Name_occurrences.t
 
   val seen_a_function : t -> bool
   val with_seen_a_function : t -> bool -> t
+
+  val sorted_static_functions_bindings
+     : t
+    -> (Bound_symbols.Pattern.t * Flambda.Static_const.t) list list
 
   val add_declared_symbol
      : symbol:Symbol.t
@@ -150,6 +151,7 @@ module Acc : sig
   val add_code : code_id:Code_id.t -> code:Flambda.Code.t -> t -> t
 
   val add_symbol_to_free_names : symbol:Symbol.t -> t -> t
+  val add_code_id_to_free_names : code_id:Code_id.t -> t -> t
   val add_closure_var_to_free_names : closure_var:Var_within_closure.t -> t -> t
   val add_continuation_occurrence
     : cont:Continuation.t -> has_traps:bool -> t -> t

--- a/middle_end/flambda/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda/from_lambda/closure_conversion_aux.mli
@@ -119,6 +119,8 @@ module Acc : sig
   val empty : t
 
   val declared_symbols : t -> (Symbol.t * Flambda.Static_const.t) list
+  val declared_static_sets_of_closures
+     : t -> (Symbol.t Closure_id.Lmap.t * Flambda.Set_of_closures.t) list
   val shareable_constants : t -> Symbol.t Flambda.Static_const.Map.t
   val code : t -> Flambda.Code.t Code_id.Map.t
   val free_names_of_current_function : t -> Name_occurrences.t
@@ -130,6 +132,12 @@ module Acc : sig
   val add_declared_symbol
      : symbol:Symbol.t
     -> constant:Flambda.Static_const.t
+    -> t
+    -> t
+
+  val add_declared_set_of_closures
+     : symbols:(Symbol.t Closure_id.Lmap.t)
+    -> set_of_closures:Flambda.Set_of_closures.t
     -> t
     -> t
 


### PR DESCRIPTION
This finish the job of #511 by replacing closure projections by the corresponding lifted symbols and ordering the symbols topologically before declaring them, and grouping when necessary.

This is concurrent to #541, which simply groups declarations together in a single let-binding.

The patch is not in a mergeable state, see issue #542.

I open the two PRs to discuss which approach is preferable as I have little insight on the way Simplify deals with let-symbols, performance-wise.

This patch is heavier than #541 (which doesn't add cost to the transformation) but produce code that might be more easily handled down the line. Sorting the declarations is done in a very similar way than `Sorted_lifted_constants`, which is a bit frustrating but I didn't think wise to try to adapt it to be of use in `Lambda_to_flambda`.