### PR TITLE
Clean up handling of inlining_arguments in simplify_set_of_closures

### DIFF
--- a/middle_end/flambda/simplify/env/downwards_env.ml
+++ b/middle_end/flambda/simplify/env/downwards_env.ml
@@ -611,11 +611,7 @@ let closure_info t = t.closure_info
 let inlining_arguments { inlining_state; _ } =
   Inlining_state.arguments inlining_state
 
-let restrict_inlining_arguments inlining_arguments t =
-  let arguments =
-    Inlining_state.arguments t.inlining_state
-    |> Inlining_arguments.meet inlining_arguments
-  in
+let set_inlining_arguments arguments t =
   { t with inlining_state =
              Inlining_state.with_arguments arguments t.inlining_state
   }

--- a/middle_end/flambda/simplify/env/downwards_env.mli
+++ b/middle_end/flambda/simplify/env/downwards_env.mli
@@ -239,7 +239,7 @@ val closure_info : t -> Closure_info.t
 
 val inlining_arguments : t -> Inlining_arguments.t
 
-val restrict_inlining_arguments : Inlining_arguments.t -> t -> t
+val set_inlining_arguments : Inlining_arguments.t -> t -> t
 
 val enter_inlined_apply : called_code:Code.t -> apply:Apply.t -> t -> t
 

--- a/middle_end/flambda/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda/simplify/simplify_set_of_closures.ml
@@ -374,9 +374,9 @@ let simplify_function context ~used_closure_vars ~shareable_constants
     |> DE.inlining_arguments
   in
   (* Compute the set of inlining_arguments used to define this function
-    by taking the "least powerfull" set between the one set in the environment
+    by taking the "least powerful" set between the one set in the environment
     and the one used to define the symbol previously. This way, functions that
-    were imported from a foreign compilation unit after inlining will still
+    were imported from a foreign compilation unit after inlining will still be
     considered with a set of inlining arguments coherent with the one used
     to compile the current file when inlining.
   *)


### PR DESCRIPTION
To merge before #538.

#538 is doing the right thing but the reason why exactly wasn't obvious for me. This PR cleans up simplify_set_of_closures a bit and clarifies the treatment of inlining_arguments around closures a bit more.