### PR TITLE
Allow tag = Unknown on Block_access_kind

### DIFF
--- a/middle_end/flambda/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion.ml
@@ -1105,7 +1105,7 @@ let close_program ~backend ~module_ident ~module_block_size_in_words
     in
     let block_access : P.Block_access_kind.t =
       Values {
-        tag = Tag.Scannable.zero;
+        tag = Known Tag.Scannable.zero;
         size = Known (Targetint_31_63.Imm.of_int module_block_size_in_words);
         field_kind = Any_value;
       }

--- a/middle_end/flambda/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda/from_lambda/lambda_to_flambda_primitives.ml
@@ -378,7 +378,7 @@ let convert_lprim ~backend (prim : L.primitive) (args : Simple.t list)
       (* Pfield_computed is only used for class access, on blocks of tag
          [Object_tag], created in [CamlinternalOO]. *)
       Values {
-        tag = Tag.Scannable.object_tag;
+        tag = Known Tag.Scannable.object_tag;
         size = Unknown;
         field_kind = Any_value;
       }
@@ -390,7 +390,7 @@ let convert_lprim ~backend (prim : L.primitive) (args : Simple.t list)
     let field_kind = C.convert_block_access_field_kind imm_or_pointer in
     let block_access : P.Block_access_kind.t =
       Values {
-        tag = Tag.Scannable.object_tag;
+        tag = Known Tag.Scannable.object_tag;
         size = Unknown;
         field_kind;
       }
@@ -620,7 +620,7 @@ let convert_lprim ~backend (prim : L.primitive) (args : Simple.t list)
     let tag = Tag.Scannable.create_exn tag in
     let size = C.convert_lambda_block_size size in
     let block_access : P.Block_access_kind.t =
-      Values { tag; size; field_kind = Any_value; }
+      Values { tag = Known tag; size; field_kind = Any_value; }
     in
     Binary (Block_load (block_access, mutability), arg, Simple field)
   | Pfloatfield (field, sem), [arg] ->
@@ -640,7 +640,7 @@ let convert_lprim ~backend (prim : L.primitive) (args : Simple.t list)
     let field = Simple.const (Reg_width_const.tagged_immediate imm) in
     let size = C.convert_lambda_block_size size in
     let block_access : P.Block_access_kind.t =
-      Values { tag = Tag.Scannable.create_exn tag; size; field_kind; }
+      Values { tag = Known (Tag.Scannable.create_exn tag); size; field_kind; }
     in
     Ternary (Block_set (block_access,
          C.convert_init_or_assign initialization_or_assignment),
@@ -849,7 +849,7 @@ let convert_lprim ~backend (prim : L.primitive) (args : Simple.t list)
   | Poffsetref n, [block] ->
     let block_access : P.Block_access_kind.t =
       Values {
-        tag = Tag.Scannable.zero;
+        tag = Known Tag.Scannable.zero;
         size = Known Targetint_31_63.Imm.one;
         field_kind = Immediate;
       }

--- a/middle_end/flambda/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda/parser/fexpr_to_flambda.ml
@@ -372,7 +372,8 @@ let binop (binop:Fexpr.binop) : Flambda_primitive.binary_primitive =
       | Values { field_kind; tag; size = s } ->
         let tag = tag |> Tag.Scannable.create_exn in
         let size = size s in
-        Values { field_kind; tag; size }
+        (* CR mshinwell: add support for "Unknown" tags *)
+        Values { field_kind; tag = Known tag; size }
       | Naked_floats { size = s } ->
         let size = size s in
         Naked_floats { size }

--- a/middle_end/flambda/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda/parser/flambda_to_fexpr.ml
@@ -406,7 +406,15 @@ let binop (op : Flambda_primitive.binary_primitive) : Fexpr.binop =
       match access_kind with
       | Values { field_kind; size = s; tag } ->
         let size = s |> size in
-        let tag = tag |> Tag.Scannable.to_int in
+        let tag =
+          match tag with
+          | Unknown ->
+            (* CR mshinwell: add support for "Unknown" tags *)
+            Misc.fatal_error "[tag = Unknown] in [Block_access_kind] \
+              not supported"
+          | Known tag ->
+            tag |> Tag.Scannable.to_int
+        in
         Values { field_kind; size; tag }
       | Naked_floats { size = s } ->
         let size = s |> size in

--- a/middle_end/flambda/simplify/expr_builder.ml
+++ b/middle_end/flambda/simplify/expr_builder.ml
@@ -416,7 +416,7 @@ let create_let_symbols uacc (scoping_rule : Symbol_scoping_rule.t)
               let index = Simple.const_int index in
               let block_access_kind : P.Block_access_kind.t =
                 Values {
-                  tag = Tag.Scannable.zero;
+                  tag = Known Tag.Scannable.zero;
                   size = Unknown;
                   field_kind = Any_value;
                 }

--- a/middle_end/flambda/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda/simplify/simplify_binary_primitive.ml
@@ -953,7 +953,7 @@ let simplify_immutable_block_load (access_kind : P.Block_access_kind.t)
          to constrain the type of the block *)
       let tag : _ Or_unknown.t =
         match access_kind with
