### PR TITLE
Remove middle_end/flambda -> Clflags deps

### DIFF
--- a/.depend
+++ b/.depend
@@ -3736,13 +3736,13 @@ middle_end/flambda/flambda_middle_end.cmo : \
     middle_end/flambda/inlining/inlining_report.cmi \
     middle_end/flambda/terms/flambda_unit.cmi \
     middle_end/flambda/parser/flambda_to_fexpr.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/cmx/flambda_cmx_format.cmi \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/parser/fexpr.cmo \
     middle_end/flambda/cmx/exported_code.cmi \
     middle_end/flambda/basic/code_id.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/flambda_middle_end.cmi
 middle_end/flambda/flambda_middle_end.cmx : \
     middle_end/flambda/simplify/simplify.cmx \
@@ -3753,13 +3753,13 @@ middle_end/flambda/flambda_middle_end.cmx : \
     middle_end/flambda/inlining/inlining_report.cmx \
     middle_end/flambda/terms/flambda_unit.cmx \
     middle_end/flambda/parser/flambda_to_fexpr.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/cmx/flambda_cmx_format.cmx \
     middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/parser/fexpr.cmx \
     middle_end/flambda/cmx/exported_code.cmx \
     middle_end/flambda/basic/code_id.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/flambda_middle_end.cmi
 middle_end/flambda/flambda_middle_end.cmi : \
     lambda/lambda.cmi \
@@ -3890,7 +3890,8 @@ middle_end/flambda/compilenv_deps/flambda_features.cmo : \
 middle_end/flambda/compilenv_deps/flambda_features.cmx : \
     utils/clflags.cmx \
     middle_end/flambda/compilenv_deps/flambda_features.cmi
-middle_end/flambda/compilenv_deps/flambda_features.cmi :
+middle_end/flambda/compilenv_deps/flambda_features.cmi : \
+    utils/misc.cmi
 middle_end/flambda/compilenv_deps/linkage_name.cmo : \
     middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/compilenv_deps/linkage_name.cmi
@@ -4113,13 +4114,13 @@ middle_end/flambda/flambda_middle_end.cmo : \
     middle_end/flambda/inlining/inlining_report.cmi \
     middle_end/flambda/terms/flambda_unit.cmi \
     middle_end/flambda/parser/flambda_to_fexpr.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/cmx/flambda_cmx_format.cmi \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/parser/fexpr.cmo \
     middle_end/flambda/cmx/exported_code.cmi \
     middle_end/flambda/basic/code_id.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/flambda_middle_end.cmi
 middle_end/flambda/flambda_middle_end.cmx : \
     middle_end/flambda/simplify/simplify.cmx \
@@ -4130,13 +4131,13 @@ middle_end/flambda/flambda_middle_end.cmx : \
     middle_end/flambda/inlining/inlining_report.cmx \
     middle_end/flambda/terms/flambda_unit.cmx \
     middle_end/flambda/parser/flambda_to_fexpr.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/cmx/flambda_cmx_format.cmx \
     middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/parser/fexpr.cmx \
     middle_end/flambda/cmx/exported_code.cmx \
     middle_end/flambda/basic/code_id.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/flambda_middle_end.cmi
 middle_end/flambda/flambda_middle_end.cmi : \
     lambda/lambda.cmi \
@@ -4679,26 +4680,26 @@ middle_end/flambda/cmx/flambda_cmx.cmo : \
     middle_end/flambda/naming/name_occurrences.cmi \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/basic/name.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/cmx/flambda_cmx_format.cmi \
     middle_end/flambda/flambda_backend_intf.cmi \
     middle_end/flambda/cmx/exported_offsets.cmi \
     middle_end/flambda/cmx/exported_code.cmi \
     middle_end/flambda/simplify/env/continuation_uses_env.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/cmx/flambda_cmx.cmi
 middle_end/flambda/cmx/flambda_cmx.cmx : \
     middle_end/flambda/simplify/simplify_import.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/basic/name.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/cmx/flambda_cmx_format.cmx \
     middle_end/flambda/flambda_backend_intf.cmi \
     middle_end/flambda/cmx/exported_offsets.cmx \
     middle_end/flambda/cmx/exported_code.cmx \
     middle_end/flambda/simplify/env/continuation_uses_env.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/cmx/flambda_cmx.cmi
 middle_end/flambda/cmx/flambda_cmx.cmi : \
     middle_end/flambda/basic/var_within_closure.cmi \
@@ -4888,6 +4889,7 @@ middle_end/flambda/from_lambda/closure_conversion.cmo : \
     middle_end/flambda/terms/flambda_unit.cmi \
     middle_end/flambda/terms/flambda_primitive.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/flambda_backend_intf.cmi \
     middle_end/flambda/terms/flambda.cmi \
@@ -4900,7 +4902,6 @@ middle_end/flambda/from_lambda/closure_conversion.cmo : \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/basic/closure_id.cmi \
     middle_end/flambda/from_lambda/closure_conversion_aux.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/terms/call_kind.cmi \
     middle_end/flambda/terms/bound_symbols.cmi \
     middle_end/flambda/naming/bindable_let_bound.cmi \
@@ -4943,6 +4944,7 @@ middle_end/flambda/from_lambda/closure_conversion.cmx : \
     middle_end/flambda/terms/flambda_unit.cmx \
     middle_end/flambda/terms/flambda_primitive.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/flambda_backend_intf.cmi \
     middle_end/flambda/terms/flambda.cmx \
@@ -4955,7 +4957,6 @@ middle_end/flambda/from_lambda/closure_conversion.cmx : \
     middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/basic/closure_id.cmx \
     middle_end/flambda/from_lambda/closure_conversion_aux.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/terms/call_kind.cmx \
     middle_end/flambda/terms/bound_symbols.cmx \
     middle_end/flambda/naming/bindable_let_bound.cmx \
@@ -5309,28 +5310,28 @@ middle_end/flambda/inlining/function_decl_inlining_decision.cmi : \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/inlining/metrics/code_size.cmi
 middle_end/flambda/inlining/inlining_arguments.cmo : \
-    utils/clflags.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/inlining/inlining_arguments.cmi
 middle_end/flambda/inlining/inlining_arguments.cmx : \
-    utils/clflags.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/inlining/inlining_arguments.cmi
 middle_end/flambda/inlining/inlining_arguments.cmi :
 middle_end/flambda/inlining/inlining_report.cmo : \
     utils/misc.cmi \
     middle_end/flambda/inlining/function_decl_inlining_decision.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     lambda/debuginfo.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/basic/code_id.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/inlining/call_site_inlining_decision.cmi \
     middle_end/flambda/inlining/inlining_report.cmi
 middle_end/flambda/inlining/inlining_report.cmx : \
     utils/misc.cmx \
     middle_end/flambda/inlining/function_decl_inlining_decision.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     lambda/debuginfo.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
     middle_end/flambda/basic/code_id.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/inlining/call_site_inlining_decision.cmx \
     middle_end/flambda/inlining/inlining_report.cmi
 middle_end/flambda/inlining/inlining_report.cmi : \
@@ -5503,8 +5504,8 @@ middle_end/flambda/lifting/reification.cmo : \
     middle_end/flambda/basic/mutability.cmi \
     utils/misc.cmi \
     middle_end/flambda/compilenv_deps/linkage_name.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/lifting/reification.cmi
 middle_end/flambda/lifting/reification.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
@@ -5519,8 +5520,8 @@ middle_end/flambda/lifting/reification.cmx : \
     middle_end/flambda/basic/mutability.cmx \
     utils/misc.cmx \
     middle_end/flambda/compilenv_deps/linkage_name.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/lifting/reification.cmi
 middle_end/flambda/lifting/reification.cmi : \
     middle_end/flambda/naming/var_in_binding_pos.cmi \
@@ -5729,11 +5730,11 @@ middle_end/flambda/naming/name_occurrences.cmo : \
     middle_end/flambda/naming/name_mode.cmi \
     middle_end/flambda/basic/name.cmi \
     utils/misc.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/basic/code_id_or_symbol.cmi \
     middle_end/flambda/basic/code_id.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/naming/name_occurrences.cmi
 middle_end/flambda/naming/name_occurrences.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
@@ -5743,11 +5744,11 @@ middle_end/flambda/naming/name_occurrences.cmx : \
     middle_end/flambda/naming/name_mode.cmx \
     middle_end/flambda/basic/name.cmx \
     utils/misc.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/basic/continuation.cmx \
     middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/basic/code_id_or_symbol.cmx \
     middle_end/flambda/basic/code_id.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/naming/name_occurrences.cmi
 middle_end/flambda/naming/name_occurrences.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
@@ -6384,6 +6385,7 @@ middle_end/flambda/simplify/simplify.cmo : \
     middle_end/flambda/basic/name.cmi \
     utils/misc.cmi \
     middle_end/flambda/terms/flambda_unit.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/cmx/flambda_cmx_format.cmi \
     middle_end/flambda/cmx/flambda_cmx.cmi \
     middle_end/flambda/flambda_backend_intf.cmi \
