### PR TITLE
Grouping symbols for closures and code, and closure projection substitution

### DIFF
--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -950,29 +950,36 @@ method emit_expr (env:environment) exp =
       let env_body = env_enter_trywith env kind in
       let (r1, s1) = self#emit_sequence env_body e1 in
       let rv = self#regs_for typ_val in
-      let env_handler =
-        let env = env_add v rv env in
-        match kind with
-        | Regular -> env
-        | Delayed lbl ->
-          begin match env_find_static_exception lbl env_body with
-          | (_, { contents = Reachable ts; }) ->
-            env_set_trap_stack env ts
-          | (_, { contents = Unreachable; }) ->
-            Misc.fatal_errorf "Selection.emit_expr: Unreachable exception handler %d" lbl
-          | exception Not_found ->
-            Misc.fatal_errorf "Selection.emit_expr: Unbound handler %d" lbl
-          end
+      let with_handler env_handler e2 =
+        let (r2, s2) = self#emit_sequence env_handler e2 in
+        let r = join env r1 s1 r2 s2 in
+        self#insert env
+          (Itrywith(s1#extract, kind,
+                    (env_handler.trap_stack,
+                     instr_cons (Iop Imove) [|Proc.loc_exn_bucket|] rv
+                       (s2#extract))))
+          [||] [||];
+        r
       in
-      let (r2, s2) = self#emit_sequence env_handler e2 in
-      let r = join env r1 s1 r2 s2 in
-      self#insert env
-        (Itrywith(s1#extract, kind,
-                  (env_handler.trap_stack,
-                   instr_cons (Iop Imove) [|Proc.loc_exn_bucket|] rv
-                              (s2#extract))))
-        [||] [||];
-      r
+      let env = env_add v rv env in
+      match kind with
+      | Regular -> with_handler env e2
+      | Delayed lbl ->
+        begin match env_find_static_exception lbl env_body with
+        | (_, { contents = Reachable ts; }) ->
+          with_handler (env_set_trap_stack env ts) e2
+        | (_, { contents = Unreachable; }) ->
+          let unreachable =
+            Cmm.(Cop ((Cload (Word_int, Mutable)),
+                      [Cconst_int (0, Debuginfo.none)],
+                      Debuginfo.none))
+          in
+          with_handler env unreachable
+          (* Misc.fatal_errorf "Selection.emit_expr: \
+           *                    Unreachable exception handler %d" lbl *)
+        | exception Not_found ->
+          Misc.fatal_errorf "Selection.emit_expr: Unbound handler %d" lbl
+        end
 
 method private emit_sequence (env:environment) exp =
   let s = {< instr_seq = dummy_instr >} in
@@ -1300,26 +1307,34 @@ method emit_tail (env:environment) exp =
       let env_body = env_enter_trywith env kind in
       let s1 = self#emit_tail_sequence env_body e1 in
       let rv = self#regs_for typ_val in
-      let env_handler =
-        let env = env_add v rv env in
-        match kind with
-        | Regular -> env
-        | Delayed lbl ->
-          begin match env_find_static_exception lbl env_body with
-          | (_, { contents = Reachable ts; }) ->
-            env_set_trap_stack env ts
-          | (_, { contents = Unreachable; }) ->
-            Misc.fatal_errorf "Selection.emit_expr: Unreachable exception handler %d" lbl
-          | exception Not_found ->
-            Misc.fatal_errorf "Selection.emit_expr: Unbound handler %d" lbl
-          end
+      let with_handler env_handler e2 =
+        let s2 = self#emit_tail_sequence env_handler e2 in
+        self#insert env
+          (Itrywith(s1, kind,
+                    (env_handler.trap_stack,
+                     instr_cons (Iop Imove) [|Proc.loc_exn_bucket|] rv s2)))
+          [||] [||]
       in
-      let s2 = self#emit_tail_sequence env_handler e2 in
-      self#insert env
-        (Itrywith(s1, kind,
-                  (env_handler.trap_stack,
-                   instr_cons (Iop Imove) [|Proc.loc_exn_bucket|] rv s2)))
-        [||] [||]
+      let env = env_add v rv env in
+      begin match kind with
+      | Regular -> with_handler env e2
+      | Delayed lbl ->
+        begin match env_find_static_exception lbl env_body with
+        | (_, { contents = Reachable ts; }) ->
+          with_handler (env_set_trap_stack env ts) e2
+        | (_, { contents = Unreachable; }) ->
+          let unreachable =
+            Cmm.(Cop ((Cload (Word_int, Mutable)),
+                      [Cconst_int (0, Debuginfo.none)],
+                      Debuginfo.none))
+          in
+          with_handler env unreachable
+          (* Misc.fatal_errorf "Selection.emit_expr: \
+             Unreachable exception handler %d" lbl *)
+        | exception Not_found ->
+          Misc.fatal_errorf "Selection.emit_expr: Unbound handler %d" lbl
+        end
+      end
   | Cop _
   | Cconst_int _ | Cconst_natint _ | Cconst_float _ | Cconst_symbol _
   | Cvar _

--- a/middle_end/flambda/flambda_middle_end.ml
+++ b/middle_end/flambda/flambda_middle_end.ml
@@ -80,47 +80,55 @@ let middle_end0 ppf ~prefixname ~backend ~filename ~module_ident
       ~module_block_size_in_words ~module_initializer =
   Misc.Color.setup !Clflags.color;
   Profile.record_call "flambda.0" (fun () ->
-    let flambda =
+    let flambda, code =
       Profile.record_call "lambda_to_flambda" (fun () ->
         Lambda_to_flambda.lambda_to_flambda ~backend ~module_ident
           ~module_block_size_in_words module_initializer)
     in
     print_rawflambda ppf flambda;
     check_invariants flambda;
-    let flambda =
-      if !Clflags.Flambda.Debug.permute_every_name
-      then Flambda_unit.permute_everything flambda
-      else flambda
-    in
-    let round = 0 in
-    let new_flambda =
-      Profile.record_call ~accumulate:true "simplify"
-        (fun () -> Simplify.run ~backend ~round flambda)
-    in
-    if !Clflags.inlining_report then begin
-      let output_prefix = Printf.sprintf "%s.%d" prefixname round in
-      Inlining_report.output_then_forget_decisions ~output_prefix
-    end;
-    print_flambda "simplify" ppf new_flambda.unit;
-    output_flexpect ~ml_filename:filename flambda new_flambda.unit;
-    new_flambda)
+    if !Clflags.Flambda.Expert.fallback_inlining_heuristic
+    then
+      { cmx = None;
+        unit = flambda;
+        all_code = code;
+      }
+    else begin
+      let flambda =
+        if !Clflags.Flambda.Debug.permute_every_name
+        then Flambda_unit.permute_everything flambda
+        else flambda
+      in
+      let round = 0 in
+      let new_flambda =
+        Profile.record_call ~accumulate:true "simplify"
+          (fun () -> Simplify.run ~backend ~round flambda)
+      in
+      if !Clflags.inlining_report then begin
+        let output_prefix = Printf.sprintf "%s.%d" prefixname round in
+        Inlining_report.output_then_forget_decisions ~output_prefix
+      end;
+      print_flambda "simplify" ppf new_flambda.unit;
+      output_flexpect ~ml_filename:filename flambda new_flambda.unit;
+      { cmx = new_flambda.cmx;
+        unit = new_flambda.unit;
+        all_code = new_flambda.all_code;
+      }
+    end)
 
 let middle_end ~ppf_dump:ppf ~prefixname ~backend ~filename ~module_ident
       ~module_block_size_in_words ~module_initializer : middle_end_result =
-  let simplify_result =
+  let middle_end_result =
     middle_end0 ppf ~prefixname ~backend ~filename ~module_ident
       ~module_block_size_in_words ~module_initializer
   in
   begin match Sys.getenv "PRINT_SIZES" with
   | exception Not_found -> ()
   | _ ->
-    Exported_code.iter simplify_result.all_code (fun id code ->
+    Exported_code.iter middle_end_result.all_code (fun id code ->
       let size = Flambda.Code.cost_metrics code in
       Format.fprintf Format.std_formatter "%a %a\n"
         Code_id.print id Flambda.Cost_metrics.print size
     )
   end;
-  { cmx = simplify_result.cmx;
-    unit = simplify_result.unit;
-    all_code = simplify_result.all_code;
-  }
+  middle_end_result

--- a/middle_end/flambda/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion.ml
@@ -707,6 +707,7 @@ let close_one_function acc ~external_env ~by_closure_id decl
   let dbg = Debuginfo.from_location loc in
   let params = Function_decl.params decl in
   let return = Function_decl.return decl in
+  let return_continuation = Function_decl.return_continuation decl in
   let recursive = Function_decl.recursive decl in
   let my_closure = Variable.create "my_closure" in
   let closure_id = Function_decl.closure_id decl in
@@ -895,9 +896,14 @@ let close_one_function acc ~external_env ~by_closure_id decl
     then Never_inline
     else LC.inline_attribute (Function_decl.inline decl)
   in
+  let acc =
+    Acc.remove_continuation_from_free_names return_continuation acc
+    |> Acc.remove_continuation_from_free_names
+         (Exn_continuation.exn_handler exn_continuation)
+  in
   let params_and_body =
     Function_params_and_body.create
-      ~return_continuation:(Function_decl.return_continuation decl)
+      ~return_continuation
       exn_continuation params ~dbg ~body ~my_closure ~my_depth
       ~free_names_of_body:Unknown
   in
@@ -911,7 +917,7 @@ let close_one_function acc ~external_env ~by_closure_id decl
     Code.create
       code_id
       ~params_and_body:
-        (Present (params_and_body, Acc.free_names_of_current_function acc))
+        (Present (params_and_body, Acc.free_names acc))
       ~params_arity
       ~result_arity:[LC.value_kind return]
       ~stub
@@ -965,18 +971,22 @@ let close_functions acc external_env function_declarations =
       Ident.Map.empty
       func_decl_list
   in
-  let acc, funs =
-    List.fold_left (fun (acc, by_closure_id) function_decl ->
+  let acc, funs, free_names =
+    List.fold_left (fun (acc, by_closure_id, free_names) function_decl ->
         let _, acc, expr =
           Acc.measure_cost_metrics acc ~f:(fun acc ->
             close_one_function acc ~external_env ~by_closure_id function_decl
               ~var_within_closures_from_idents ~closure_ids_from_idents
               function_declarations)
         in
-        acc, expr)
-      (acc, Closure_id.Map.empty)
+        let free_names =
+          Name_occurrences.union free_names (Acc.free_names acc)
+        in
+        acc, expr, free_names)
+      (acc, Closure_id.Map.empty, Acc.free_names acc)
       func_decl_list
   in
+  let acc = Acc.with_free_names free_names acc in
   (* CR lmaurer: funs has arbitrary order (ultimately coming from
      function_declarations) *)
   let funs =

--- a/middle_end/flambda/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion.ml
@@ -1211,6 +1211,6 @@ let close_program ~backend ~module_ident ~module_block_size_in_words
       (acc, body)
       (Acc.declared_symbols acc)
   in
-  ignore (acc : Acc.t);
   Flambda_unit.create ~return_continuation:return_cont ~exn_continuation
-    ~body ~module_symbol ~used_closure_vars:Unknown
+    ~body ~module_symbol ~used_closure_vars:Unknown,
+  Exported_code.add_code (Acc.code acc) Exported_code.empty

--- a/middle_end/flambda/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion.ml
@@ -47,6 +47,19 @@ let symbol_for_ident acc env id =
   let symbol = Env.symbol_for_global' env id in
   use_of_symbol_as_simple acc symbol
 
+let register_set_of_closures_as_symbols acc set_of_closures
+      : Acc.t * Symbol.t Closure_id.Lmap.t =
+  let symbols =
+    Set_of_closures.function_decls set_of_closures
+    |> Function_declarations.funs_in_order
+    |> Closure_id.Lmap.mapi (fun closure_id _ ->
+        Symbol.create (Compilation_unit.get_current_exn ())
+          (Linkage_name.create
+             (Variable.unique_name (Closure_id.unwrap closure_id))))
+  in
+  let acc = Acc.add_declared_set_of_closures ~symbols ~set_of_closures acc in
+  acc, symbols
+
 let register_const0 acc constant name =
   match Static_const.Map.find constant (Acc.shareable_constants acc) with
   | exception Not_found ->
@@ -1015,15 +1028,17 @@ let close_let_rec acc env ~function_declarations
         env)
       function_declarations env
   in
-  let closure_vars =
-    List.fold_left (fun closure_vars decl ->
+  let closure_vars, ident_map =
+    List.fold_left (fun (closure_vars, ident_map) decl ->
+        let ident = Function_decl.let_rec_ident decl in
         let closure_var =
-          VB.create (Env.find_var env (Function_decl.let_rec_ident decl))
+          VB.create (Env.find_var env ident)
             Name_mode.normal
         in
         let closure_id = Function_decl.closure_id decl in
-        Closure_id.Map.add closure_id closure_var closure_vars)
-      Closure_id.Map.empty
+        Closure_id.Map.add closure_id closure_var closure_vars,
+        Closure_id.Map.add closure_id ident ident_map)
+      (Closure_id.Map.empty, Closure_id.Map.empty)
       function_declarations
   in
   let acc, set_of_closures =
@@ -1052,13 +1067,26 @@ let close_let_rec acc env ~function_declarations
           Set_of_closures.function_decls set_of_closures)
         |> Closure_id.Lmap.bindings)
   in
-  let acc, body = body acc env in
-  let named = Named.create_set_of_closures set_of_closures in
-  Let_with_acc.create acc
-    (Bindable_let_bound.set_of_closures ~closure_vars)
-    named
-    ~body ~free_names_of_body:Unknown
-  |> Expr_with_acc.create_let
+  if Set_of_closures.environment_doesn't_mention_variables set_of_closures
+  then
+    let acc, symbols =
+      register_set_of_closures_as_symbols acc set_of_closures
+    in
+    let env =
+      Closure_id.Lmap.fold (fun closure_id symbol env ->
+          let ident = Closure_id.Map.find closure_id ident_map in
+          Env.add_simple_to_substitute env ident (Simple.symbol symbol))
+        symbols
+        env
+    in
+    body acc env
+  else
+    let acc, body = body acc env in
+    Let_with_acc.create acc
+      (Bindable_let_bound.set_of_closures ~closure_vars)
+      (Named.create_set_of_closures set_of_closures)
+      ~body ~free_names_of_body:Unknown
+    |> Expr_with_acc.create_let
 
 let close_program ~backend ~module_ident ~module_block_size_in_words
       ~program ~prog_return_cont ~exn_continuation =
@@ -1162,6 +1190,26 @@ let close_program ~backend ~module_ident ~module_block_size_in_words
       ~cost_metrics_of_handler
   in
   let acc, body =
+    List.fold_left (fun (acc, body) (symbols, set_of_closures) ->
+        let bound_symbols =
+          Bound_symbols.singleton
+            (Bound_symbols.Pattern.set_of_closures symbols)
+        in
+        let defining_expr =
+          Named.create_static_consts
+            (Static_const.Group.create [Set_of_closures set_of_closures])
+        in
+        Let_with_acc.create acc
+          (Bindable_let_bound.symbols bound_symbols Syntactic)
+          defining_expr ~body ~free_names_of_body:Unknown
+        |> Expr_with_acc.create_let
+      )
+      (acc, body)
+      (Acc.declared_static_sets_of_closures acc)
+  in
+  let acc, body =
+    (* CR Keryan: The order of the bindings is important as blocks of code
+       might refer one another. There should be a topological sort here. *)
     Code_id.Map.fold (fun code_id code (acc, body) ->
       let bound_symbols =
           Bound_symbols.singleton (Bound_symbols.Pattern.code code_id)

--- a/middle_end/flambda/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion.ml
@@ -988,6 +988,7 @@ let close_functions acc external_env function_declarations =
   in
   let can_be_lifted =
     Ident.Map.is_empty var_within_closures_from_idents
+    && !Clflags.Flambda.Expert.fallback_inlining_heuristic
   in
   let func_decl_list = Function_decls.to_list function_declarations in
   let closure_ids_from_idents =

--- a/middle_end/flambda/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion.ml
@@ -1189,44 +1189,32 @@ let close_program ~backend ~module_ident ~module_block_size_in_words
       ~body
       ~cost_metrics_of_handler
   in
-  let acc, body =
-    List.fold_left (fun (acc, body) (symbols, set_of_closures) ->
-        let bound_symbols =
-          Bound_symbols.singleton
-            (Bound_symbols.Pattern.set_of_closures symbols)
-        in
-        let defining_expr =
-          Named.create_static_consts
-            (Static_const.Group.create [Set_of_closures set_of_closures])
-        in
-        Let_with_acc.create acc
-          (Bindable_let_bound.symbols bound_symbols Syntactic)
-          defining_expr ~body ~free_names_of_body:Unknown
-        |> Expr_with_acc.create_let
-      )
-      (acc, body)
+  let bound_set_of_closures_symbols, set_of_closures_consts =
+    List.fold_left (fun (bound_symbols, consts) (symbols, set_of_closures) ->
+        let symbols = Bound_symbols.Pattern.set_of_closures symbols in
+        let const : Static_const.t = Set_of_closures set_of_closures in
+        symbols::bound_symbols, const::consts)
+      ([], [])
       (Acc.declared_static_sets_of_closures acc)
   in
-  let acc, body =
-    (* CR Keryan: The order of the bindings is important as blocks of code
-       might refer one another. There should be a topological sort here. *)
-    Code_id.Map.fold (fun code_id code (acc, body) ->
-      let bound_symbols =
-          Bound_symbols.singleton (Bound_symbols.Pattern.code code_id)
-        in
-        let static_const : Static_const.t =
-          Code code
-        in
-        let defining_expr =
-          Static_const.Group.create [static_const]
-          |> Named.create_static_consts
-        in
-        Let_with_acc.create acc
-          (Bindable_let_bound.symbols bound_symbols Syntactic)
-          defining_expr ~body ~free_names_of_body:Unknown
-        |> Expr_with_acc.create_let)
+  let bound_symbols, consts =
+    Code_id.Map.fold (fun code_id code (bound_symbols, consts) ->
+        let symbol = Bound_symbols.Pattern.code code_id in
+        let const : Static_const.t = Code code in
+        symbol::bound_symbols, const::consts)
       (Acc.code acc)
-      (acc, body)
+      (bound_set_of_closures_symbols, set_of_closures_consts)
+  in
+  let acc, body =
+    let bound_symbols = Bound_symbols.create bound_symbols in
+    let defining_expr =
+      Named.create_static_consts
+        (Static_const.Group.create consts)
+    in
+    Let_with_acc.create acc
+      (Bindable_let_bound.symbols bound_symbols Syntactic)
+      defining_expr ~body ~free_names_of_body:Unknown
+    |> Expr_with_acc.create_let
   in
   (* We must make sure there is always an outer [Let_symbol] binding so that
      lifted constants not in the scope of any other [Let_symbol] binding get

--- a/middle_end/flambda/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion.ml
@@ -37,6 +37,10 @@ module LC = Lambda_conversions
 module P = Flambda_primitive
 module VB = Var_in_binding_pos
 
+type close_functions_result =
+  | Lifted of Symbol.t Closure_id.Lmap.t
+  | Dynamic of Set_of_closures.t
+
 (* Do not use [Simple.symbol], use this function instead, to ensure that
    we correctly compute the free names of [Code]. *)
 let use_of_symbol_as_simple acc symbol =
@@ -47,18 +51,14 @@ let symbol_for_ident acc env id =
   let symbol = Env.symbol_for_global' env id in
   use_of_symbol_as_simple acc symbol
 
-let register_set_of_closures_as_symbols acc set_of_closures
-      : Acc.t * Symbol.t Closure_id.Lmap.t =
-  let symbols =
-    Set_of_closures.function_decls set_of_closures
-    |> Function_declarations.funs_in_order
-    |> Closure_id.Lmap.mapi (fun closure_id _ ->
-        Symbol.create (Compilation_unit.get_current_exn ())
-          (Linkage_name.create
-             (Variable.unique_name (Closure_id.unwrap closure_id))))
+let declare_symbol_for_closure_ident env ident closure_id
+  : Env.t * Symbol.t =
+  let symbol =
+    Symbol.create (Compilation_unit.get_current_exn ())
+      (Linkage_name.create (Closure_id.to_string closure_id))
   in
-  let acc = Acc.add_declared_set_of_closures ~symbols ~set_of_closures acc in
-  acc, symbols
+  let env = Env.add_simple_to_substitute env ident (Simple.symbol symbol) in
+  env, symbol
 
 let register_const0 acc constant name =
   match Static_const.Map.find constant (Acc.shareable_constants acc) with
@@ -712,8 +712,8 @@ let close_switch acc env scrutinee (sw : IR.switch)
 external reraise : exn -> 'a = "%reraise"
 
 let close_one_function acc ~external_env ~by_closure_id decl
-      ~var_within_closures_from_idents ~closure_ids_from_idents
-      function_declarations =
+      ~has_lifted_closure ~var_within_closures_from_idents
+      ~closure_ids_from_idents function_declarations =
   let acc = Acc.with_free_names Name_occurrences.empty acc in
   let body = Function_decl.body decl in
   let loc = Function_decl.loc decl in
@@ -761,32 +761,43 @@ let close_one_function acc ~external_env ~by_closure_id decl
       ~from:(Rec_info_expr.var my_depth)
       ~to_:(Rec_info_expr.var next_depth)
   in
+  if has_lifted_closure
+  && not (Variable.Map.is_empty var_within_closures_to_bind)
+  then
+    Misc.fatal_errorf "Variables found in closure when trying \
+        to lift %a in [Closure_conversion]."
+      Ident.print our_let_rec_ident;
   (* CR mshinwell: Remove "project_closure" names *)
   let project_closure_to_bind, simples_for_project_closure =
-    List.fold_left (fun (to_bind, simples_for_idents) function_decl ->
-        let let_rec_ident = Function_decl.let_rec_ident function_decl in
-        let to_bind, var =
-          if Ident.same our_let_rec_ident let_rec_ident && is_curried then
-            (* When the function being compiled is tupled, my_closure
-               points to the curried version but let_rec_ident is called
-               with tuple arguments, so the correct closure to bind
-               is the one in the closure_ids_from_idents map.
-            *)
-            to_bind, my_closure  (* my_closure is already bound *)
-          else
-            let variable =
-              Variable.create_with_same_name_as_ident let_rec_ident
-            in
-            let closure_id =
-              Ident.Map.find let_rec_ident closure_ids_from_idents
-            in
-            Variable.Map.add variable closure_id to_bind, variable
-        in
-        let simple = Simple.with_coercion (Simple.var var) coerce_to_deeper in
-        to_bind,
-        Ident.Map.add let_rec_ident simple simples_for_idents)
-      (Variable.Map.empty, Ident.Map.empty)
-      (Function_decls.to_list function_declarations)
+    if has_lifted_closure
+    then
+      (* No projection needed *)
+      Variable.Map.empty, Ident.Map.empty
+    else
+      List.fold_left (fun (to_bind, simples_for_idents) function_decl ->
+          let let_rec_ident = Function_decl.let_rec_ident function_decl in
+          let to_bind, var =
+            if Ident.same our_let_rec_ident let_rec_ident && is_curried then
+              (* When the function being compiled is tupled, my_closure
+                 points to the curried version but let_rec_ident is called
+                 with tuple arguments, so the correct closure to bind
+                 is the one in the closure_ids_from_idents map.
+              *)
+              to_bind, my_closure  (* my_closure is already bound *)
+            else
+              let variable =
+                Variable.create_with_same_name_as_ident let_rec_ident
+              in
+              let closure_id =
+                Ident.Map.find let_rec_ident closure_ids_from_idents
+              in
+              Variable.Map.add variable closure_id to_bind, variable
+          in
+          let simple = Simple.with_coercion (Simple.var var) coerce_to_deeper in
+          to_bind,
+          Ident.Map.add let_rec_ident simple simples_for_idents)
+        (Variable.Map.empty, Ident.Map.empty)
+        (Function_decls.to_list function_declarations)
   in
   let closure_env_without_parameters =
     let empty_env = Env.clear_local_bindings external_env in
@@ -975,6 +986,9 @@ let close_functions acc external_env function_declarations =
       (Function_decls.all_free_idents function_declarations)
       Ident.Map.empty
   in
+  let can_be_lifted =
+    Ident.Map.is_empty var_within_closures_from_idents
+  in
   let func_decl_list = Function_decls.to_list function_declarations in
   let closure_ids_from_idents =
     List.fold_left (fun map decl ->
@@ -984,13 +998,26 @@ let close_functions acc external_env function_declarations =
       Ident.Map.empty
       func_decl_list
   in
+  let external_env, symbol_map =
+    if can_be_lifted
+    then
+      Ident.Map.fold (fun ident closure_id (env, symbol_map) ->
+        let env, symbol =
+          declare_symbol_for_closure_ident env ident closure_id
+        in
+        env,
+        Closure_id.Map.add closure_id symbol symbol_map)
+        closure_ids_from_idents
+        (external_env, Closure_id.Map.empty)
+    else external_env, Closure_id.Map.empty
+  in
   let acc, funs, free_names =
     List.fold_left (fun (acc, by_closure_id, free_names) function_decl ->
         let _, acc, expr =
           Acc.measure_cost_metrics acc ~f:(fun acc ->
             close_one_function acc ~external_env ~by_closure_id function_decl
-              ~var_within_closures_from_idents ~closure_ids_from_idents
-              function_declarations)
+              ~has_lifted_closure:can_be_lifted ~var_within_closures_from_idents
+              ~closure_ids_from_idents function_declarations)
         in
         let free_names =
           Name_occurrences.union free_names (Acc.free_names acc)
@@ -1016,8 +1043,22 @@ let close_functions acc external_env function_declarations =
       var_within_closures_from_idents
       Var_within_closure.Map.empty
   in
-  acc,
-  Set_of_closures.create function_decls ~closure_elements
+  let set_of_closures =
+    Set_of_closures.create function_decls ~closure_elements
+  in
+  if can_be_lifted
+  then
+    let symbols =
+      Closure_id.Lmap.mapi (fun closure_id _ ->
+        Closure_id.Map.find closure_id symbol_map)
+        funs
+    in
+    let acc =
+      Acc.add_declared_set_of_closures ~symbols ~set_of_closures acc
+    in
+    acc, Lifted symbols
+  else
+    acc, Dynamic set_of_closures
 
 let close_let_rec acc env ~function_declarations
   ~(body : Acc.t -> Env.t -> Acc.t * Expr_with_acc.t) =
@@ -1041,37 +1082,11 @@ let close_let_rec acc env ~function_declarations
       (Closure_id.Map.empty, Closure_id.Map.empty)
       function_declarations
   in
-  let acc, set_of_closures =
+  let acc, closed_functions =
     close_functions acc env (Function_decls.create function_declarations)
   in
-  (* CR mshinwell: We should maybe have something more elegant here *)
-  let generated_closures =
-    Closure_id.Set.diff
-      (Closure_id.Map.keys (Function_declarations.funs (
-        Set_of_closures.function_decls set_of_closures)))
-      (Closure_id.Map.keys closure_vars)
-  in
-  let closure_vars =
-    Closure_id.Set.fold (fun closure_id closure_vars ->
-        let closure_var =
-          VB.create (Variable.create "generated") Name_mode.normal
-        in
-        Closure_id.Map.add closure_id closure_var closure_vars)
-      generated_closures
-      closure_vars
-  in
-  let closure_vars =
-    List.map (fun (closure_id, _) ->
-        Closure_id.Map.find closure_id closure_vars)
-      (Function_declarations.funs_in_order (
-          Set_of_closures.function_decls set_of_closures)
-        |> Closure_id.Lmap.bindings)
-  in
-  if Set_of_closures.environment_doesn't_mention_variables set_of_closures
-  then
-    let acc, symbols =
-      register_set_of_closures_as_symbols acc set_of_closures
-    in
+  match closed_functions with
+  | Lifted symbols ->
     let env =
       Closure_id.Lmap.fold (fun closure_id symbol env ->
           let ident = Closure_id.Map.find closure_id ident_map in
@@ -1080,7 +1095,30 @@ let close_let_rec acc env ~function_declarations
         env
     in
     body acc env
-  else
+  | Dynamic set_of_closures ->
+    (* CR mshinwell: We should maybe have something more elegant here *)
+    let generated_closures =
+      Closure_id.Set.diff
+        (Closure_id.Map.keys (Function_declarations.funs (
+             Set_of_closures.function_decls set_of_closures)))
+        (Closure_id.Map.keys closure_vars)
+    in
+    let closure_vars =
+      Closure_id.Set.fold (fun closure_id closure_vars ->
+          let closure_var =
+            VB.create (Variable.create "generated") Name_mode.normal
+          in
+          Closure_id.Map.add closure_id closure_var closure_vars)
+        generated_closures
+        closure_vars
+    in
+    let closure_vars =
+      List.map (fun (closure_id, _) ->
+          Closure_id.Map.find closure_id closure_vars)
+        (Function_declarations.funs_in_order (
+            Set_of_closures.function_decls set_of_closures)
+         |> Closure_id.Lmap.bindings)
+    in
     let acc, body = body acc env in
     Let_with_acc.create acc
       (Bindable_let_bound.set_of_closures ~closure_vars)

--- a/middle_end/flambda/from_lambda/closure_conversion.mli
+++ b/middle_end/flambda/from_lambda/closure_conversion.mli
@@ -63,4 +63,4 @@ val close_program
   -> program:(Acc.t -> Env.t -> Acc.t * Expr_with_acc.t)
   -> prog_return_cont:Continuation.t
   -> exn_continuation:Continuation.t
-  -> Flambda_unit.t
+  -> Flambda_unit.t * Exported_code.t

--- a/middle_end/flambda/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion_aux.ml
@@ -201,8 +201,7 @@ module Acc = struct
     declared_symbols : (Symbol.t * Flambda.Static_const.t) list;
     shareable_constants : Symbol.t Flambda.Static_const.Map.t;
     code : Flambda.Code.t Code_id.Map.t;
-    free_names_of_current_function : Name_occurrences.t;
-    free_continuations : Name_occurrences.t;
+    free_names : Name_occurrences.t;
     cost_metrics : Flambda.Cost_metrics.t;
     seen_a_function : bool;
   }
@@ -220,8 +219,7 @@ module Acc = struct
     declared_symbols = [];
     shareable_constants = Flambda.Static_const.Map.empty;
     code = Code_id.Map.empty;
-    free_names_of_current_function = Name_occurrences.empty;
-    free_continuations = Name_occurrences.empty;
+    free_names = Name_occurrences.empty;
     cost_metrics = Flambda.Cost_metrics.zero;
     seen_a_function = false;
   }
@@ -229,8 +227,7 @@ module Acc = struct
   let declared_symbols t = t.declared_symbols
   let shareable_constants t = t.shareable_constants
   let code t = t.code
-  let free_names_of_current_function t = t.free_names_of_current_function
-  let free_continuations t = t.free_continuations
+  let free_names t = t.free_names
 
   let add_declared_symbol ~symbol ~constant t =
     let declared_symbols = (symbol, constant) :: t.declared_symbols in
@@ -245,28 +242,38 @@ module Acc = struct
   let add_code ~code_id ~code t =
     { t with code = Code_id.Map.add code_id code t.code; }
 
+  let add_free_names free_names t =
+    { t with free_names = Name_occurrences.union free_names t.free_names; }
+
   let add_symbol_to_free_names ~symbol t =
     { t with
-      free_names_of_current_function =
-        Name_occurrences.add_symbol t.free_names_of_current_function
+      free_names =
+        Name_occurrences.add_symbol t.free_names
           symbol Name_mode.normal;
     }
+
   let add_closure_var_to_free_names ~closure_var t =
     { t with
-      free_names_of_current_function =
-        Name_occurrences.add_closure_var t.free_names_of_current_function
+      free_names =
+        Name_occurrences.add_closure_var t.free_names
           closure_var Name_mode.normal;
     }
 
-  let add_continuation_occurrence ~cont ~has_traps t =
+  let add_continuation_to_free_names ~cont ~has_traps t =
     { t with
-      free_continuations =
-        Name_occurrences.add_continuation t.free_continuations
+      free_names =
+        Name_occurrences.add_continuation t.free_names
           cont ~has_traps;
     }
 
+  let remove_continuation_from_free_names cont t =
+    { t with
+      free_names =
+        Name_occurrences.remove_continuation t.free_names cont;
+    }
+
   let with_free_names free_names t =
-    { t with free_names_of_current_function = free_names; }
+    { t with free_names; }
 
   let measure_cost_metrics acc ~f =
     let saved_cost_metrics = cost_metrics acc in
@@ -401,10 +408,10 @@ module Expr_with_acc = struct
     let acc = match Apply.continuation apply with
       | Never_returns -> acc
       | Return cont ->
-          Acc.add_continuation_occurrence ~cont ~has_traps:false acc
+          Acc.add_continuation_to_free_names ~cont ~has_traps:false acc
     in
     let acc =
-      Acc.add_continuation_occurrence
+      Acc.add_continuation_to_free_names
         ~cont:(Exn_continuation.exn_handler (Apply.exn_continuation apply))
         ~has_traps:false acc
     in
@@ -437,7 +444,7 @@ end
 module Apply_cont_with_acc = struct
   let create acc ?trap_action cont ~args ~dbg =
     let acc =
-      Acc.add_continuation_occurrence ~cont
+      Acc.add_continuation_to_free_names ~cont
         ~has_traps:(match trap_action with
             | None -> false
             | _ -> true)
@@ -492,17 +499,22 @@ end
 module Let_cont_with_acc = struct
   let create_non_recursive acc cont handler
         ~body ~cost_metrics_of_handler =
-    let free_conts = Acc.free_continuations acc in
+    let free_conts = Acc.free_names acc in
     let acc =
       Acc.increment_metrics
         (Cost_metrics.increase_due_to_let_cont_non_recursive
            ~cost_metrics_of_handler)
         acc
     in
-    acc,
-    (* This function only uses continuations of [free_names_of_body] *)
-    Let_cont.create_non_recursive cont handler ~body
-      ~free_names_of_body:(Known free_conts)
+    let acc = Acc.remove_continuation_from_free_names cont acc in
+    match Name_occurrences.count_continuation free_conts cont with
+    | Zero when not (Continuation_handler.is_exn_handler handler) ->
+      acc, body
+    | _ ->
+      acc,
+      (* This function only uses continuations of [free_names_of_body] *)
+      Let_cont.create_non_recursive cont handler ~body
+        ~free_names_of_body:(Known free_conts)
 
   let create_recursive acc handlers ~body ~cost_metrics_of_handlers =
     let acc =
@@ -510,6 +522,11 @@ module Let_cont_with_acc = struct
         (Cost_metrics.increase_due_to_let_cont_recursive
            ~cost_metrics_of_handlers)
         acc
+    in
+    let acc =
+      Continuation.Map.fold (fun cont _ acc ->
+          Acc.remove_continuation_from_free_names cont acc)
+        handlers acc
     in
     acc, Let_cont.create_recursive handlers ~body
 end

--- a/middle_end/flambda/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion_aux.ml
@@ -199,6 +199,8 @@ end
 module Acc = struct
   type t = {
     declared_symbols : (Symbol.t * Flambda.Static_const.t) list;
+    declared_static_sets_of_closures
+      : (Symbol.t Closure_id.Lmap.t * Flambda.Set_of_closures.t) list;
     shareable_constants : Symbol.t Flambda.Static_const.Map.t;
     code : Flambda.Code.t Code_id.Map.t;
     free_names : Name_occurrences.t;
@@ -217,6 +219,7 @@ module Acc = struct
 
   let empty = {
     declared_symbols = [];
+    declared_static_sets_of_closures = [];
     shareable_constants = Flambda.Static_const.Map.empty;
     code = Code_id.Map.empty;
     free_names = Name_occurrences.empty;
@@ -225,6 +228,7 @@ module Acc = struct
   }
 
   let declared_symbols t = t.declared_symbols
+  let declared_static_sets_of_closures t = t.declared_static_sets_of_closures
   let shareable_constants t = t.shareable_constants
   let code t = t.code
   let free_names t = t.free_names
@@ -232,6 +236,11 @@ module Acc = struct
   let add_declared_symbol ~symbol ~constant t =
     let declared_symbols = (symbol, constant) :: t.declared_symbols in
     { t with declared_symbols; }
+
+  let add_declared_set_of_closures ~symbols ~set_of_closures t =
+    { t with
+      declared_static_sets_of_closures =
+        (symbols, set_of_closures) :: t.declared_static_sets_of_closures; }
 
   let add_shareable_constant ~symbol ~constant t =
     let shareable_constants =

--- a/middle_end/flambda/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda/from_lambda/closure_conversion_aux.mli
@@ -122,8 +122,7 @@ module Acc : sig
   val declared_symbols : t -> (Symbol.t * Flambda.Static_const.t) list
   val shareable_constants : t -> Symbol.t Flambda.Static_const.Map.t
   val code : t -> Flambda.Code.t Code_id.Map.t
-  val free_names_of_current_function : t -> Name_occurrences.t
-  val free_continuations : t -> Name_occurrences.t
+  val free_names : t -> Name_occurrences.t
 
   val seen_a_function : t -> bool
   val with_seen_a_function : t -> bool -> t
@@ -142,10 +141,14 @@ module Acc : sig
 
   val add_code : code_id:Code_id.t -> code:Flambda.Code.t -> t -> t
 
+  val add_free_names : Name_occurrences.t -> t -> t
   val add_symbol_to_free_names : symbol:Symbol.t -> t -> t
   val add_closure_var_to_free_names : closure_var:Var_within_closure.t -> t -> t
-  val add_continuation_occurrence
+  val add_continuation_to_free_names
     : cont:Continuation.t -> has_traps:bool -> t -> t
+  val remove_continuation_from_free_names
+    : Continuation.t -> t -> t
+
 
   val with_free_names : Name_occurrences.t -> t -> t
 

--- a/middle_end/flambda/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda/from_lambda/closure_conversion_aux.mli
@@ -120,6 +120,8 @@ module Acc : sig
   val empty : t
 
   val declared_symbols : t -> (Symbol.t * Flambda.Static_const.t) list
+  val declared_static_sets_of_closures
+     : t -> (Symbol.t Closure_id.Lmap.t * Flambda.Set_of_closures.t) list
   val shareable_constants : t -> Symbol.t Flambda.Static_const.Map.t
   val code : t -> Flambda.Code.t Code_id.Map.t
   val free_names : t -> Name_occurrences.t
@@ -130,6 +132,12 @@ module Acc : sig
   val add_declared_symbol
      : symbol:Symbol.t
     -> constant:Flambda.Static_const.t
+    -> t
+    -> t
+
+  val add_declared_set_of_closures
+     : symbols:(Symbol.t Closure_id.Lmap.t)
+    -> set_of_closures:Flambda.Set_of_closures.t
     -> t
     -> t
 

--- a/middle_end/flambda/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda/from_lambda/lambda_to_flambda.ml
@@ -1678,7 +1678,7 @@ and cps_switch acc env ccenv (switch : L.lambda_switch) ~scrutinee
     k_exn
 
 let lambda_to_flambda ~backend ~module_ident ~module_block_size_in_words
-      (lam : Lambda.lambda) : Flambda_unit.t =
+      (lam : Lambda.lambda) : Flambda_unit.t * Exported_code.t =
   let current_unit_id =
     Compilation_unit.get_persistent_ident
       (Compilation_unit.get_current_exn ())

--- a/middle_end/flambda/from_lambda/lambda_to_flambda.mli
+++ b/middle_end/flambda/from_lambda/lambda_to_flambda.mli
@@ -23,4 +23,4 @@ val lambda_to_flambda
   -> module_ident:Ident.t
   -> module_block_size_in_words:int
   -> Lambda.lambda
-  -> Flambda_unit.t
+  -> Flambda_unit.t * Exported_code.t

--- a/middle_end/flambda/terms/continuation_handler.rec.ml
+++ b/middle_end/flambda/terms/continuation_handler.rec.ml
@@ -112,7 +112,7 @@ let pattern_match_pair t1 t2 ~f =
         Error Pattern_match_pair_error.Parameter_lists_have_different_lengths))
 
 let print_using_where_with_cache (recursive : Recursive.t) ~cache ppf k
-      ({ abst = _; is_exn_handler; } as t) ~first =
+      ({ abst = _; is_exn_handler; } as t) occurrences ~first =
   let fprintf = Format.fprintf in
   if not first then begin
     fprintf ppf "@ "
@@ -133,8 +133,9 @@ let print_using_where_with_cache (recursive : Recursive.t) ~cache ppf k
     if List.length params > 0 then begin
       fprintf ppf " %a" Kinded_parameter.List.print params
     end;
-    fprintf ppf "@<0>%s:@<0>%s@ %a"
+    fprintf ppf "@<0>%s #%a:@<0>%s@ %a"
       (Flambda_colours.elide ())
+      (Or_unknown.print Num_occurrences.print) occurrences
       (Flambda_colours.normal ())
       (Expr.print_with_cache ~cache) handler;
     fprintf ppf "@]")

--- a/middle_end/flambda/terms/continuation_handler.rec.mli
+++ b/middle_end/flambda/terms/continuation_handler.rec.mli
@@ -32,6 +32,7 @@ val print_using_where_with_cache
   -> Format.formatter
   -> Continuation.t
   -> t
+  -> Num_occurrences.t Or_unknown.t
   -> first:bool
   -> unit
 

--- a/middle_end/flambda/terms/let_cont_expr.rec.ml
+++ b/middle_end/flambda/terms/let_cont_expr.rec.ml
@@ -51,7 +51,7 @@ let print_with_cache ~cache ppf t =
   end else begin
     let rec gather_let_conts let_conts let_cont =
       match let_cont with
-      | Non_recursive { handler; num_free_occurrences = _;
+      | Non_recursive { handler; num_free_occurrences;
                         is_applied_with_traps = _; } ->
         Non_recursive_let_cont_handler.pattern_match handler
           ~f:(fun k ~(body : Expr.t) ->
@@ -61,7 +61,8 @@ let print_with_cache ~cache ppf t =
               | _ -> let_conts, body
             in
             let handler = Non_recursive_let_cont_handler.handler handler in
-            (k, Recursive.Non_recursive, handler) :: let_conts, body)
+            (k, Recursive.Non_recursive, handler, num_free_occurrences)
+            :: let_conts, body)
       | Recursive handlers ->
         Recursive_let_cont_handlers.pattern_match handlers
           ~f:(fun ~(body : Expr.t) handlers ->
@@ -72,7 +73,8 @@ let print_with_cache ~cache ppf t =
               | _ -> let_conts, body
             in
             let new_let_conts =
-              List.map (fun (k, handler) -> k, Recursive.Recursive, handler)
+              List.map (fun (k, handler) ->
+                  k, Recursive.Recursive, handler, Or_unknown.Unknown)
                 (Continuation.Map.bindings handlers)
             in
             new_let_conts @ let_conts, body)
@@ -80,9 +82,9 @@ let print_with_cache ~cache ppf t =
     let let_conts, body = gather_let_conts [] t in
     fprintf ppf "@[<v 1>(%a@;" (Expr.print_with_cache ~cache) body;
     let first = ref true in
-    List.iter (fun (cont, recursive, handler) ->
+    List.iter (fun (cont, recursive, handler, occurrences) ->
         Continuation_handler.print_using_where_with_cache recursive ~cache
-          ppf cont handler ~first:!first;
+          ppf cont handler occurrences ~first:!first;
         first := false)
       (List.rev let_conts);
     fprintf ppf ")@]"


### PR DESCRIPTION
(From #571, [relevant diff](https://github.com/ocaml-flambda/ocaml/pull/541/files/2967eda1881f82029bc7e396d61f862e80c89231..ec76f80f98921efe9f38c47c2a915f25bbb7fa5d))

This finish the job of #511 by replacing closure projections by the corresponding lifted symbols and grouping the symbols in a single let-binding.

This is concurrent to #540, which orders declarations and groups them in a much less lowbrow manner.

The patch is not in a mergeable state, see issue #542.