-        | Values { tag; _ } -> Known (Tag.Scannable.to_tag tag)
+        | Values { tag; _ } -> Or_unknown.map tag ~f:Tag.Scannable.to_tag
         | Naked_floats { size; } ->
           match size with
           | Known size ->

--- a/middle_end/flambda/simplify/simplify_common.ml
+++ b/middle_end/flambda/simplify/simplify_common.ml
@@ -115,7 +115,7 @@ let project_tuple ~dbg ~size ~field tuple =
   let module BAK = P.Block_access_kind in
   let bak : BAK.t = Values {
     field_kind = Any_value;
-    tag = Tag.Scannable.zero;
+    tag = Known Tag.Scannable.zero;
     size = Known (Targetint_31_63.Imm.of_int size);
   } in
   let mutability : Mutability.t = Immutable in

--- a/middle_end/flambda/terms/flambda_primitive.ml
+++ b/middle_end/flambda/terms/flambda_primitive.ml
@@ -204,7 +204,7 @@ end
 module Block_access_kind = struct
   type t =
     | Values of {
-        tag : Tag.Scannable.t;
+        tag : Tag.Scannable.t Or_unknown.t;
         size : Targetint_31_63.Imm.t Or_unknown.t;
         field_kind : Block_access_field_kind.t;
       }
@@ -219,7 +219,7 @@ module Block_access_kind = struct
           @[<hov 1>(size@ %a)@]@ \
           @[<hov 1>(field_kind@ %a)@]\
           )@]"
-        Tag.Scannable.print tag
+        (Or_unknown.print Tag.Scannable.print) tag
         (Or_unknown.print Targetint_31_63.Imm.print) size
         Block_access_field_kind.print field_kind
     | Naked_floats { size; } ->
@@ -240,7 +240,7 @@ module Block_access_kind = struct
     match t1, t2 with
     | Values { tag = tag1; size = size1; field_kind = field_kind1; },
         Values { tag = tag2; size = size2; field_kind = field_kind2; } ->
-      let c = Tag.Scannable.compare tag1 tag2 in
+      let c = Or_unknown.compare Tag.Scannable.compare tag1 tag2 in
       if c <> 0 then c
       else
         let c = Or_unknown.compare Targetint_31_63.Imm.compare size1 size2 in

--- a/middle_end/flambda/terms/flambda_primitive.mli
+++ b/middle_end/flambda/terms/flambda_primitive.mli
@@ -110,7 +110,7 @@ end
 module Block_access_kind : sig
   type t =
     | Values of {
-        tag : Tag.Scannable.t;
+        tag : Tag.Scannable.t Or_unknown.t;
         size : Targetint_31_63.Imm.t Or_unknown.t;
         field_kind : Block_access_field_kind.t;
       }

--- a/middle_end/flambda/unboxing/unboxing_epa.ml
+++ b/middle_end/flambda/unboxing/unboxing_epa.ml
@@ -279,7 +279,7 @@ and compute_extra_args_for_block ~pass
     else
       P.Block_access_kind.Values {
         size;
-        tag = Option.get (Tag.Scannable.of_tag tag);
+        tag = Known (Option.get (Tag.Scannable.of_tag tag));
         field_kind = Any_value;
       }, Const.const_zero
   in
@@ -391,7 +391,7 @@ and compute_extra_args_for_variant ~pass
       let bak : Flambda_primitive.Block_access_kind.t =
         Values {
           size = Known (Targetint_31_63.Imm.of_int size);
-          tag = tag_decision;
+          tag = Known tag_decision;
           field_kind = Any_value;
         }
       in


### PR DESCRIPTION
This will allow us to run on the Flambda backend in the first instance without needing the large patch that propagates block tags and sizes from the front end.  My suspicion is that we can probably supercede the tag-and-size patch with the block kind patch (which is already merged, and sounds like it's in line with current thinking upstream).