@@ -6391,7 +6393,6 @@ middle_end/flambda/simplify/simplify.cmo : \
     middle_end/flambda/basic/exn_continuation.cmi \
     middle_end/flambda/simplify/env/continuation_uses_env.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/simplify/simplify.cmi
 middle_end/flambda/simplify/simplify.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
@@ -6404,6 +6405,7 @@ middle_end/flambda/simplify/simplify.cmx : \
     middle_end/flambda/basic/name.cmx \
     utils/misc.cmx \
     middle_end/flambda/terms/flambda_unit.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/cmx/flambda_cmx_format.cmx \
     middle_end/flambda/cmx/flambda_cmx.cmx \
     middle_end/flambda/flambda_backend_intf.cmi \
@@ -6411,7 +6413,6 @@ middle_end/flambda/simplify/simplify.cmx : \
     middle_end/flambda/basic/exn_continuation.cmx \
     middle_end/flambda/simplify/env/continuation_uses_env.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/simplify/simplify.cmi
 middle_end/flambda/simplify/simplify.cmi : \
     middle_end/flambda/terms/flambda_unit.cmi \
@@ -6599,6 +6600,7 @@ middle_end/flambda/simplify/simplify_common.cmo : \
     middle_end/flambda/types/flambda_type.cmi \
     middle_end/flambda/terms/flambda_primitive.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/types/kinds/flambda_arity.cmi \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/simplify/expr_builder.cmi \
@@ -6608,7 +6610,6 @@ middle_end/flambda/simplify/simplify_common.cmo : \
     middle_end/flambda/simplify/env/continuation_use_kind.cmi \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/basic/code_id.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/terms/call_kind.cmi \
     middle_end/flambda/terms/apply_cont_expr.cmi \
     middle_end/flambda/simplify/simplify_common.cmi
@@ -6628,6 +6629,7 @@ middle_end/flambda/simplify/simplify_common.cmx : \
     middle_end/flambda/types/flambda_type.cmx \
     middle_end/flambda/terms/flambda_primitive.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/types/kinds/flambda_arity.cmx \
     middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/simplify/expr_builder.cmx \
@@ -6637,7 +6639,6 @@ middle_end/flambda/simplify/simplify_common.cmx : \
     middle_end/flambda/simplify/env/continuation_use_kind.cmx \
     middle_end/flambda/basic/continuation.cmx \
     middle_end/flambda/basic/code_id.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/terms/call_kind.cmx \
     middle_end/flambda/terms/apply_cont_expr.cmx \
     middle_end/flambda/simplify/simplify_common.cmi
@@ -6890,9 +6891,9 @@ middle_end/flambda/simplify/simplify_named.cmo : \
     middle_end/flambda/basic/name.cmi \
     utils/misc.cmi \
     middle_end/flambda/terms/flambda_primitive.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/basic/closure_id.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/terms/bound_symbols.cmi \
     middle_end/flambda/naming/bindable_let_bound.cmi \
     middle_end/flambda/simplify/simplify_named.cmi
@@ -6918,9 +6919,9 @@ middle_end/flambda/simplify/simplify_named.cmx : \
     middle_end/flambda/basic/name.cmx \
     utils/misc.cmx \
     middle_end/flambda/terms/flambda_primitive.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/basic/closure_id.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/terms/bound_symbols.cmx \
     middle_end/flambda/naming/bindable_let_bound.cmx \
     middle_end/flambda/simplify/simplify_named.cmi
@@ -7038,6 +7039,7 @@ middle_end/flambda/simplify/simplify_set_of_closures.cmo : \
     middle_end/flambda/inlining/inlining_report.cmi \
     middle_end/flambda/inlining/inlining_arguments.cmi \
     middle_end/flambda/terms/function_declarations.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/basic/exn_continuation.cmi \
@@ -7049,7 +7051,6 @@ middle_end/flambda/simplify/simplify_set_of_closures.cmo : \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/types/structures/code_age_relation.cmi \
     middle_end/flambda/basic/closure_id.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/terms/bound_symbols.cmi \
     middle_end/flambda/naming/bindable_let_bound.cmi \
     middle_end/flambda/simplify/simplify_set_of_closures.cmi
@@ -7078,6 +7079,7 @@ middle_end/flambda/simplify/simplify_set_of_closures.cmx : \
     middle_end/flambda/inlining/inlining_report.cmx \
     middle_end/flambda/inlining/inlining_arguments.cmx \
     middle_end/flambda/terms/function_declarations.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/basic/exn_continuation.cmx \
@@ -7089,7 +7091,6 @@ middle_end/flambda/simplify/simplify_set_of_closures.cmx : \
     middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/types/structures/code_age_relation.cmx \
     middle_end/flambda/basic/closure_id.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/terms/bound_symbols.cmx \
     middle_end/flambda/naming/bindable_let_bound.cmx \
     middle_end/flambda/simplify/simplify_set_of_closures.cmi
@@ -7178,11 +7179,11 @@ middle_end/flambda/simplify/simplify_switch_expr.cmo : \
     middle_end/flambda/basic/reg_width_const.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     utils/misc.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/types/kinds/flambda_arity.cmi \
     lambda/debuginfo.cmi \
     middle_end/flambda/simplify/env/data_flow.cmi \
     middle_end/flambda/basic/continuation.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/naming/bindable_let_bound.cmi \
     middle_end/flambda/simplify/simplify_switch_expr.cmi
 middle_end/flambda/simplify/simplify_switch_expr.cmx : \
@@ -7197,11 +7198,11 @@ middle_end/flambda/simplify/simplify_switch_expr.cmx : \
     middle_end/flambda/basic/reg_width_const.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     utils/misc.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/types/kinds/flambda_arity.cmx \
     lambda/debuginfo.cmx \
     middle_end/flambda/simplify/env/data_flow.cmx \
     middle_end/flambda/basic/continuation.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/naming/bindable_let_bound.cmx \
     middle_end/flambda/simplify/simplify_switch_expr.cmi
 middle_end/flambda/simplify/simplify_switch_expr.cmi : \
@@ -7341,10 +7342,10 @@ middle_end/flambda/simplify/basic/simplified_named.cmo : \
     utils/misc.cmi \
     middle_end/flambda/basic/invalid_term_semantics.cmi \
     middle_end/flambda/terms/flambda_primitive.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/terms/flambda.cmi \
     lambda/debuginfo.cmi \
     middle_end/flambda/inlining/metrics/code_size.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/simplify/basic/simplified_named.cmi
 middle_end/flambda/simplify/basic/simplified_named.cmx : \
     middle_end/flambda/basic/simple.cmx \
@@ -7354,10 +7355,10 @@ middle_end/flambda/simplify/basic/simplified_named.cmx : \
     utils/misc.cmx \
     middle_end/flambda/basic/invalid_term_semantics.cmx \
     middle_end/flambda/terms/flambda_primitive.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/terms/flambda.cmx \
     lambda/debuginfo.cmx \
     middle_end/flambda/inlining/metrics/code_size.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/simplify/basic/simplified_named.cmi
 middle_end/flambda/simplify/basic/simplified_named.cmi : \
     middle_end/flambda/basic/simple.cmi \
@@ -7566,6 +7567,7 @@ middle_end/flambda/simplify/env/downwards_env.cmo : \
     middle_end/flambda/inlining/inlining_arguments.cmi \
     middle_end/flambda/types/flambda_type.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/flambda_backend_intf.cmi \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/cmx/exported_code.cmi \
@@ -7575,7 +7577,6 @@ middle_end/flambda/simplify/env/downwards_env.cmo : \
     middle_end/flambda/simplify/common_subexpression_elimination.cmi \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/simplify/env/closure_info.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/simplify/env/downwards_env.cmi
 middle_end/flambda/simplify/env/downwards_env.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
@@ -7592,6 +7593,7 @@ middle_end/flambda/simplify/env/downwards_env.cmx : \
     middle_end/flambda/inlining/inlining_arguments.cmx \
     middle_end/flambda/types/flambda_type.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/flambda_backend_intf.cmi \
     middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/cmx/exported_code.cmx \
@@ -7601,7 +7603,6 @@ middle_end/flambda/simplify/env/downwards_env.cmx : \
     middle_end/flambda/simplify/common_subexpression_elimination.cmx \
     middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/simplify/env/closure_info.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/simplify/env/downwards_env.cmi
 middle_end/flambda/simplify/env/downwards_env.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
@@ -7740,7 +7741,6 @@ middle_end/flambda/simplify/typing_helpers/continuation_uses.cmo : \
     middle_end/flambda/simplify/env/continuation_env_and_param_types.cmi \
     middle_end/flambda/basic/continuation.cmi \
     middle_end/flambda/simplify/common_subexpression_elimination.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/basic/apply_cont_rewrite_id.cmi \
     middle_end/flambda/simplify/typing_helpers/continuation_uses.cmi
 middle_end/flambda/simplify/typing_helpers/continuation_uses.cmx : \
@@ -7762,7 +7762,6 @@ middle_end/flambda/simplify/typing_helpers/continuation_uses.cmx : \
     middle_end/flambda/simplify/env/continuation_env_and_param_types.cmx \
     middle_end/flambda/basic/continuation.cmx \
     middle_end/flambda/simplify/common_subexpression_elimination.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/basic/apply_cont_rewrite_id.cmx \
     middle_end/flambda/simplify/typing_helpers/continuation_uses.cmi
 middle_end/flambda/simplify/typing_helpers/continuation_uses.cmi : \
