### PR TITLE
Unify free_names instances of Closure_conversion.Acc

### DIFF
--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -950,29 +950,36 @@ method emit_expr (env:environment) exp =
       let env_body = env_enter_trywith env kind in
       let (r1, s1) = self#emit_sequence env_body e1 in
       let rv = self#regs_for typ_val in
-      let env_handler =
-        let env = env_add v rv env in
-        match kind with
-        | Regular -> env
-        | Delayed lbl ->
-          begin match env_find_static_exception lbl env_body with
-          | (_, { contents = Reachable ts; }) ->
-            env_set_trap_stack env ts
-          | (_, { contents = Unreachable; }) ->
-            Misc.fatal_errorf "Selection.emit_expr: Unreachable exception handler %d" lbl
-          | exception Not_found ->
-            Misc.fatal_errorf "Selection.emit_expr: Unbound handler %d" lbl
-          end
+      let with_handler env_handler e2 =
+        let (r2, s2) = self#emit_sequence env_handler e2 in
+        let r = join env r1 s1 r2 s2 in
+        self#insert env
+          (Itrywith(s1#extract, kind,
+                    (env_handler.trap_stack,
+                     instr_cons (Iop Imove) [|Proc.loc_exn_bucket|] rv
+                       (s2#extract))))
+          [||] [||];
+        r
       in
-      let (r2, s2) = self#emit_sequence env_handler e2 in
-      let r = join env r1 s1 r2 s2 in
-      self#insert env
-        (Itrywith(s1#extract, kind,
-                  (env_handler.trap_stack,
-                   instr_cons (Iop Imove) [|Proc.loc_exn_bucket|] rv
-                              (s2#extract))))
-        [||] [||];
-      r
+      let env = env_add v rv env in
+      match kind with
+      | Regular -> with_handler env e2
+      | Delayed lbl ->
+        begin match env_find_static_exception lbl env_body with
+        | (_, { contents = Reachable ts; }) ->
+          with_handler (env_set_trap_stack env ts) e2
+        | (_, { contents = Unreachable; }) ->
+          let unreachable =
+            Cmm.(Cop ((Cload (Word_int, Mutable)),
+                      [Cconst_int (0, Debuginfo.none)],
+                      Debuginfo.none))
+          in
+          with_handler env unreachable
+          (* Misc.fatal_errorf "Selection.emit_expr: \
+           *                    Unreachable exception handler %d" lbl *)
+        | exception Not_found ->
+          Misc.fatal_errorf "Selection.emit_expr: Unbound handler %d" lbl
+        end
 
 method private emit_sequence (env:environment) exp =
   let s = {< instr_seq = dummy_instr >} in
@@ -1300,26 +1307,34 @@ method emit_tail (env:environment) exp =
       let env_body = env_enter_trywith env kind in
       let s1 = self#emit_tail_sequence env_body e1 in
       let rv = self#regs_for typ_val in
-      let env_handler =
-        let env = env_add v rv env in
-        match kind with
-        | Regular -> env
-        | Delayed lbl ->
-          begin match env_find_static_exception lbl env_body with
-          | (_, { contents = Reachable ts; }) ->
-            env_set_trap_stack env ts
-          | (_, { contents = Unreachable; }) ->
-            Misc.fatal_errorf "Selection.emit_expr: Unreachable exception handler %d" lbl
-          | exception Not_found ->
-            Misc.fatal_errorf "Selection.emit_expr: Unbound handler %d" lbl
-          end
+      let with_handler env_handler e2 =
+        let s2 = self#emit_tail_sequence env_handler e2 in
+        self#insert env
+          (Itrywith(s1, kind,
+                    (env_handler.trap_stack,
+                     instr_cons (Iop Imove) [|Proc.loc_exn_bucket|] rv s2)))
+          [||] [||]
       in
-      let s2 = self#emit_tail_sequence env_handler e2 in
-      self#insert env
-        (Itrywith(s1, kind,
-                  (env_handler.trap_stack,
-                   instr_cons (Iop Imove) [|Proc.loc_exn_bucket|] rv s2)))
-        [||] [||]
+      let env = env_add v rv env in
+      begin match kind with
+      | Regular -> with_handler env e2
+      | Delayed lbl ->
+        begin match env_find_static_exception lbl env_body with
+        | (_, { contents = Reachable ts; }) ->
+          with_handler (env_set_trap_stack env ts) e2
+        | (_, { contents = Unreachable; }) ->
+          let unreachable =
+            Cmm.(Cop ((Cload (Word_int, Mutable)),
+                      [Cconst_int (0, Debuginfo.none)],
+                      Debuginfo.none))
+          in
+          with_handler env unreachable
+          (* Misc.fatal_errorf "Selection.emit_expr: \
+             Unreachable exception handler %d" lbl *)
+        | exception Not_found ->
+          Misc.fatal_errorf "Selection.emit_expr: Unbound handler %d" lbl
+        end
+      end
   | Cop _
   | Cconst_int _ | Cconst_natint _ | Cconst_float _ | Cconst_symbol _
   | Cvar _

--- a/middle_end/flambda/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion.ml
@@ -707,6 +707,7 @@ let close_one_function acc ~external_env ~by_closure_id decl
   let dbg = Debuginfo.from_location loc in
   let params = Function_decl.params decl in
   let return = Function_decl.return decl in
+  let return_continuation = Function_decl.return_continuation decl in
   let recursive = Function_decl.recursive decl in
   let my_closure = Variable.create "my_closure" in
   let closure_id = Function_decl.closure_id decl in
@@ -895,9 +896,14 @@ let close_one_function acc ~external_env ~by_closure_id decl
     then Never_inline
     else LC.inline_attribute (Function_decl.inline decl)
   in
+  let acc =
+    Acc.remove_continuation_from_free_names return_continuation acc
+    |> Acc.remove_continuation_from_free_names
+         (Exn_continuation.exn_handler exn_continuation)
+  in
   let params_and_body =
     Function_params_and_body.create
-      ~return_continuation:(Function_decl.return_continuation decl)
+      ~return_continuation
       exn_continuation params ~dbg ~body ~my_closure ~my_depth
       ~free_names_of_body:Unknown
   in
@@ -911,7 +917,7 @@ let close_one_function acc ~external_env ~by_closure_id decl
     Code.create
       code_id
       ~params_and_body:
-        (Present (params_and_body, Acc.free_names_of_current_function acc))
+        (Present (params_and_body, Acc.free_names acc))
       ~params_arity
       ~result_arity:[LC.value_kind return]
       ~stub
@@ -965,18 +971,22 @@ let close_functions acc external_env function_declarations =
       Ident.Map.empty
       func_decl_list
   in
-  let acc, funs =
-    List.fold_left (fun (acc, by_closure_id) function_decl ->
+  let acc, funs, free_names =
+    List.fold_left (fun (acc, by_closure_id, free_names) function_decl ->
         let _, acc, expr =
           Acc.measure_cost_metrics acc ~f:(fun acc ->
             close_one_function acc ~external_env ~by_closure_id function_decl
               ~var_within_closures_from_idents ~closure_ids_from_idents
               function_declarations)
         in
-        acc, expr)
-      (acc, Closure_id.Map.empty)
+        let free_names =
+          Name_occurrences.union free_names (Acc.free_names acc)
+        in
+        acc, expr, free_names)
+      (acc, Closure_id.Map.empty, Acc.free_names acc)
       func_decl_list
   in
+  let acc = Acc.with_free_names free_names acc in
   (* CR lmaurer: funs has arbitrary order (ultimately coming from
      function_declarations) *)
   let funs =

--- a/middle_end/flambda/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda/from_lambda/closure_conversion_aux.ml
@@ -201,8 +201,7 @@ module Acc = struct
     declared_symbols : (Symbol.t * Flambda.Static_const.t) list;
     shareable_constants : Symbol.t Flambda.Static_const.Map.t;
     code : Flambda.Code.t Code_id.Map.t;
-    free_names_of_current_function : Name_occurrences.t;
-    free_continuations : Name_occurrences.t;
+    free_names : Name_occurrences.t;
     cost_metrics : Flambda.Cost_metrics.t;
     seen_a_function : bool;
   }
@@ -220,8 +219,7 @@ module Acc = struct
     declared_symbols = [];
     shareable_constants = Flambda.Static_const.Map.empty;
     code = Code_id.Map.empty;
-    free_names_of_current_function = Name_occurrences.empty;
-    free_continuations = Name_occurrences.empty;
+    free_names = Name_occurrences.empty;
     cost_metrics = Flambda.Cost_metrics.zero;
     seen_a_function = false;
   }
@@ -229,8 +227,7 @@ module Acc = struct
   let declared_symbols t = t.declared_symbols
   let shareable_constants t = t.shareable_constants
   let code t = t.code
-  let free_names_of_current_function t = t.free_names_of_current_function
-  let free_continuations t = t.free_continuations
+  let free_names t = t.free_names
 
   let add_declared_symbol ~symbol ~constant t =
     let declared_symbols = (symbol, constant) :: t.declared_symbols in
@@ -245,28 +242,38 @@ module Acc = struct
   let add_code ~code_id ~code t =
     { t with code = Code_id.Map.add code_id code t.code; }
 
+  let add_free_names free_names t =
+    { t with free_names = Name_occurrences.union free_names t.free_names; }
+
   let add_symbol_to_free_names ~symbol t =
     { t with
-      free_names_of_current_function =
-        Name_occurrences.add_symbol t.free_names_of_current_function
+      free_names =
+        Name_occurrences.add_symbol t.free_names
           symbol Name_mode.normal;
     }
+
   let add_closure_var_to_free_names ~closure_var t =
     { t with
-      free_names_of_current_function =
-        Name_occurrences.add_closure_var t.free_names_of_current_function
+      free_names =
+        Name_occurrences.add_closure_var t.free_names
           closure_var Name_mode.normal;
     }
 
-  let add_continuation_occurrence ~cont ~has_traps t =
+  let add_continuation_to_free_names ~cont ~has_traps t =
     { t with
-      free_continuations =
-        Name_occurrences.add_continuation t.free_continuations
+      free_names =
+        Name_occurrences.add_continuation t.free_names
           cont ~has_traps;
     }
 
+  let remove_continuation_from_free_names cont t =
+    { t with
+      free_names =
+        Name_occurrences.remove_continuation t.free_names cont;
+    }
+
   let with_free_names free_names t =
-    { t with free_names_of_current_function = free_names; }
+    { t with free_names; }
 
   let measure_cost_metrics acc ~f =
     let saved_cost_metrics = cost_metrics acc in
@@ -401,10 +408,10 @@ module Expr_with_acc = struct
     let acc = match Apply.continuation apply with
       | Never_returns -> acc
       | Return cont ->
-          Acc.add_continuation_occurrence ~cont ~has_traps:false acc
+          Acc.add_continuation_to_free_names ~cont ~has_traps:false acc
     in
     let acc =
-      Acc.add_continuation_occurrence
+      Acc.add_continuation_to_free_names
         ~cont:(Exn_continuation.exn_handler (Apply.exn_continuation apply))
         ~has_traps:false acc
     in
@@ -437,7 +444,7 @@ end
 module Apply_cont_with_acc = struct
   let create acc ?trap_action cont ~args ~dbg =
     let acc =
-      Acc.add_continuation_occurrence ~cont
+      Acc.add_continuation_to_free_names ~cont
         ~has_traps:(match trap_action with
             | None -> false
             | _ -> true)
@@ -492,17 +499,22 @@ end
 module Let_cont_with_acc = struct
   let create_non_recursive acc cont handler
         ~body ~cost_metrics_of_handler =
-    let free_conts = Acc.free_continuations acc in
+    let free_conts = Acc.free_names acc in
     let acc =
       Acc.increment_metrics
         (Cost_metrics.increase_due_to_let_cont_non_recursive
            ~cost_metrics_of_handler)
         acc
     in
-    acc,
-    (* This function only uses continuations of [free_names_of_body] *)
-    Let_cont.create_non_recursive cont handler ~body
-      ~free_names_of_body:(Known free_conts)
+    let acc = Acc.remove_continuation_from_free_names cont acc in
+    match Name_occurrences.count_continuation free_conts cont with
+    | Zero when not (Continuation_handler.is_exn_handler handler) ->
+      acc, body
+    | _ ->
+      acc,
+      (* This function only uses continuations of [free_names_of_body] *)
+      Let_cont.create_non_recursive cont handler ~body
+        ~free_names_of_body:(Known free_conts)
 
   let create_recursive acc handlers ~body ~cost_metrics_of_handlers =
     let acc =
@@ -510,6 +522,11 @@ module Let_cont_with_acc = struct
         (Cost_metrics.increase_due_to_let_cont_recursive
            ~cost_metrics_of_handlers)
         acc
+    in
+    let acc =
+      Continuation.Map.fold (fun cont _ acc ->
+          Acc.remove_continuation_from_free_names cont acc)
+        handlers acc
     in
     acc, Let_cont.create_recursive handlers ~body
 end

--- a/middle_end/flambda/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda/from_lambda/closure_conversion_aux.mli
@@ -122,8 +122,7 @@ module Acc : sig
   val declared_symbols : t -> (Symbol.t * Flambda.Static_const.t) list
   val shareable_constants : t -> Symbol.t Flambda.Static_const.Map.t
   val code : t -> Flambda.Code.t Code_id.Map.t
-  val free_names_of_current_function : t -> Name_occurrences.t
-  val free_continuations : t -> Name_occurrences.t
+  val free_names : t -> Name_occurrences.t
 
   val seen_a_function : t -> bool
   val with_seen_a_function : t -> bool -> t
@@ -142,10 +141,14 @@ module Acc : sig
 
   val add_code : code_id:Code_id.t -> code:Flambda.Code.t -> t -> t
 
+  val add_free_names : Name_occurrences.t -> t -> t
   val add_symbol_to_free_names : symbol:Symbol.t -> t -> t
   val add_closure_var_to_free_names : closure_var:Var_within_closure.t -> t -> t
-  val add_continuation_occurrence
+  val add_continuation_to_free_names
     : cont:Continuation.t -> has_traps:bool -> t -> t
+  val remove_continuation_from_free_names
+    : Continuation.t -> t -> t
+
 
   val with_free_names : Name_occurrences.t -> t -> t
 

--- a/middle_end/flambda/terms/continuation_handler.rec.ml
+++ b/middle_end/flambda/terms/continuation_handler.rec.ml
@@ -112,7 +112,7 @@ let pattern_match_pair t1 t2 ~f =
         Error Pattern_match_pair_error.Parameter_lists_have_different_lengths))
 
 let print_using_where_with_cache (recursive : Recursive.t) ~cache ppf k
-      ({ abst = _; is_exn_handler; } as t) ~first =
+      ({ abst = _; is_exn_handler; } as t) occurrences ~first =
   let fprintf = Format.fprintf in
   if not first then begin
     fprintf ppf "@ "
@@ -133,8 +133,9 @@ let print_using_where_with_cache (recursive : Recursive.t) ~cache ppf k
     if List.length params > 0 then begin
       fprintf ppf " %a" Kinded_parameter.List.print params
     end;
-    fprintf ppf "@<0>%s:@<0>%s@ %a"
+    fprintf ppf "@<0>%s #%a:@<0>%s@ %a"
       (Flambda_colours.elide ())
+      (Or_unknown.print Num_occurrences.print) occurrences
       (Flambda_colours.normal ())
       (Expr.print_with_cache ~cache) handler;
     fprintf ppf "@]")

--- a/middle_end/flambda/terms/continuation_handler.rec.mli
+++ b/middle_end/flambda/terms/continuation_handler.rec.mli
@@ -32,6 +32,7 @@ val print_using_where_with_cache
   -> Format.formatter
   -> Continuation.t
   -> t
+  -> Num_occurrences.t Or_unknown.t
   -> first:bool
   -> unit
 

--- a/middle_end/flambda/terms/let_cont_expr.rec.ml
+++ b/middle_end/flambda/terms/let_cont_expr.rec.ml
@@ -51,7 +51,7 @@ let print_with_cache ~cache ppf t =
   end else begin
     let rec gather_let_conts let_conts let_cont =
       match let_cont with
-      | Non_recursive { handler; num_free_occurrences = _;
+      | Non_recursive { handler; num_free_occurrences;
                         is_applied_with_traps = _; } ->
         Non_recursive_let_cont_handler.pattern_match handler
           ~f:(fun k ~(body : Expr.t) ->
@@ -61,7 +61,8 @@ let print_with_cache ~cache ppf t =
               | _ -> let_conts, body
             in
             let handler = Non_recursive_let_cont_handler.handler handler in
-            (k, Recursive.Non_recursive, handler) :: let_conts, body)
+            (k, Recursive.Non_recursive, handler, num_free_occurrences)
+            :: let_conts, body)
       | Recursive handlers ->
         Recursive_let_cont_handlers.pattern_match handlers
           ~f:(fun ~(body : Expr.t) handlers ->
@@ -72,7 +73,8 @@ let print_with_cache ~cache ppf t =
               | _ -> let_conts, body
             in
             let new_let_conts =
-              List.map (fun (k, handler) -> k, Recursive.Recursive, handler)
+              List.map (fun (k, handler) ->
+                  k, Recursive.Recursive, handler, Or_unknown.Unknown)
                 (Continuation.Map.bindings handlers)
             in
             new_let_conts @ let_conts, body)
@@ -80,9 +82,9 @@ let print_with_cache ~cache ppf t =
     let let_conts, body = gather_let_conts [] t in
     fprintf ppf "@[<v 1>(%a@;" (Expr.print_with_cache ~cache) body;
     let first = ref true in
-    List.iter (fun (cont, recursive, handler) ->
+    List.iter (fun (cont, recursive, handler, occurrences) ->
         Continuation_handler.print_using_where_with_cache recursive ~cache
-          ppf cont handler ~first:!first;
+          ppf cont handler occurrences ~first:!first;
         first := false)
       (List.rev let_conts);
     fprintf ppf ")@]"


### PR DESCRIPTION
(From #569, [relevant diff](https://github.com/ocaml-flambda/ocaml/pull/570/files/f51c33c4004901f171ab45424cba547834447c67..1870555f6bf71fb7e9858504e847b8b09797b9e0))

This builds upon #491, and is work toward a classic mode compilation path.

It merges the pre-existing Name_occurrences with the one introduced in #491.

