### PR TITLE
Un_cps.switch: remove unnecessary extra index

### DIFF
--- a/middle_end/flambda/to_cmm/un_cps.ml
+++ b/middle_end/flambda/to_cmm/un_cps.ml
@@ -1274,7 +1274,7 @@ and make_switch ~tag_discriminant env res e arms =
     let (max_d, _) = Targetint_31_63.Map.max_binding arms in
     let m = prepare_discriminant ~tag:tag_discriminant max_d in
     let cases = Array.make (n + 1) C.unreachable in
-    let index = Array.make (m + 2) n in
+    let index = Array.make (m + 1) n in
     let _, res =
       Targetint_31_63.Map.fold (fun discriminant action (i, res) ->
         let (d, cmm_action), res =


### PR DESCRIPTION
I was looking at the code produced by Flambda 2 in the case from https://github.com/ocaml/ocaml/issues/9741, and I found that it was not generating constant table lookups because of a spurious index pointing to an unreachable action.
As far as I can tell there's no reason for this extra index, so I've removed it (and can confirm that with this patch, Flambda 2 produces jump tables in both cases).