@@ -8135,8 +8134,8 @@ middle_end/flambda/terms/expr.rec.cmo : \
     utils/misc.cmi \
     middle_end/flambda/basic/invalid_term_semantics.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/naming/bindable_let_bound.cmi \
     middle_end/flambda/terms/expr.rec.cmi
 middle_end/flambda/terms/expr.rec.cmx : \
@@ -8150,8 +8149,8 @@ middle_end/flambda/terms/expr.rec.cmx : \
     utils/misc.cmx \
     middle_end/flambda/basic/invalid_term_semantics.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/naming/bindable_let_bound.cmx \
     middle_end/flambda/terms/expr.rec.cmi
 middle_end/flambda/terms/expr.rec.cmi : \
@@ -8198,6 +8197,7 @@ middle_end/flambda/terms/flambda.cmo : \
     middle_end/flambda/terms/function_declarations.cmi \
     middle_end/flambda/terms/flambda_primitive.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/types/kinds/flambda_arity.cmi \
     middle_end/flambda/basic/expr_std.cmo \
@@ -8212,7 +8212,6 @@ middle_end/flambda/terms/flambda.cmo : \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/terms/code0.cmi \
     middle_end/flambda/basic/closure_id.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/terms/bound_symbols.cmi \
     middle_end/flambda/naming/bindable_variable_in_terms.cmi \
     middle_end/flambda/naming/bindable_let_bound.cmi \
@@ -8257,6 +8256,7 @@ middle_end/flambda/terms/flambda.cmx : \
     middle_end/flambda/terms/function_declarations.cmx \
     middle_end/flambda/terms/flambda_primitive.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/types/kinds/flambda_arity.cmx \
     middle_end/flambda/basic/expr_std.cmx \
@@ -8271,7 +8271,6 @@ middle_end/flambda/terms/flambda.cmx : \
     middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/terms/code0.cmx \
     middle_end/flambda/basic/closure_id.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/terms/bound_symbols.cmx \
     middle_end/flambda/naming/bindable_variable_in_terms.cmx \
     middle_end/flambda/naming/bindable_let_bound.cmx \
@@ -8338,12 +8337,12 @@ middle_end/flambda/terms/flambda_primitive.cmo : \
     middle_end/flambda/basic/invariant_env.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/basic/effects.cmi \
     middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/basic/coeffects.cmi \
     middle_end/flambda/basic/closure_id.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/terms/flambda_primitive.cmi
 middle_end/flambda/terms/flambda_primitive.cmx : \
     middle_end/flambda/basic/var_within_closure.cmx \
@@ -8359,12 +8358,12 @@ middle_end/flambda/terms/flambda_primitive.cmx : \
     middle_end/flambda/basic/invariant_env.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/basic/effects.cmx \
     middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/basic/coeffects.cmx \
     middle_end/flambda/basic/closure_id.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/terms/flambda_primitive.cmi
 middle_end/flambda/terms/flambda_primitive.cmi : \
     middle_end/flambda/basic/var_within_closure.cmi \
@@ -8488,8 +8487,8 @@ middle_end/flambda/terms/let_cont_expr.rec.cmo : \
     middle_end/flambda/naming/num_occurrences.cmi \
     middle_end/flambda/naming/name_occurrences.cmi \
     utils/misc.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/basic/continuation.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/terms/let_cont_expr.rec.cmi
 middle_end/flambda/terms/let_cont_expr.rec.cmx : \
     middle_end/flambda/basic/recursive.cmx \
@@ -8498,8 +8497,8 @@ middle_end/flambda/terms/let_cont_expr.rec.cmx : \
     middle_end/flambda/naming/num_occurrences.cmx \
     middle_end/flambda/naming/name_occurrences.cmx \
     utils/misc.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/basic/continuation.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/terms/let_cont_expr.rec.cmi
 middle_end/flambda/terms/let_cont_expr.rec.cmi : \
     middle_end/flambda/types/basic/or_unknown.cmi \
@@ -8864,7 +8863,6 @@ middle_end/flambda/to_cmm/un_cps.cmo : \
     asmcomp/cmm_helpers.cmi \
     asmcomp/cmm.cmi \
     middle_end/flambda/basic/closure_id.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/terms/call_kind.cmi \
     middle_end/flambda/terms/bound_symbols.cmi \
     middle_end/flambda/naming/bindable_let_bound.cmi \
@@ -8927,7 +8925,6 @@ middle_end/flambda/to_cmm/un_cps.cmx : \
     asmcomp/cmm_helpers.cmx \
     asmcomp/cmm.cmx \
     middle_end/flambda/basic/closure_id.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/terms/call_kind.cmx \
     middle_end/flambda/terms/bound_symbols.cmx \
     middle_end/flambda/naming/bindable_let_bound.cmx \
@@ -8948,12 +8945,12 @@ middle_end/flambda/to_cmm/un_cps_closure.cmo : \
     middle_end/flambda/compilenv_deps/linkage_name.cmi \
     middle_end/flambda/terms/function_declarations.cmi \
     middle_end/flambda/terms/flambda_unit.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/cmx/exported_offsets.cmi \
     middle_end/flambda/cmx/exported_code.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/basic/closure_id.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/to_cmm/un_cps_closure.cmi
 middle_end/flambda/to_cmm/un_cps_closure.cmx : \
     middle_end/flambda/basic/var_within_closure.cmx \
@@ -8964,12 +8961,12 @@ middle_end/flambda/to_cmm/un_cps_closure.cmx : \
     middle_end/flambda/compilenv_deps/linkage_name.cmx \
     middle_end/flambda/terms/function_declarations.cmx \
     middle_end/flambda/terms/flambda_unit.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/cmx/exported_offsets.cmx \
     middle_end/flambda/cmx/exported_code.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
     middle_end/flambda/basic/closure_id.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/to_cmm/un_cps_closure.cmi
 middle_end/flambda/to_cmm/un_cps_closure.cmi : \
     middle_end/flambda/basic/var_within_closure.cmi \
@@ -9135,6 +9132,7 @@ middle_end/flambda/to_cmm/un_cps_static.cmo : \
     middle_end/flambda/compilenv_deps/linkage_name.cmi \
     lambda/lambda.cmi \
     middle_end/flambda/terms/function_declarations.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/terms/flambda.cmi \
     lambda/debuginfo.cmi \
@@ -9145,7 +9143,6 @@ middle_end/flambda/to_cmm/un_cps_static.cmo : \
     asmcomp/cmm_helpers.cmi \
     asmcomp/cmm.cmi \
     middle_end/flambda/basic/closure_id.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/terms/bound_symbols.cmi \
     middle_end/flambda/naming/bindable_let_bound.cmi \
     middle_end/flambda/to_cmm/un_cps_static.cmi
@@ -9170,6 +9167,7 @@ middle_end/flambda/to_cmm/un_cps_static.cmx : \
     middle_end/flambda/compilenv_deps/linkage_name.cmx \
     lambda/lambda.cmx \
     middle_end/flambda/terms/function_declarations.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/terms/flambda.cmx \
     lambda/debuginfo.cmx \
@@ -9180,7 +9178,6 @@ middle_end/flambda/to_cmm/un_cps_static.cmx : \
     asmcomp/cmm_helpers.cmx \
     asmcomp/cmm.cmx \
     middle_end/flambda/basic/closure_id.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/terms/bound_symbols.cmx \
     middle_end/flambda/naming/bindable_let_bound.cmx \
     middle_end/flambda/to_cmm/un_cps_static.cmi
@@ -9231,6 +9228,7 @@ middle_end/flambda/types/flambda_type.cmo : \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/inlining/function_decl_inlining_decision.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/types/kinds/flambda_arity.cmi \
     middle_end/flambda/terms/flambda.cmi \
@@ -9244,7 +9242,6 @@ middle_end/flambda/types/flambda_type.cmo : \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/types/structures/code_age_relation.cmi \
     middle_end/flambda/basic/closure_id.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/types/env/binding_time.cmi \
     middle_end/flambda/basic/apply_cont_rewrite_id.cmi \
     middle_end/flambda/types/env/aliases.cmi \
@@ -9287,6 +9284,7 @@ middle_end/flambda/types/flambda_type.cmx : \
     middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/inlining/function_decl_inlining_decision.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/types/kinds/flambda_arity.cmx \
     middle_end/flambda/terms/flambda.cmx \
@@ -9300,7 +9298,6 @@ middle_end/flambda/types/flambda_type.cmx : \
     middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/types/structures/code_age_relation.cmx \
     middle_end/flambda/basic/closure_id.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/types/env/binding_time.cmx \
     middle_end/flambda/basic/apply_cont_rewrite_id.cmx \
     middle_end/flambda/types/env/aliases.cmx \
@@ -9370,9 +9367,9 @@ middle_end/flambda/types/type_descr.rec.cmo : \
     middle_end/flambda/naming/name_mode.cmi \
     utils/misc.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/basic/coercion.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/types/env/aliases.cmi \
     middle_end/flambda/types/type_descr.rec.cmi
 middle_end/flambda/types/type_descr.rec.cmx : \
@@ -9389,9 +9386,9 @@ middle_end/flambda/types/type_descr.rec.cmx : \
     middle_end/flambda/naming/name_mode.cmx \
     utils/misc.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/basic/coercion.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/types/env/aliases.cmx \
     middle_end/flambda/types/type_descr.rec.cmi
 middle_end/flambda/types/type_descr.rec.cmi : \
@@ -9440,8 +9437,8 @@ middle_end/flambda/types/type_grammar.rec.cmo : \
     middle_end/flambda/basic/name.cmi \
     utils/misc.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/basic/closure_id.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/types/type_grammar.rec.cmi
 middle_end/flambda/types/type_grammar.rec.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
@@ -9464,8 +9461,8 @@ middle_end/flambda/types/type_grammar.rec.cmx : \
     middle_end/flambda/basic/name.cmx \
     utils/misc.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/basic/closure_id.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/types/type_grammar.rec.cmi
 middle_end/flambda/types/type_grammar.rec.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
@@ -9569,17 +9566,17 @@ middle_end/flambda/types/basic/or_unknown.cmo : \
     middle_end/flambda/naming/name_occurrences.cmi \
     utils/misc.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/compilenv_deps/container_types.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/types/basic/or_unknown.cmi
 middle_end/flambda/types/basic/or_unknown.cmx : \
     middle_end/flambda/naming/name_occurrences.cmx \
     utils/misc.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/compilenv_deps/container_types.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/types/basic/or_unknown.cmi
 middle_end/flambda/types/basic/or_unknown.cmi : \
     middle_end/flambda/naming/renaming.cmi \
@@ -9669,9 +9666,9 @@ middle_end/flambda/types/env/aliases.cmo : \
     middle_end/flambda/basic/name.cmi \
     utils/misc.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/basic/coercion.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/types/env/binding_time.cmi \
     middle_end/flambda/types/env/aliases.cmi
 middle_end/flambda/types/env/aliases.cmx : \
@@ -9683,9 +9680,9 @@ middle_end/flambda/types/env/aliases.cmx : \
     middle_end/flambda/basic/name.cmx \
     utils/misc.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/basic/coercion.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/types/env/binding_time.cmx \
     middle_end/flambda/types/env/aliases.cmi
 middle_end/flambda/types/env/aliases.cmi : \
@@ -9747,6 +9744,7 @@ middle_end/flambda/types/env/typing_env.rec.cmo : \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/terms/flambda.cmi \
     middle_end/flambda/cmx/exported_code.cmi \
@@ -9754,7 +9752,6 @@ middle_end/flambda/types/env/typing_env.rec.cmo : \
     middle_end/flambda/basic/coercion.cmi \
     middle_end/flambda/basic/code_id.cmi \
     middle_end/flambda/types/structures/code_age_relation.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/types/env/binding_time.cmi \
     middle_end/flambda/types/env/aliases.cmi \
     middle_end/flambda/types/env/typing_env.rec.cmi
@@ -9775,6 +9772,7 @@ middle_end/flambda/types/env/typing_env.rec.cmx : \
     middle_end/flambda/basic/kinded_parameter.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/terms/flambda.cmx \
     middle_end/flambda/cmx/exported_code.cmx \
@@ -9782,7 +9780,6 @@ middle_end/flambda/types/env/typing_env.rec.cmx : \
     middle_end/flambda/basic/coercion.cmx \
     middle_end/flambda/basic/code_id.cmx \
     middle_end/flambda/types/structures/code_age_relation.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/types/env/binding_time.cmx \
     middle_end/flambda/types/env/aliases.cmx \
     middle_end/flambda/types/env/typing_env.rec.cmi
@@ -9817,7 +9814,7 @@ middle_end/flambda/types/env/typing_env_extension.rec.cmo : \
     middle_end/flambda/basic/name.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
-    utils/clflags.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/types/env/typing_env_extension.rec.cmi
 middle_end/flambda/types/env/typing_env_extension.rec.cmx : \
     middle_end/flambda/compilenv_deps/variable.cmx \
@@ -9828,7 +9825,7 @@ middle_end/flambda/types/env/typing_env_extension.rec.cmx : \
     middle_end/flambda/basic/name.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
-    utils/clflags.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/types/env/typing_env_extension.rec.cmi
 middle_end/flambda/types/env/typing_env_extension.rec.cmi : \
     middle_end/flambda/compilenv_deps/variable.cmi \
@@ -9852,9 +9849,9 @@ middle_end/flambda/types/env/typing_env_level.rec.cmo : \
     middle_end/flambda/basic/kinded_parameter.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/compilenv_deps/compilation_unit.cmi \
     middle_end/flambda/types/structures/code_age_relation.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/types/env/binding_time.cmi \
     middle_end/flambda/types/env/typing_env_level.rec.cmi
 middle_end/flambda/types/env/typing_env_level.rec.cmx : \
@@ -9872,9 +9869,9 @@ middle_end/flambda/types/env/typing_env_level.rec.cmx : \
     middle_end/flambda/basic/kinded_parameter.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/compilenv_deps/compilation_unit.cmx \
     middle_end/flambda/types/structures/code_age_relation.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/types/env/binding_time.cmx \
     middle_end/flambda/types/env/typing_env_level.rec.cmi
 middle_end/flambda/types/env/typing_env_level.rec.cmi : \
@@ -10069,10 +10066,10 @@ middle_end/flambda/types/structures/row_like.rec.cmo : \
     utils/misc.cmi \
     middle_end/flambda/cmx/ids_for_export.cmi \
     middle_end/flambda/types/kinds/flambda_kind.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/compilenv_deps/flambda_colours.cmi \
     middle_end/flambda/compilenv_deps/container_types.cmi \
     middle_end/flambda/basic/closure_id.cmi \
-    utils/clflags.cmi \
     middle_end/flambda/types/structures/row_like.rec.cmi
 middle_end/flambda/types/structures/row_like.rec.cmx : \
     middle_end/flambda/basic/var_within_closure.cmx \
@@ -10091,10 +10088,10 @@ middle_end/flambda/types/structures/row_like.rec.cmx : \
     utils/misc.cmx \
     middle_end/flambda/cmx/ids_for_export.cmx \
     middle_end/flambda/types/kinds/flambda_kind.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/compilenv_deps/flambda_colours.cmx \
     middle_end/flambda/compilenv_deps/container_types.cmx \
     middle_end/flambda/basic/closure_id.cmx \
-    utils/clflags.cmx \
     middle_end/flambda/types/structures/row_like.rec.cmi
 middle_end/flambda/types/structures/row_like.rec.cmi : \
     middle_end/flambda/basic/var_within_closure.cmi \
@@ -10397,7 +10394,7 @@ middle_end/flambda/unboxing/optimistic_unboxing_decision.cmo : \
     middle_end/flambda/naming/name_in_binding_pos.cmi \
     middle_end/flambda/basic/name.cmi \
     utils/misc.cmi \
-    utils/clflags.cmi \
+    middle_end/flambda/compilenv_deps/flambda_features.cmi \
     middle_end/flambda/unboxing/optimistic_unboxing_decision.cmi
 middle_end/flambda/unboxing/optimistic_unboxing_decision.cmx : \
     middle_end/flambda/basic/var_within_closure.cmx \
@@ -10411,7 +10408,7 @@ middle_end/flambda/unboxing/optimistic_unboxing_decision.cmx : \
     middle_end/flambda/naming/name_in_binding_pos.cmx \
     middle_end/flambda/basic/name.cmx \
     utils/misc.cmx \
-    utils/clflags.cmx \
+    middle_end/flambda/compilenv_deps/flambda_features.cmx \
     middle_end/flambda/unboxing/optimistic_unboxing_decision.cmi
 middle_end/flambda/unboxing/optimistic_unboxing_decision.cmi : \
     middle_end/flambda/unboxing/unboxing_types.cmi \

--- a/middle_end/flambda/cmx/flambda_cmx.ml
+++ b/middle_end/flambda/cmx/flambda_cmx.ml
@@ -113,7 +113,7 @@ let prepare_cmx_file_contents ~return_cont_env:cont_uses_env
       cont_uses_env return_continuation
   with
   | None -> None
-  | Some _ when !Clflags.opaque -> None
+  | Some _ when Flambda_features.opaque () -> None
   | Some final_typing_env ->
     (* CR mshinwell: We should remove typing information about names that
        do not occur (transitively) in the type of the module block. *)

--- a/middle_end/flambda/compilenv_deps/flambda_features.ml
+++ b/middle_end/flambda/compilenv_deps/flambda_features.ml
@@ -20,6 +20,73 @@ let unbox_along_intra_function_control_flow () =
 let backend_cse_at_toplevel () = !Clflags.Flambda.backend_cse_at_toplevel
 let cse_depth () = !Clflags.Flambda.cse_depth
 
+let debug () = !Clflags.debug
+let opaque () = !Clflags.opaque
+let float_const_prop () = !Clflags.float_const_prop
+let treat_invalid_code_as_unreachable () =
+  !Clflags.treat_invalid_code_as_unreachable
+
+let optimize_for_speed () = !Clflags.optimize_for_speed
+
+let inlining_report () = !Clflags.inlining_report
+let inlining_report_bin () = !Clflags.inlining_report_bin
+
+let colour () = !Clflags.color
+let unicode () = !Clflags.flambda_unicode
+
+let check_invariants () = !Clflags.flambda_invariant_checks
+let context_on_error () = !Clflags.flambda_context_on_error
+
+let dump_rawflambda () = !Clflags.dump_rawflambda
+let dump_flambda () = !Clflags.dump_flambda
+let dump_rawfexpr () = !Clflags.dump_rawfexpr
+let dump_fexpr () = !Clflags.dump_fexpr
+let dump_flexpect () = !Clflags.dump_flexpect
+let dump_let_cont () = !Clflags.dump_let_cont
+let dump_offset () = !Clflags.dump_offset
+
+module Inlining = struct
+  module I = Clflags.Int_arg_helper
+  module F = Clflags.Float_arg_helper
+
+  let max_depth ~round =
+    I.get ~key:round !Clflags.inline_max_depth
+
+  let call_cost ~round =
+    F.get ~key:round !Clflags.inline_call_cost
+
+  let alloc_cost ~round =
+    F.get ~key:round !Clflags.inline_alloc_cost
+
+  let prim_cost ~round =
+    F.get ~key:round !Clflags.inline_prim_cost
+
+  let branch_cost ~round =
+    F.get ~key:round !Clflags.inline_branch_cost
+
+  let indirect_call_cost ~round =
+    F.get ~key:round !Clflags.inline_indirect_call_cost
+
+  let poly_compare_cost ~round =
+    F.get ~key:round !Clflags.inline_poly_compare_cost
+
+  let small_function_size ~round =
+    I.get ~key:round !Clflags.inline_small_function_size
+
+  let large_function_size ~round =
+    I.get ~key:round !Clflags.inline_large_function_size
+
+  let threshold ~round =
+    F.get ~key:round !Clflags.inline_threshold
+end
+
+module Debug = struct
+  let permute_every_name () = !Clflags.Flambda.Debug.permute_every_name
+
+  let concrete_types_only_on_canonicals () =
+    !Clflags.Flambda.Debug.concrete_types_only_on_canonicals
+end
+
 module Expert = struct
   let code_id_and_symbol_scoping_checks () =
     !Clflags.Flambda.Expert.code_id_and_symbol_scoping_checks
@@ -29,4 +96,8 @@ module Expert = struct
     !Clflags.Flambda.Expert.inline_effects_in_cmm
   let max_block_size_for_projections () =
     !Clflags.Flambda.Expert.max_block_size_for_projections
+  let phantom_lets () =
+    !Clflags.Flambda.Expert.phantom_lets
+  let max_unboxing_depth () =
+    !Clflags.Flambda.Expert.max_unboxing_depth
 end

--- a/middle_end/flambda/compilenv_deps/flambda_features.mli
+++ b/middle_end/flambda/compilenv_deps/flambda_features.mli
@@ -19,9 +19,53 @@ val unbox_along_intra_function_control_flow : unit -> bool
 val backend_cse_at_toplevel : unit -> bool
 val cse_depth : unit -> int
 
+val debug : unit -> bool
+val opaque : unit -> bool
+val float_const_prop : unit -> bool
+val treat_invalid_code_as_unreachable : unit -> bool
+
+val optimize_for_speed : unit -> bool
+
+val inlining_report : unit -> bool
+val inlining_report_bin : unit -> bool
+
+val colour : unit -> Misc.Color.setting option
+val unicode : unit -> bool
+
+val check_invariants : unit -> bool
+val context_on_error : unit -> bool
+
+val dump_rawflambda : unit -> bool
+val dump_flambda : unit -> bool
+val dump_rawfexpr : unit -> bool
+val dump_fexpr : unit -> bool
+val dump_flexpect : unit -> bool
+val dump_let_cont : unit -> bool
+val dump_offset : unit -> bool
+
+module Inlining : sig
+  val max_depth : round:int -> int
+  val call_cost : round:int -> float
+  val alloc_cost : round:int -> float
+  val prim_cost : round:int -> float
+  val branch_cost : round:int -> float
+  val indirect_call_cost : round:int -> float
+  val poly_compare_cost : round:int -> float
+  val small_function_size : round:int -> int
+  val large_function_size : round:int -> int
+  val threshold : round:int -> float
+end
+
+module Debug : sig
+  val permute_every_name : unit -> bool
+  val concrete_types_only_on_canonicals : unit -> bool
+end
+
 module Expert : sig
   val code_id_and_symbol_scoping_checks : unit -> bool
   val fallback_inlining_heuristic : unit -> bool
   val inline_effects_in_cmm : unit -> bool
   val max_block_size_for_projections : unit -> int option
+  val phantom_lets : unit -> bool
+  val max_unboxing_depth : unit -> int
 end

--- a/middle_end/flambda/flambda_middle_end.ml
+++ b/middle_end/flambda/flambda_middle_end.ml
@@ -32,13 +32,13 @@ let check_invariants unit =
   end
 
 let print_rawflambda ppf unit =
-  if !Clflags.dump_rawflambda then begin
+  if Flambda_features.dump_rawflambda () then begin
     Format.fprintf ppf "\n%sAfter CPS conversion:%s@ %a@."
       (Flambda_colours.each_file ())
       (Flambda_colours.normal ())
       Flambda_unit.print unit
   end;
-  if !Clflags.dump_rawfexpr then begin
+  if Flambda_features.dump_rawfexpr () then begin
     Format.fprintf ppf "\n%sAfter CPS conversion:%s@ %a@."
       (Flambda_colours.each_file ())
       (Flambda_colours.normal ())
@@ -46,14 +46,14 @@ let print_rawflambda ppf unit =
   end
 
 let print_flambda name ppf unit =
-  if !Clflags.dump_flambda then begin
+  if Flambda_features.dump_flambda () then begin
     Format.fprintf ppf "\n%sAfter %s:%s@ %a@."
       (Flambda_colours.each_file ())
       name
       (Flambda_colours.normal ())
       Flambda_unit.print unit
   end;
-  if !Clflags.dump_fexpr then begin
+  if Flambda_features.dump_fexpr () then begin
     Format.fprintf ppf "\n%sAfter %s:%s@ %a@."
       (Flambda_colours.each_file ())
       name
@@ -62,7 +62,7 @@ let print_flambda name ppf unit =
   end
 
 let output_flexpect ~ml_filename old_unit new_unit =
-  if !Clflags.dump_flexpect then begin
+  if Flambda_features.dump_flexpect () then begin
     let basename = Filename.chop_suffix ml_filename ".ml" in
     let filename = basename ^ ".flt" in
     let before = old_unit |> Flambda_to_fexpr.conv in
@@ -78,7 +78,7 @@ let output_flexpect ~ml_filename old_unit new_unit =
 
 let middle_end0 ppf ~prefixname ~backend ~filename ~module_ident
       ~module_block_size_in_words ~module_initializer =
-  Misc.Color.setup !Clflags.color;
+  Misc.Color.setup (Flambda_features.colour ());
   Profile.record_call "flambda.0" (fun () ->
     let flambda =
       Profile.record_call "lambda_to_flambda" (fun () ->
@@ -88,7 +88,7 @@ let middle_end0 ppf ~prefixname ~backend ~filename ~module_ident
     print_rawflambda ppf flambda;
     check_invariants flambda;
     let flambda =
-      if !Clflags.Flambda.Debug.permute_every_name
+      if Flambda_features.Debug.permute_every_name ()
       then Flambda_unit.permute_everything flambda
       else flambda
     in
@@ -97,7 +97,7 @@ let middle_end0 ppf ~prefixname ~backend ~filename ~module_ident
       Profile.record_call ~accumulate:true "simplify"
         (fun () -> Simplify.run ~backend ~round flambda)
     in
-    if !Clflags.inlining_report then begin
+    if Flambda_features.inlining_report () then begin
       let output_prefix = Printf.sprintf "%s.%d" prefixname round in
       Inlining_report.output_then_forget_decisions ~output_prefix
     end;

--- a/middle_end/flambda/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion.ml
@@ -801,7 +801,7 @@ let close_one_function acc ~external_env ~by_closure_id decl
   let acc, body =
     try body acc closure_env
     with Misc.Fatal_error -> begin
-      if !Clflags.flambda_context_on_error then begin
+      if Flambda_features.context_on_error () then begin
         Format.eprintf "\n%sContext is:%s closure converting \
           function@ with [our_let_rec_ident] %a (closure ID %a)"(* @ \ *)
           (* and body:@ %a *)
@@ -891,7 +891,7 @@ let close_one_function acc ~external_env ~by_closure_id decl
        been lifted by our other check in [Inlining_cost] (thus preventing us
        seeing they were originally there). *)
     if contains_subfunctions
-      && !Clflags.Flambda.Expert.fallback_inlining_heuristic
+      && Flambda_features.Expert.fallback_inlining_heuristic ()
     then Never_inline
     else LC.inline_attribute (Function_decl.inline decl)
   in

--- a/middle_end/flambda/inlining/inlining_arguments.ml
+++ b/middle_end/flambda/inlining/inlining_arguments.ml
@@ -184,25 +184,19 @@ module Args = struct
       threshold = Float.min t1_threshold t2_threshold
     }
 
-
-  let cost_i (flag : Clflags.Int_arg_helper.parsed) ~round =
-    Clflags.Int_arg_helper.get ~key:round flag
-
-  let cost_f (flag : Clflags.Float_arg_helper.parsed) ~round =
-    Clflags.Float_arg_helper.get ~key:round flag
-
-  let create ~round = {
-    max_inlining_depth = cost_i !Clflags.inline_max_depth ~round;
-    call_cost = cost_f !Clflags.inline_call_cost ~round;
-    alloc_cost = cost_f !Clflags.inline_alloc_cost ~round;
-    prim_cost = cost_f !Clflags.inline_prim_cost ~round;
-    branch_cost = cost_f !Clflags.inline_branch_cost ~round;
-    indirect_call_cost = cost_f !Clflags.inline_indirect_call_cost ~round;
-    poly_compare_cost = cost_f !Clflags.inline_poly_compare_cost ~round;
-    small_function_size = cost_i !Clflags.inline_small_function_size ~round;
-    large_function_size = cost_i !Clflags.inline_large_function_size ~round;
-    threshold = cost_f !Clflags.inline_threshold ~round;
-  }
+  let create ~round =
+    let module I = Flambda_features.Inlining in
+    { max_inlining_depth = I.max_depth ~round;
+      call_cost = I.call_cost ~round;
+      alloc_cost = I.alloc_cost ~round;
+      prim_cost = I.prim_cost ~round;
+      branch_cost = I.branch_cost ~round;
+      indirect_call_cost = I.indirect_call_cost ~round;
+      poly_compare_cost = I.poly_compare_cost ~round;
+      small_function_size = I.small_function_size ~round;
+      large_function_size = I.large_function_size ~round;
+      threshold = I.threshold ~round;
+    }
 end
 
 type t = Args.t

--- a/middle_end/flambda/inlining/inlining_report.ml
+++ b/middle_end/flambda/inlining/inlining_report.ml
@@ -141,7 +141,7 @@ let rec print ~depth fmt = function
 (* Exposed interface *)
 
 let record_decision ~dbg decision =
-  if !Clflags.inlining_report || !Clflags.inlining_report_bin then begin
+  if Flambda_features.inlining_report () || Flambda_features.inlining_report_bin () then begin
     log := { dbg; decision; } :: !log
   end
 
@@ -154,13 +154,13 @@ let output_then_forget_decisions ~output_prefix =
       Format.eprintf "WARNING: inlining report output failed@.")
     (fun () ->
        let l = lazy (List.rev !log) in
-       if !Clflags.inlining_report then begin
+       if Flambda_features.inlining_report () then begin
          let out_channel = open_out (output_prefix ^ ".inlining.org") in
          let fmt = Format.formatter_of_out_channel out_channel in
          Format.fprintf fmt "%a@." (print ~depth:0) (Lazy.force l);
          close_out out_channel;
        end;
-       if !Clflags.inlining_report_bin then begin
+       if Flambda_features.inlining_report_bin () then begin
          let ch = open_out_bin (output_prefix ^ ".inlining") in
          let metadata = {
            compilation_unit = Compilation_unit.get_current_exn ();

--- a/middle_end/flambda/lifting/reification.ml
+++ b/middle_end/flambda/lifting/reification.ml
@@ -57,7 +57,7 @@ let lift dacc ty ~bound_to static_const =
     in
     match existing_symbol with
     | Some symbol ->
-      if !Clflags.flambda_invariant_checks
+      if Flambda_features.check_invariants ()
         && not (DE.mem_symbol (DA.denv dacc) symbol)
       then begin
         Misc.fatal_errorf "Constant with symbol %a is shareable but not in \

--- a/middle_end/flambda/naming/name_occurrences.ml
+++ b/middle_end/flambda/naming/name_occurrences.ml
@@ -270,7 +270,7 @@ end = struct
     N.Map.print For_one_name.print ppf (map t)
 
   let invariant t =
-    if !Clflags.flambda_invariant_checks then begin
+    if Flambda_features.check_invariants () then begin
       N.Map.iter (fun _name for_one_name ->
           For_one_name.invariant for_one_name)
         (map t)

--- a/middle_end/flambda/simplify/basic/simplified_named.ml
+++ b/middle_end/flambda/simplify/basic/simplified_named.ml
@@ -94,7 +94,7 @@ let reachable_with_known_free_names ~find_code_characteristics
   }
 
 let invalid () =
-  if !Clflags.treat_invalid_code_as_unreachable then
+  if Flambda_features.treat_invalid_code_as_unreachable () then
     Invalid Treat_as_unreachable
   else
     Invalid Halt_and_catch_fire

--- a/middle_end/flambda/simplify/env/downwards_env.ml
+++ b/middle_end/flambda/simplify/env/downwards_env.ml
@@ -603,7 +603,7 @@ let enter_inlined_apply ~called_code ~apply t =
   }
 
 let generate_phantom_lets t =
-  !Clflags.debug && !Clflags.Flambda.Expert.phantom_lets
+  Flambda_features.debug () && Flambda_features.Expert.phantom_lets ()
     (* It would be a waste of time generating phantom lets when not
        rebuilding terms, since they have no effect on cost metrics. *)
     && are_rebuilding_terms t

--- a/middle_end/flambda/simplify/simplify.ml
+++ b/middle_end/flambda/simplify/simplify.ml
@@ -75,7 +75,7 @@ let run ~backend ~round unit =
       ~resolver
       ~get_imported_names
       ~get_imported_code
-      ~float_const_prop:!Clflags.float_const_prop
+      ~float_const_prop:(Flambda_features.float_const_prop ())
       ~unit_toplevel_return_continuation:return_continuation
       ~unit_toplevel_exn_continuation:exn_continuation
   in

--- a/middle_end/flambda/simplify/simplify_common.ml
+++ b/middle_end/flambda/simplify/simplify_common.ml
@@ -189,7 +189,7 @@ let apply_cont_use_kind ~context apply_cont : Continuation_use_kind.t =
            at Cmm level; see [Cmm_helpers.raise_prim].)
            We set [escaping = true] for the cases we do not want to
            convert into jumps. *)
-        if !Clflags.debug then Non_inlinable { escaping = true; }
+        if Flambda_features.debug () then Non_inlinable { escaping = true; }
         else Non_inlinable { escaping = false; }
       | Some No_trace ->
         Non_inlinable { escaping = false; }

--- a/middle_end/flambda/simplify/simplify_named.ml
+++ b/middle_end/flambda/simplify/simplify_named.ml
@@ -237,7 +237,7 @@ let simplify_named0 dacc (bindable_let_bound : Bindable_let_bound.t)
         Simplify_static_const.simplify_static_consts dacc bound_symbols
           static_consts ~simplify_toplevel
       with Misc.Fatal_error -> begin
-        if !Clflags.flambda_context_on_error then begin
+        if Flambda_features.context_on_error () then begin
           Format.eprintf "\n%sContext is:%s simplifying 'let symbol' binding \
                             of@ %a@ with downwards accumulator:@ %a\n"
             (Flambda_colours.error ())
@@ -398,7 +398,7 @@ let simplify_named dacc bindable_let_bound named ~simplify_toplevel =
     in
     simplified_named, removed_operations named simplified_named
   with Misc.Fatal_error -> begin
-    if !Clflags.flambda_context_on_error then begin
+    if Flambda_features.context_on_error () then begin
       Format.eprintf "\n%sContext is:%s simplifying [Let] binding@ %a =@ %a@ \
           with downwards accumulator:@ %a\n"
         (Flambda_colours.error ())

--- a/middle_end/flambda/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda/simplify/simplify_set_of_closures.ml
@@ -515,7 +515,7 @@ let simplify_function context ~used_closure_vars ~shareable_constants
           end;
           params_and_body, dacc_after_body, free_names_of_code, uacc
         | exception Misc.Fatal_error ->
-          if !Clflags.flambda_context_on_error then begin
+          if Flambda_features.context_on_error () then begin
             Format.eprintf "\n%sContext is:%s simplifying function \
                 with closure ID %a,@ params %a,@ return continuation %a,@ \
                 exn continuation %a,@ my_closure %a,@ body:@ %a@ \

--- a/middle_end/flambda/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda/simplify/simplify_switch_expr.ml
@@ -236,7 +236,7 @@ let rebuild_switch ~simplify_let dacc ~arms ~scrutinee ~scrutinee_ty uacc
              branches wouldn't have been taken during execution anyway.
           *)
           let expr, uacc = EB.create_switch uacc ~scrutinee ~arms in
-          if !Clflags.flambda_invariant_checks
+          if Flambda_features.check_invariants ()
             && Simple.is_const scrutinee
             && Targetint_31_63.Map.cardinal arms > 1
           then begin

--- a/middle_end/flambda/simplify/typing_helpers/continuation_uses.ml
+++ b/middle_end/flambda/simplify/typing_helpers/continuation_uses.ml
@@ -60,7 +60,7 @@ let add_use t kind ~env_at_use id ~arg_types =
       uses = use :: t.uses;
     }
   with Misc.Fatal_error -> begin
-    if !Clflags.flambda_context_on_error then begin
+    if Flambda_features.context_on_error () then begin
       Format.eprintf "\n%sContext is:%s adding use of %a with \
             arg types@ (%a);@ existing uses:@ %a; environment:@ %a"
         (Flambda_colours.error ())

--- a/middle_end/flambda/terms/expr.rec.ml
+++ b/middle_end/flambda/terms/expr.rec.ml
@@ -156,7 +156,7 @@ let create_invalid ?semantics () =
     | Some semantics ->
       semantics
     | None ->
-      if !Clflags.treat_invalid_code_as_unreachable then
+      if Flambda_features.treat_invalid_code_as_unreachable () then
         Treat_as_unreachable
       else
         Halt_and_catch_fire

--- a/middle_end/flambda/terms/flambda_primitive.ml
+++ b/middle_end/flambda/terms/flambda_primitive.ml
@@ -643,8 +643,7 @@ let unary_primitive_eligible_for_cse p ~arg =
   | Int_as_pointer -> true
   | Opaque_identity -> false
   | Int_arith _ -> true
-    (* CR mshinwell: See CR below about [Clflags]. *)
-  | Float_arith _ -> !Clflags.float_const_prop
+  | Float_arith _ -> Flambda_features.float_const_prop ()
   | Num_conv _
   | Boolean_not
   | Reinterpret_int64_as_float -> true
@@ -1001,8 +1000,6 @@ let binary_primitive_eligible_for_cse p =
   | Int_arith _
   | Int_shift _
   | Int_comp _  -> true
-    (* CR mshinwell: Elsewhere, we don't directly depend on [Clflags].
-       Maybe that's a mistake? *)
   | Float_arith _
   | Float_comp _ ->
     (* We believe that under the IEEE standard it is correct to CSE
@@ -1011,7 +1008,7 @@ let binary_primitive_eligible_for_cse p =
        floating-point support on Intel processors (and indeed whether we
        make use of that).  As such, we don't CSE these comparisons unless
        we would also CSE floating-point arithmetic operations. *)
-    !Clflags.float_const_prop
+    Flambda_features.float_const_prop ()
 
 let compare_binary_primitive p1 p2 =
   let binary_primitive_numbering p =

--- a/middle_end/flambda/terms/let_cont_expr.rec.ml
+++ b/middle_end/flambda/terms/let_cont_expr.rec.ml
@@ -28,7 +28,7 @@ type t =
 let invariant _env _t = ()
 
 let print_with_cache ~cache ppf t =
-  if !Clflags.dump_let_cont then begin
+  if Flambda_features.dump_let_cont () then begin
     (* Printing the same way as for [Let] is easier when debugging lifting
        passes. *)
     Misc.fatal_error "Needs re-enabling"

--- a/middle_end/flambda/to_cmm/un_cps.ml
+++ b/middle_end/flambda/to_cmm/un_cps.ml
@@ -650,7 +650,7 @@ let function_args vars my_closure ~(is_my_closure_used : _ Or_unknown.t) =
     vars
 
 let function_flags () =
-  if !Clflags.optimize_for_speed then
+  if Flambda_features.optimize_for_speed () then
     []
   else
     [ Cmm.Reduce_code_size ]

--- a/middle_end/flambda/to_cmm/un_cps_closure.ml
+++ b/middle_end/flambda/to_cmm/un_cps_closure.ml
@@ -653,7 +653,7 @@ let compute_offsets env code unit =
   Flambda_unit.iter unit ~set_of_closures:aux;
   Misc.try_finally (fun () -> Greedy.finalize !state)
     ~always:(fun () ->
-      if !Clflags.dump_offset then
+      if Flambda_features.dump_offset () then
         Format.eprintf "%a@." Greedy.print !state
     )
 

--- a/middle_end/flambda/to_cmm/un_cps_static.ml
+++ b/middle_end/flambda/to_cmm/un_cps_static.ml
@@ -438,7 +438,7 @@ let static_consts env r ~params_and_body bound_symbols static_consts =
     let r = R.add_gc_roots r roots in
     static_consts0 env r ~params_and_body bound_symbols static_consts
   with Misc.Fatal_error as e ->
-    if !Clflags.flambda_context_on_error then begin
+    if Flambda_features.context_on_error () then begin
       (* Create a new "let symbol" with a dummy body to better print the bound
          symbols and static consts. *)
       let dummy_body = Expr.create_invalid () in

--- a/middle_end/flambda/types/basic/or_unknown.ml
+++ b/middle_end/flambda/types/basic/or_unknown.ml
@@ -26,7 +26,7 @@ let print f ppf t =
   | Known contents -> Format.fprintf ppf "@[<hov 1>%a@]" f contents
     (* Format.fprintf ppf "@[<hov 1>(Known@ %a)@]" f contents *)
   | Unknown ->
-    if !Clflags.flambda_unicode then
+    if Flambda_features.unicode () then
       Format.fprintf ppf "%s@<1>\u{22a4}%s" colour (Flambda_colours.normal ())
     else
       Format.fprintf ppf "%sT%s" colour (Flambda_colours.normal ())

--- a/middle_end/flambda/types/env/aliases.ml
+++ b/middle_end/flambda/types/env/aliases.ml
@@ -145,7 +145,7 @@ end = struct
         (function
           | None -> Some (Name.Map.singleton elt coercion_to_canonical)
           | Some elts ->
-            if !Clflags.flambda_invariant_checks then begin
+            if Flambda_features.check_invariants () then begin
               assert (not (Name.Map.mem elt elts))
             end;
             Some (Name.Map.add elt coercion_to_canonical elts))
@@ -450,7 +450,7 @@ let name_mode t elt ~min_binding_time =
     ~min_binding_time
 
 let invariant t =
-  if !Clflags.flambda_invariant_checks then begin
+  if Flambda_features.check_invariants () then begin
     let all_aliases_of_names : Map_to_canonical.t =
       Name.Map.fold (fun canonical_element aliases all_aliases ->
           Aliases_of_canonical_element.invariant aliases;
@@ -522,7 +522,7 @@ let canonical t element : canonical =
             coercion_from_element_to_bare_element
             ~then_:coercion_from_bare_element_to_canonical
         in
-        if !Clflags.flambda_invariant_checks then begin
+        if Flambda_features.check_invariants () then begin
           assert (not (Simple.equal element canonical_element))
         end;
         Alias_of_canonical
@@ -606,7 +606,7 @@ let add_alias_between_canonical_elements t ~canonical_element
     let aliases_of_to_be_demoted =
       get_aliases_of_canonical_element t ~canonical_element:to_be_demoted
     in
-    if !Clflags.flambda_invariant_checks then begin
+    if Flambda_features.check_invariants () then begin
       Simple.pattern_match canonical_element
         ~const:(fun _ -> ())
         ~name:(fun canonical_element ~coercion ->
@@ -627,7 +627,7 @@ let add_alias_between_canonical_elements t ~canonical_element
     let aliases_of_canonical_element =
       get_aliases_of_canonical_element t ~canonical_element
     in
-    if !Clflags.flambda_invariant_checks then begin
+    if Flambda_features.check_invariants () then begin
       assert (not (Aliases_of_canonical_element.mem
         aliases_of_canonical_element name_to_be_demoted));
       assert (Aliases_of_canonical_element.is_empty (
@@ -684,7 +684,7 @@ type add_result = {
 
 let invariant_add_result
       ~original_t { canonical_element; alias_of_demoted_element; t; } =
-  if !Clflags.flambda_invariant_checks then begin
+  if Flambda_features.check_invariants () then begin
     invariant t;
     if not (defined_earlier t canonical_element ~than:alias_of_demoted_element) then begin
       Misc.fatal_errorf "Canonical element %a should be defined earlier \
@@ -918,7 +918,7 @@ let add t ~element1:element1_with_coercion ~binding_time_and_mode1
     Coercion.compose_exn (Simple.coercion element2_with_coercion)
       ~then_:(Coercion.inverse (Simple.coercion element1_with_coercion))
   in
-  if !Clflags.flambda_invariant_checks then begin
+  if Flambda_features.check_invariants () then begin
     if Simple.equal element1 element2 then begin
       Misc.fatal_errorf
         "Cannot alias an element to itself: %a" Simple.print element1
@@ -948,7 +948,7 @@ let add t ~element1:element1_with_coercion ~binding_time_and_mode1
     }
   in
   let add_result = add_alias t ~element1 ~coercion_from_element2_to_element1 ~element2 in
-  if !Clflags.flambda_invariant_checks then begin
+  if Flambda_features.check_invariants () then begin
     invariant_add_result ~original_t add_result
   end;
   add_result
@@ -1094,7 +1094,7 @@ let get_aliases t element =
       compose_map_values_exn alias_names_with_coercions_to_canonical
         ~then_:coercion_from_canonical_to_element
     in
-    if !Clflags.flambda_invariant_checks then begin
+    if Flambda_features.check_invariants () then begin
       let element_coerced_to_canonical =
         Simple.apply_coercion_exn element coercion_from_element_to_canonical
       in

--- a/middle_end/flambda/types/env/typing_env.rec.ml
+++ b/middle_end/flambda/types/env/typing_env.rec.ml
@@ -499,7 +499,7 @@ let print ppf t =
   print_with_cache ~cache:(Printing_cache.create ()) ppf t
 
 let invariant0 ?force _t =
-  if !Clflags.flambda_invariant_checks || Option.is_some (force : unit option)
+  if Flambda_features.check_invariants () || Option.is_some (force : unit option)
   then begin
 (* CR mshinwell: Fix things so this check passes, or delete it.
     let no_empty_prev_levels =
@@ -825,7 +825,7 @@ let add_variable_definition t var kind name_mode =
       print t
   end;
   let name = Name.var var in
-  if !Clflags.flambda_invariant_checks && mem t name then begin
+  if Flambda_features.check_invariants () && mem t name then begin
     Misc.fatal_errorf "Cannot rebind %a in environment:@ %a"
       Name.print name
       print t
@@ -895,7 +895,7 @@ let add_definition t (name : Name_in_binding_pos.t) kind =
 
 let invariant_for_alias (t:t) name ty =
   (* Check that no canonical element gets an [Equals] type *)
-  if !Clflags.flambda_invariant_checks || true then begin
+  if Flambda_features.check_invariants () || true then begin
     match Type_grammar.get_alias_exn ty with
     | exception Not_found -> ()
     | alias ->
@@ -918,7 +918,7 @@ let invariant_for_aliases (t:t) =
 *)
 
 let invariant_for_new_equation (t:t) name ty =
-  if !Clflags.flambda_invariant_checks then begin
+  if Flambda_features.check_invariants () then begin
     invariant_for_alias t name ty;
     (* CR mshinwell: This should check that precision is not decreasing. *)
     let defined_names =
@@ -941,7 +941,7 @@ let invariant_for_new_equation (t:t) name ty =
   end
 
 let rec add_equation0 (t:t) name ty =
-  if !Clflags.Flambda.Debug.concrete_types_only_on_canonicals then begin
+  if Flambda_features.Debug.concrete_types_only_on_canonicals () then begin
     let is_concrete =
       match Type_grammar.get_alias_exn ty with
       | exception Not_found -> true
@@ -998,7 +998,7 @@ let rec add_equation0 (t:t) name ty =
   res
 
 and add_equation t name ty =
-  if !Clflags.flambda_invariant_checks then begin
+  if Flambda_features.check_invariants () then begin
     let existing_ty = find t name None in
     if not (K.equal (Type_grammar.kind existing_ty) (Type_grammar.kind ty))
     then begin
@@ -1026,7 +1026,7 @@ and add_equation t name ty =
   end;
   *)
   end;
-  if !Clflags.flambda_invariant_checks then begin
+  if Flambda_features.check_invariants () then begin
     match Type_grammar.get_alias_exn ty with
     | exception Not_found -> ()
     | simple ->
@@ -1179,7 +1179,7 @@ let add_definitions_of_params t ~params =
     params
 
 let check_params_and_types ~params ~param_types =
-  if !Clflags.flambda_invariant_checks
+  if Flambda_features.check_invariants ()
     && List.compare_lengths params param_types <> 0
   then begin
     Misc.fatal_errorf "Mismatch between number of [params] and \
@@ -1347,7 +1347,7 @@ let type_simple_in_term_exn t ?min_name_mode simple =
       ~min_name_mode ~min_binding_time
   with
   | exception Misc.Fatal_error ->
-    if !Clflags.flambda_context_on_error then begin
+    if Flambda_features.context_on_error () then begin
       Format.eprintf "\n%sContext is:%s typing environment@ %a\n"
         (Flambda_colours.error ())
         (Flambda_colours.normal ())
@@ -1429,7 +1429,7 @@ let get_canonical_simple_exn t ?min_name_mode ?name_mode_of_existing_simple
       ~min_name_mode ~min_binding_time
   with
   | exception Misc.Fatal_error ->
-    if !Clflags.flambda_context_on_error then begin
+    if Flambda_features.context_on_error () then begin
       Format.eprintf "\n%sContext is:%s typing environment@ %a\n"
         (Flambda_colours.error ())
         (Flambda_colours.normal ())

--- a/middle_end/flambda/types/env/typing_env_extension.rec.ml
+++ b/middle_end/flambda/types/env/typing_env_extension.rec.ml
@@ -44,7 +44,7 @@ let fold ~equation t acc =
   Name.Map.fold equation t.equations acc
 
 let invariant { equations; } =
-  if !Clflags.flambda_invariant_checks then
+  if Flambda_features.check_invariants () then
     Name.Map.iter Type_grammar.check_equation equations
 
 let empty () = { equations = Name.Map.empty; }
@@ -60,7 +60,7 @@ let one_equation name ty =
 
 let add_or_replace_equation t name ty =
   Type_grammar.check_equation name ty;
-  if !Clflags.flambda_invariant_checks
+  if Flambda_features.check_invariants ()
   && Name.Map.mem name t.equations
   then begin
     Format.eprintf

--- a/middle_end/flambda/types/env/typing_env_level.rec.ml
+++ b/middle_end/flambda/types/env/typing_env_level.rec.ml
@@ -113,7 +113,7 @@ let add_symbol_projection t var proj =
   { t with symbol_projections; }
 
 let add_definition t var kind binding_time =
-  if !Clflags.flambda_invariant_checks
+  if Flambda_features.check_invariants ()
     && Variable.Map.mem var t.defined_vars
   then begin
     Misc.fatal_errorf "Environment extension already binds variable %a:@ %a"

--- a/middle_end/flambda/types/structures/row_like.rec.ml
+++ b/middle_end/flambda/types/structures/row_like.rec.ml
@@ -75,7 +75,7 @@ struct
     if is_bottom t then
       (* CR mshinwell: factor out (also in [Type_descr]) *)
       let colour = Flambda_colours.top_or_bottom_type () in
-      if !Clflags.flambda_unicode then
+      if Flambda_features.unicode () then
         Format.fprintf ppf "@<0>%s@<1>\u{22a5}@<0>%s"
           colour (Flambda_colours.normal ())
       else

--- a/middle_end/flambda/types/type_descr.rec.ml
+++ b/middle_end/flambda/types/type_descr.rec.ml
@@ -37,13 +37,13 @@ module Make (Head : Type_head_intf.S
       let colour = Flambda_colours.top_or_bottom_type () in
       match t with
       | No_alias Unknown ->
-        if !Clflags.flambda_unicode then
+        if Flambda_features.unicode () then
           Format.fprintf ppf "@<0>%s@<1>\u{22a4}@<0>%s"
             colour (Flambda_colours.normal ())
         else
           Format.fprintf ppf "@<0>%sT@<0>%s" colour (Flambda_colours.normal ())
       | No_alias Bottom ->
-        if !Clflags.flambda_unicode then
+        if Flambda_features.unicode () then
           Format.fprintf ppf "@<0>%s@<1>\u{22a5}@<0>%s"
             colour (Flambda_colours.normal ())
         else

--- a/middle_end/flambda/types/type_grammar.rec.ml
+++ b/middle_end/flambda/types/type_grammar.rec.ml
@@ -1016,7 +1016,7 @@ let equation_is_directly_recursive name ty =
       ~const:(fun _ -> false)
 
 let check_equation name ty =
-  if !Clflags.flambda_invariant_checks then begin
+  if Flambda_features.check_invariants () then begin
     if equation_is_directly_recursive name ty then begin
       Misc.fatal_errorf "Directly recursive equation@ %a = %a@ \
           disallowed"

--- a/middle_end/flambda/types/type_grammar.rec.mli
+++ b/middle_end/flambda/types/type_grammar.rec.mli
@@ -219,5 +219,5 @@ val join
   -> t Or_unknown.t
 
 (* Checks that the equation is not directly recursive (x : =x)
-   (Depends on Clflags.flambda_invariant_checks) *)
+   (Depends on [Flambda_features.invariant_checks ()]) *)
 val check_equation : Name.t -> t -> unit

--- a/middle_end/flambda/unboxing/optimistic_unboxing_decision.ml
+++ b/middle_end/flambda/unboxing/optimistic_unboxing_decision.ml
@@ -65,7 +65,7 @@ let rec make_optimistic_decision ~depth tenv ~param_type : U.decision =
   | Some decision ->
     if unbox_numbers then decision else Do_not_unbox Incomplete_parameter_type
   | None ->
-    if depth >= !Clflags.Flambda.Expert.max_unboxing_depth then
+    if depth >= Flambda_features.Expert.max_unboxing_depth () then
       Do_not_unbox Max_depth_exceeded
     else match T.prove_unique_tag_and_size tenv param_type with
       | Proved (tag, size) when unbox_blocks ->


### PR DESCRIPTION
Rather dull.

These should all have been going via `Flambda_features` anyway.  The extra indirection will assist with getting this code into the Flambda backend (it means it can be merged and got to compile without wiring everything in).